### PR TITLE
Hide soft keyboard before dismissing modal sheet

### DIFF
--- a/core/src/commonMain/kotlin/ModalBottomSheet.kt
+++ b/core/src/commonMain/kotlin/ModalBottomSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.composeunstyled.AppearInstantly
@@ -277,6 +278,9 @@ fun ModalBottomSheet(
                     // start the scrim animation
                     scope.scrimVisibilityState.targetState = true
                 }
+
+                val softwareKeyboard = LocalSoftwareKeyboardController.current
+
                 Box(
                     Modifier
                         .fillMaxSize()
@@ -285,6 +289,7 @@ fun ModalBottomSheet(
                                 it.pointerInput(Unit) {
                                     detectTapGestures {
                                         if (state.bottomSheetState.confirmDetentChange(SheetDetent.Hidden)) {
+                                            softwareKeyboard?.hide()
                                             onDismissRequest()
                                         }
                                     }


### PR DESCRIPTION
Hey Alex,

This is a small fix for the modal bottom sheet dismiss on tap behavior. On this video, you can see that currently the soft keyboard stays open until the sheet is fully dismissed, and then it instantly disappears, which doesn't look right:

https://github.com/user-attachments/assets/9f6c5f74-add6-4dd8-819a-74293531df30


With the fix, the keyboard and the sheet dismiss simultaneously:

https://github.com/user-attachments/assets/d3c25216-cc9d-424f-98a5-9bde02131894


I wanted to have the soft keyboard dismiss call in the `onDismissRequest()` method, but the problem is that `LocalSoftwareKeyboardController` only returns the correct controller inside `Modal`.