### PR TITLE
Measure padded sheet height for bottom sheet detents

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -646,70 +646,76 @@ fun BottomSheetScope.Sheet(
   val context = LocalBottomSheetContext.current
   val state = context.state
 
-  Layout(
-    modifier = modifier.clipToBounds(),
-    content = content,
-  ) { measurables, constraints ->
-    val fallbackContentHeight = when {
-      state == null -> constraints.maxHeight
-      state.hasContentDependentDetents() -> state.containerHeightPx.roundToInt()
-      state.layoutHeightPx.isNaN() -> constraints.maxHeight
-      else -> state.layoutHeightPx.roundToInt()
-    }.coerceIn(constraints.minHeight, constraints.maxHeight)
-    val intrinsicContentHeight = measurables.maxOfOrNull { measurable ->
-      try {
-        measurable.maxIntrinsicHeight(constraints.maxWidth)
-      } catch (_: IllegalStateException) {
-        fallbackContentHeight
+  Box(
+    modifier = Modifier
+      .onSizeChanged { measuredSize ->
+        state?.updateContentHeight(measuredSize.height.toFloat())
       }
-    } ?: 0
-    val estimatedContentHeight = if (intrinsicContentHeight == 0) {
-      fallbackContentHeight
-    } else {
-      intrinsicContentHeight
-    }
+      .then(modifier)
+      .clipToBounds(),
+  ) {
+    Layout(
+      content = content,
+    ) { measurables, constraints ->
+      val fallbackContentHeight = when {
+        state == null -> constraints.maxHeight
+        state.hasContentDependentDetents() -> state.containerHeightPx.roundToInt()
+        state.layoutHeightPx.isNaN() -> constraints.maxHeight
+        else -> state.layoutHeightPx.roundToInt()
+      }.coerceIn(constraints.minHeight, constraints.maxHeight)
+      val intrinsicContentHeight = measurables.maxOfOrNull { measurable ->
+        try {
+          measurable.maxIntrinsicHeight(constraints.maxWidth)
+        } catch (_: IllegalStateException) {
+          fallbackContentHeight
+        }
+      } ?: 0
+      val estimatedContentHeight = if (intrinsicContentHeight == 0) {
+        fallbackContentHeight
+      } else {
+        intrinsicContentHeight
+      }
+      val estimatedSheetHeightPx = max(
+        estimatedContentHeight.toFloat(),
+        state?.contentHeightPx?.takeUnless { it.isNaN() } ?: 0f,
+      )
 
-    val resolvedLayoutHeight = state?.layoutHeightPxFor(estimatedContentHeight.toFloat())
-      ?: estimatedContentHeight.toFloat()
-    val waitingForHiddenAnchors = state != null &&
-      state.anchoredDraggableState.offset.isNaN() &&
-      state.currentDetent == SheetDetent.Hidden &&
-      state.targetDetent == SheetDetent.Hidden
-    val layoutMaxHeight = when {
-      waitingForHiddenAnchors -> constraints.minHeight
-      resolvedLayoutHeight.isNaN() -> constraints.maxHeight
-      else -> resolvedLayoutHeight.roundToInt()
-    }.coerceIn(constraints.minHeight, constraints.maxHeight)
-    val contentMaxHeight = when {
-      waitingForHiddenAnchors -> layoutMaxHeight
-      state?.hasContentDependentDetents() == true -> fallbackContentHeight
-      else -> layoutMaxHeight
-    }
-    val contentConstraints = constraints.copy(maxHeight = contentMaxHeight)
+      val resolvedLayoutHeight = state?.layoutHeightPxFor(estimatedSheetHeightPx)
+        ?: estimatedSheetHeightPx
+      val waitingForHiddenAnchors = state != null &&
+        state.anchoredDraggableState.offset.isNaN() &&
+        state.currentDetent == SheetDetent.Hidden &&
+        state.targetDetent == SheetDetent.Hidden
+      val layoutMaxHeight = when {
+        waitingForHiddenAnchors -> constraints.minHeight
+        resolvedLayoutHeight.isNaN() -> constraints.maxHeight
+        else -> resolvedLayoutHeight.roundToInt()
+      }.coerceIn(constraints.minHeight, constraints.maxHeight)
+      val contentMaxHeight = when {
+        waitingForHiddenAnchors -> layoutMaxHeight
+        state?.hasContentDependentDetents() == true -> fallbackContentHeight
+        else -> layoutMaxHeight
+      }
+      val contentConstraints = constraints.copy(maxHeight = contentMaxHeight)
 
-    val placeables = measurables.map { measurable ->
-      measurable.measure(contentConstraints)
-    }
+      val placeables = measurables.map { measurable ->
+        measurable.measure(contentConstraints)
+      }
 
-    val width = max(
-      constraints.minWidth,
-      placeables.maxOfOrNull { it.width } ?: 0,
-    )
-    val contentHeight = placeables.maxOfOrNull { it.height } ?: 0
-    val height = min(
-      contentHeight,
-      layoutMaxHeight,
-    ).coerceIn(constraints.minHeight, constraints.maxHeight)
+      val width = max(
+        constraints.minWidth,
+        placeables.maxOfOrNull { it.width } ?: 0,
+      )
+      val contentHeight = placeables.maxOfOrNull { it.height } ?: 0
+      val height = min(
+        contentHeight,
+        layoutMaxHeight,
+      ).coerceIn(constraints.minHeight, constraints.maxHeight)
 
-    val measuredContentHeight = max(
-      estimatedContentHeight,
-      contentHeight,
-    )
-    state?.updateContentHeight(max(measuredContentHeight, height).toFloat())
-
-    layout(width, height) {
-      placeables.forEach { placeable ->
-        placeable.placeRelative(0, 0)
+      layout(width, height) {
+        placeables.forEach { placeable ->
+          placeable.placeRelative(0, 0)
+        }
       }
     }
   }

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -750,6 +751,53 @@ class BottomSheetCommonTest {
       with(density) { DensityTolerance.toPx() },
     )
     onNodeWithTag("sheet").assertHeightIsEqualTo(200.dp)
+  }
+
+  @Test
+  fun fully_expanded_detent_includes_sheet_top_padding_in_measured_height() = runComposeUiTest {
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(300.dp)) {
+        state = rememberBottomSheetState(
+          initialDetent = SheetDetent.FullyExpanded,
+          detents = listOf(SheetDetent.FullyExpanded),
+        )
+
+        UnstyledBottomSheet(
+          state,
+          Modifier.testTag("sheet_container"),
+        ) {
+          Sheet(
+            modifier = Modifier
+              .padding(top = 24.dp)
+              .testTag("sheet"),
+          ) {
+            Box(
+              Modifier
+                .testTag("sheet_contents")
+                .fillMaxWidth()
+                .height(200.dp),
+            )
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+
+    assertThat(state.contentHeightPx).isCloseTo(
+      with(density) {
+        224.dp.toPx()
+      },
+      with(density) { DensityTolerance.toPx() },
+    )
+    assertThat(state.offset).isCloseTo(
+      with(density) {
+        224.dp.toPx()
+      },
+      with(density) { DensityTolerance.toPx() },
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary
- measure the sheet's outer height when resolving detents so FullyExpanded accounts for size-affecting sheet modifiers
- use the larger of the intrinsic content estimate and the last measured outer sheet height during layout
- add a regression test covering a sheet with top padding

## Verification
- ./gradlew :composeunstyled-bottom-sheet:jvmTest --tests com.composeunstyled.BottomSheetCommonTest.fully_expanded_detent_includes_sheet_top_padding_in_measured_height
- ./gradlew :composeunstyled-bottom-sheet:spotlessCheck

## Notes
- Running :composeunstyled-bottom-sheet:jvmTest without test filters hung in this environment after entering the jvmTest task, so verification here uses the targeted regression test plus spotlessCheck.