### PR TITLE
Make icon content descriptions optional

### DIFF
--- a/composeunstyled-icon/src/commonMain/kotlin/com/composeunstyled/Icon.kt
+++ b/composeunstyled-icon/src/commonMain/kotlin/com/composeunstyled/Icon.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 @Composable
 fun UnstyledIcon(
   painter: Painter,
-  contentDescription: String?,
+  contentDescription: String? = null,
   modifier: Modifier = Modifier,
   tint: Color = Color.Unspecified,
 ) {
@@ -49,7 +49,7 @@ fun UnstyledIcon(
 @Composable
 fun UnstyledIcon(
   imageBitmap: ImageBitmap,
-  contentDescription: String?,
+  contentDescription: String? = null,
   modifier: Modifier = Modifier,
   tint: Color = Color.Unspecified,
 ) {
@@ -62,7 +62,7 @@ fun UnstyledIcon(
 @Composable
 fun UnstyledIcon(
   imageVector: ImageVector,
-  contentDescription: String?,
+  contentDescription: String? = null,
   modifier: Modifier = Modifier,
   tint: Color = Color.Unspecified,
 ) {


### PR DESCRIPTION
## Summary
- make UnstyledIcon contentDescription nullable by default
- preserve explicit content descriptions for accessible icons while allowing decorative icons to omit one

## Verification
- ./gradlew jvmTest
- ./gradlew spotlessCheck