### PR TITLE
Fix Auto hide Thumb issue #25

### DIFF
--- a/core/src/commonMain/kotlin/ScrollArea.kt
+++ b/core/src/commonMain/kotlin/ScrollArea.kt
@@ -355,8 +355,7 @@ fun ScrollbarScope.Thumb(
         val isHovered by mutableInteractionSource.collectIsHoveredAsState()
         val isDraggingList by scrollAreaState.interactionSource.collectIsDraggedAsState()
 
-
-        LaunchedEffect(show) {
+        LaunchedEffect(show, isDraggingList) {
             if (show) {
                 delay(thumbVisibility.hideDelay)
                 show = false

--- a/core/src/commonMain/kotlin/ScrollArea.kt
+++ b/core/src/commonMain/kotlin/ScrollArea.kt
@@ -355,15 +355,13 @@ fun ScrollbarScope.Thumb(
         val isHovered by mutableInteractionSource.collectIsHoveredAsState()
         val isDraggingList by scrollAreaState.interactionSource.collectIsDraggedAsState()
 
-        LaunchedEffect(show, isDraggingList) {
-            if (show) {
-                delay(thumbVisibility.hideDelay)
-                show = false
-            }
-        }
-        LaunchedEffect(isDraggingList, isHovered) {
+        LaunchedEffect(show, isDraggingList, isHovered) {
             if (isDraggingList || isHovered) {
                 show = true
+            }
+            if (show && !isHovered) {
+                delay(thumbVisibility.hideDelay)
+                show = false
             }
         }
         LaunchedEffect(Unit) {


### PR DESCRIPTION
This adds `isDraggingList` as a parameter for the `LaunchedEffect` responsible for hiding the scrollbar. It should have no effect on performance, and it fixes issue #25 

Still not sure about the `isHover` logic for showing the scrollbar as I can't get the scrollbar to show when hovering over the list on the emulator.