### PR TITLE
Remove `protectNavBars` property

### DIFF
--- a/core/src/androidMain/kotlin/Modal.android.kt
+++ b/core/src/androidMain/kotlin/Modal.android.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.NativeKeyEvent
 import androidx.compose.ui.input.key.onKeyEvent
@@ -18,7 +16,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
@@ -29,7 +26,6 @@ import java.util.*
 
 @Composable
 internal actual fun Modal(
-    protectNavBars: Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     content: @Composable () -> Unit
 ) {
@@ -84,11 +80,6 @@ internal actual fun Modal(
         } else {
             @Suppress("DEPRECATION")
             window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-        }
-
-        if (protectNavBars) {
-            window.navigationBarColor = Color.Black.copy(alpha = 0.33f).toArgb()
-            WindowInsetsControllerCompat(window, contentView).isAppearanceLightNavigationBars = false
         }
 
         window.setDimAmount(0f)

--- a/core/src/appleMain/kotlin/Modal.apple.kt
+++ b/core/src/appleMain/kotlin/Modal.apple.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.window.DialogProperties
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal actual fun Modal(
-    protectNavBars: Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     content: @Composable () -> Unit
 ) = androidx.compose.ui.window.Dialog(

--- a/core/src/commonMain/kotlin/Modal.kt
+++ b/core/src/commonMain/kotlin/Modal.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.input.key.KeyEvent
 
 @Composable
 internal expect fun Modal(
-    protectNavBars: Boolean = false,
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     content: @Composable () -> Unit
 )

--- a/core/src/commonMain/kotlin/ModalBottomSheet.kt
+++ b/core/src/commonMain/kotlin/ModalBottomSheet.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.delay
 
 public data class ModalSheetProperties(
     val dismissOnBackPress: Boolean = true,
-    val dismissOnClickOutside: Boolean = true
+    val dismissOnClickOutside: Boolean = true,
 )
 
 @Composable
@@ -163,7 +163,7 @@ public fun ModalBottomSheet(
                 { false }
             }
 
-            Modal(protectNavBars = true, onKeyEvent = onKeyEvent) {
+            Modal(onKeyEvent = onKeyEvent) {
                 Box(Modifier
                     .fillMaxSize()
                     .let {

--- a/core/src/jsMain/kotlin/Modal.js.kt
+++ b/core/src/jsMain/kotlin/Modal.js.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.window.DialogProperties
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal actual fun Modal(
-    protectNavBars: Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     content: @Composable () -> Unit
 ) = androidx.compose.ui.window.Dialog(

--- a/core/src/jvmMain/kotlin/Modal.jvm.kt
+++ b/core/src/jvmMain/kotlin/Modal.jvm.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.window.DialogProperties
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal actual fun Modal(
-    protectNavBars: Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     content: @Composable () -> Unit
 ) = androidx.compose.ui.window.Dialog(

--- a/core/src/wasmJsMain/kotlin/Modal.wasmJs.kt
+++ b/core/src/wasmJsMain/kotlin/Modal.wasmJs.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.window.DialogProperties
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal actual fun Modal(
-    protectNavBars: Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     content: @Composable () -> Unit
 ) = androidx.compose.ui.window.Dialog(


### PR DESCRIPTION
Hi there!

I need to make my system bars fully transparent. But `ModalBottomSheet` forces to `protectNavBars = true`.

I found the issue #12 and tried this approach, but if you make this:
```kotlin
val window = LocalModalWindow.current
LaunchedEffect(Unit) {
    window.navigationBarColor = Color.TRANSPARENT
    window.statusBarColor = Color.TRANSPARENT
    WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = true
    WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightNavigationBars = true
}
```
then half-transparent system bars background blinks for a moment anyway.

You can see it on a video: 

https://github.com/user-attachments/assets/2cd37dad-93b4-4f8f-9b98-9a25a36df398


So it would be great to allow to customize `protectNavBars` value to avoid it.

Pros:
- No need to declare `LaunchedEffect` especially for `ModalBottomSheet`, you can setup it once for the whole application.
- No blinking half-transparent systems bar background when opening `ModalBottomSheet`.