### PR TITLE
make bottom sheet detents public

### DIFF
--- a/core/src/commonMain/kotlin/BottomSheet.kt
+++ b/core/src/commonMain/kotlin/BottomSheet.kt
@@ -175,8 +175,8 @@ class SheetDetent(
 }
 
 class BottomSheetState(
-    initialDetent: SheetDetent,
-    internal val detents: List<SheetDetent>,
+    val initialDetent: SheetDetent,
+    val detents: List<SheetDetent>,
     private val coroutineScope: CoroutineScope,
     animationSpec: AnimationSpec<Float>,
     velocityThreshold: () -> Float,


### PR DESCRIPTION
Hello!

We are using `compose-unstyled` bottom sheets in our projects

And turns out, we highly need to know initial detent and all detents of bottom sheet in our Decompose SlotBottomSheet wrapper

Would it be fine to make this values public?

## The problem:
Inside our implementation, we have something like this
```kotlin
is SheetLogicEvent.CloseAndOpen<C> -> {
    withRetry {
        busyBottomSheetState.animateTo(SheetDetent.Hidden)
        childContent.value = emptyContent
        childContent.value = { content(sheetLogicEvent.instance) }
        busyBottomSheetState.animateTo(SheetDetent.NearlyExpanded)
    }
}
```
And here, we need to know list of detents. Because not all our sheets have `NearlyExpanded` 