### PR TITLE
Test sheet content recomposition counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ Before pushing changes that touch Kotlin (`.kt`) files, you must run `jvmTest` a
 - Put touch-specific tests in the Android test source set. Put mouse-specific tests in the JVM test source set.
 - When creating a library module with an Android target, add the Android instrumented test dependencies required for Compose UI tests: `libs.androidx.compose.test`, `libs.androidx.compose.test.manifest`, and `libs.androidx.espresso`.
 
+## Recomposition testing
+
+- When changing Compose behavior that can affect composition stability, add focused recomposition tests in `commonTest` using `composeunstyled-test`.
+- Use `runComposeRecompositionTest {}` with `RecompositionCount(name)` placed at the specific subtree whose recomposition behavior matters. Assert with the project's normal assertion framework through `recompositionCount(name)` after calling `resetRecompositionCounts(...)`.
+- Prefer testing user-relevant state transitions, such as opening or closing components, changing detents, invalidating measured state, and resizing dynamic containers.
+- Record the current observed recomposition count unless the change is explicitly intended to improve it.
+- Do not use broad parent-level counters when the behavior under test is scoped to a specific slot or content subtree.
+
 ## Development workflow
 
 - When touching code for any playground or demo module, do not run the app. Instead, use `./gradlew :<module>:hotReloadDesktopMain` to reload the app.

--- a/composeunstyled-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-bottom-sheet/build.gradle.kts
@@ -93,6 +93,7 @@ kotlin {
     commonTest.dependencies {
       implementation(kotlin("test"))
       implementation(libs.assertk)
+      implementation(projects.composeunstyledTest)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheetRecompositionTest.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheetRecompositionTest.kt
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.composeunstyled.test.runComposeRecompositionTest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+
+class BottomSheetRecompositionTest {
+  @Test
+  fun expanding_from_hidden_does_not_recompose_content() = runComposeRecompositionTest {
+    lateinit var state: BottomSheetState
+    lateinit var scope: CoroutineScope
+
+    setContent {
+      scope = rememberCoroutineScope()
+      state = rememberBottomSheetState(
+        initialDetent = SheetDetent.Hidden,
+        detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
+      )
+
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
+        Sheet {
+          RecompositionCount("sheet-content")
+          Box(Modifier.fillMaxWidth().height(300.dp))
+        }
+      }
+    }
+
+    waitUntil { state.isIdle }
+    resetRecompositionCounts()
+
+    scope.launch {
+      state.animateTo(SheetDetent.FullyExpanded)
+    }
+    waitUntil { state.isIdle }
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(0)
+  }
+
+  @Test
+  fun expanding_to_content_sized_detent_does_not_recompose_content() = runComposeRecompositionTest {
+    val contentDetent = SheetDetent("content") { _, sheetHeight ->
+      sheetHeight
+    }
+    lateinit var state: BottomSheetState
+    lateinit var scope: CoroutineScope
+
+    setContent {
+      scope = rememberCoroutineScope()
+      state = rememberBottomSheetState(
+        initialDetent = SheetDetent.Hidden,
+        detents = listOf(SheetDetent.Hidden, contentDetent),
+      )
+
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
+        Sheet {
+          RecompositionCount("sheet-content")
+          Box(Modifier.fillMaxWidth().height(300.dp))
+        }
+      }
+    }
+
+    waitUntil { state.isIdle }
+    resetRecompositionCounts()
+
+    scope.launch {
+      state.animateTo(contentDetent)
+    }
+    waitUntil { state.isIdle }
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(0)
+  }
+
+  @Test
+  fun invalidating_content_sized_detent_does_not_recompose_content() = runComposeRecompositionTest {
+    val contentDetent = SheetDetent("content") { _, sheetHeight ->
+      sheetHeight
+    }
+    lateinit var state: BottomSheetState
+
+    setContent {
+      state = rememberBottomSheetState(
+        initialDetent = contentDetent,
+        detents = listOf(contentDetent),
+      )
+
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
+        Sheet {
+          RecompositionCount("sheet-content")
+          Box(Modifier.fillMaxWidth().height(300.dp))
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts()
+
+    state.invalidateDetents()
+    waitForIdle()
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(0)
+  }
+
+  @Test
+  fun updating_detents_recomposes_content_sized_content_once() = runComposeRecompositionTest {
+    val contentDetent = SheetDetent("content") { _, sheetHeight ->
+      sheetHeight
+    }
+    val halfDetent = SheetDetent("half") { containerHeight, _ ->
+      containerHeight / 2
+    }
+    lateinit var state: BottomSheetState
+
+    setContent {
+      state = rememberBottomSheetState(
+        initialDetent = contentDetent,
+        detents = listOf(contentDetent),
+      )
+
+      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
+        Sheet {
+          RecompositionCount("sheet-content")
+          Box(Modifier.fillMaxWidth().height(300.dp))
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts()
+
+    state.detents = listOf(halfDetent, contentDetent)
+    waitForIdle()
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(1)
+  }
+
+  @Test
+  fun resizing_container_based_detent_recomposes_content_once() = runComposeRecompositionTest {
+    val containerDetent = SheetDetent("container") { containerHeight, _ ->
+      containerHeight / 2
+    }
+    var containerSize by mutableStateOf(300.dp)
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(containerSize)) {
+        state = rememberBottomSheetState(
+          initialDetent = containerDetent,
+          detents = listOf(containerDetent),
+        )
+
+        UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
+          Sheet {
+            RecompositionCount("sheet-content")
+            Box(Modifier.fillMaxWidth().height(300.dp))
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts()
+
+    containerSize = 400.dp
+    waitForIdle()
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(1)
+  }
+}

--- a/composeunstyled-modal-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-modal-bottom-sheet/build.gradle.kts
@@ -97,6 +97,7 @@ kotlin {
       implementation(kotlin("test"))
       implementation(libs.assertk)
       implementation(projects.composeunstyledScrim)
+      implementation(projects.composeunstyledTest)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheetRecompositionTest.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheetRecompositionTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.composeunstyled.test.runComposeRecompositionTest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+
+class ModalBottomSheetRecompositionTest {
+  @Test
+  fun expanding_from_hidden_composes_content_twice() = runComposeRecompositionTest {
+    lateinit var state: ModalBottomSheetState
+    lateinit var scope: CoroutineScope
+
+    setContent {
+      scope = rememberCoroutineScope()
+      state = rememberModalBottomSheetState(
+        initialDetent = SheetDetent.Hidden,
+        detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
+      )
+
+      UnstyledModalBottomSheet(state) {
+        Sheet {
+          RecompositionCount("sheet-content")
+          Box(Modifier.fillMaxWidth().height(300.dp))
+        }
+      }
+    }
+
+    waitUntil { state.isIdle }
+    resetRecompositionCounts()
+
+    scope.launch {
+      state.animateTo(SheetDetent.FullyExpanded)
+    }
+    waitUntil { state.isIdle && state.currentDetent == SheetDetent.FullyExpanded }
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(2)
+  }
+
+  @Test
+  fun expanding_to_content_sized_detent_composes_content_twice() = runComposeRecompositionTest {
+    val contentDetent = SheetDetent("content") { _, sheetHeight ->
+      sheetHeight
+    }
+    lateinit var state: ModalBottomSheetState
+    lateinit var scope: CoroutineScope
+
+    setContent {
+      scope = rememberCoroutineScope()
+      state = rememberModalBottomSheetState(
+        initialDetent = SheetDetent.Hidden,
+        detents = listOf(SheetDetent.Hidden, contentDetent),
+      )
+
+      UnstyledModalBottomSheet(state) {
+        Sheet {
+          RecompositionCount("sheet-content")
+          Box(Modifier.fillMaxWidth().height(300.dp))
+        }
+      }
+    }
+
+    waitUntil { state.isIdle }
+    resetRecompositionCounts()
+
+    scope.launch {
+      state.animateTo(contentDetent)
+    }
+    waitUntil { state.isIdle && state.currentDetent == contentDetent }
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(2)
+  }
+
+  @Test
+  fun invalidating_content_sized_detent_does_not_recompose_content() = runComposeRecompositionTest {
+    val contentDetent = SheetDetent("content") { _, sheetHeight ->
+      sheetHeight
+    }
+    lateinit var state: ModalBottomSheetState
+
+    setContent {
+      state = rememberModalBottomSheetState(
+        initialDetent = contentDetent,
+        detents = listOf(contentDetent),
+      )
+
+      UnstyledModalBottomSheet(state) {
+        Sheet {
+          RecompositionCount("sheet-content")
+          Box(Modifier.fillMaxWidth().height(300.dp))
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts()
+
+    state.invalidateDetents()
+    waitForIdle()
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(0)
+  }
+
+  @Test
+  fun updating_detents_does_not_recompose_content_sized_content() = runComposeRecompositionTest {
+    val contentDetent = SheetDetent("content") { _, sheetHeight ->
+      sheetHeight
+    }
+    val halfDetent = SheetDetent("half") { containerHeight, _ ->
+      containerHeight / 2
+    }
+    lateinit var state: ModalBottomSheetState
+
+    setContent {
+      state = rememberModalBottomSheetState(
+        initialDetent = contentDetent,
+        detents = listOf(contentDetent),
+      )
+
+      UnstyledModalBottomSheet(state) {
+        Sheet {
+          RecompositionCount("sheet-content")
+          Box(Modifier.fillMaxWidth().height(300.dp))
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts()
+
+    state.bottomSheetState.detents = listOf(halfDetent, contentDetent)
+    waitForIdle()
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(0)
+  }
+
+  @Test
+  fun resizing_container_based_detent_recomposes_content_once() = runComposeRecompositionTest {
+    val containerDetent = SheetDetent("container") { containerHeight, _ ->
+      containerHeight / 2
+    }
+    var containerSize by mutableStateOf(300.dp)
+    lateinit var state: ModalBottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(containerSize)) {
+        state = rememberModalBottomSheetState(
+          initialDetent = containerDetent,
+          detents = listOf(containerDetent),
+        )
+
+        UnstyledModalBottomSheet(state) {
+          Sheet {
+            RecompositionCount("sheet-content")
+            Box(Modifier.fillMaxWidth().height(300.dp))
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts()
+
+    containerSize = 400.dp
+    waitForIdle()
+
+    assertThat(recompositionCount("sheet-content")).isEqualTo(1)
+  }
+}

--- a/composeunstyled-test/build.gradle.kts
+++ b/composeunstyled-test/build.gradle.kts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:Suppress("UnstableApiUsage")
+@file:OptIn(ExperimentalKotlinGradlePluginApi::class, ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
+
+plugins {
+  alias(libs.plugins.compose)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.android.library)
+}
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+  }
+}
+
+kotlin {
+  compilerOptions {
+    optIn.add("androidx.compose.ui.test.ExperimentalTestApi")
+  }
+
+  androidTarget {
+    compilerOptions {
+      jvmTarget = JvmTarget.JVM_17
+    }
+    instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+  }
+
+  jvm()
+
+  wasmJs {
+    browser()
+  }
+
+  js {
+    browser()
+  }
+
+  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+    iosTarget.binaries.framework {
+      baseName = "ComposeUnstyledTest"
+      isStatic = true
+    }
+  }
+
+  sourceSets {
+    commonMain.dependencies {
+      @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+      api(libs.compose.ui.test)
+    }
+
+    androidInstrumentedTest.dependencies {
+      implementation(libs.androidx.compose.test)
+      implementation(libs.androidx.compose.test.manifest)
+      implementation(libs.androidx.espresso)
+    }
+  }
+}
+
+android {
+  namespace = "com.composeunstyled.test"
+  compileSdk = libs.versions.android.compileSDK.get().toInt()
+  defaultConfig {
+    minSdk = libs.versions.android.minSDK.get().toInt()
+  }
+}

--- a/composeunstyled-test/src/commonMain/kotlin/com/composeunstyled/test/RecompositionTest.kt
+++ b/composeunstyled-test/src/commonMain/kotlin/com/composeunstyled/test/RecompositionTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled.test
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonSkippableComposable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.runComposeUiTest
+
+fun runComposeRecompositionTest(
+  block: RecompositionTestScope.() -> Unit,
+) = runComposeUiTest {
+  RecompositionTestScope(this).block()
+}
+
+class RecompositionTestScope(
+  private val composeUiTest: ComposeUiTest,
+) {
+  private val recompositionCounts = mutableMapOf<String, Int>()
+
+  fun setContent(content: @Composable () -> Unit) {
+    composeUiTest.setContent(content)
+  }
+
+  fun waitForIdle() {
+    composeUiTest.waitForIdle()
+  }
+
+  fun waitUntil(
+    conditionDescription: String? = null,
+    timeoutMillis: Long = 1_000,
+    condition: () -> Boolean,
+  ) {
+    composeUiTest.waitUntil(
+      conditionDescription = conditionDescription,
+      timeoutMillis = timeoutMillis,
+      condition = condition,
+    )
+  }
+
+  @Composable
+  @NonSkippableComposable
+  fun RecompositionCount(name: String) {
+    SideEffect {
+      recompositionCounts[name] = recompositionCount(name) + 1
+    }
+  }
+
+  fun resetRecompositionCounts(vararg names: String) {
+    if (names.isEmpty()) {
+      recompositionCounts.keys.forEach { name ->
+        recompositionCounts[name] = 0
+      }
+      return
+    }
+
+    names.forEach { name ->
+      recompositionCounts[name] = 0
+    }
+  }
+
+  fun recompositionCount(name: String): Int {
+    return recompositionCounts[name] ?: 0
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ dependencyResolutionManagement {
 }
 
 include(":composeunstyled-build-modifier")
+include(":composeunstyled-test")
 include(":composeunstyled-modal")
 include(":composeunstyled-scrim")
 include(":composeunstyled-dialog")


### PR DESCRIPTION
## Summary
- Adds a `composeunstyled-test` module for shared Compose recomposition test helpers.
- Adds `runComposeRecompositionTest`, `RecompositionCount(name)`, `recompositionCount(name)`, and `resetRecompositionCounts(...)` for use with the existing assertion framework.
- Adds bottom sheet and modal bottom sheet recomposition tests for expansion, content-sized detents, detent invalidation, detent updates, and container resizing.

## Observed counts
- Bottom sheet hidden to `FullyExpanded` with fixed-height content: 0 content recompositions.
- Bottom sheet hidden to content-sized detent with fixed-height content: 0 content recompositions.
- Bottom sheet `invalidateDetents()` with content-sized detent and fixed content: 0 content recompositions.
- Bottom sheet detent-list update for content-sized content: 1 content recomposition.
- Bottom sheet container resize for a container-based detent: 1 content recomposition.
- Modal bottom sheet hidden to `FullyExpanded` with fixed-height content: 2 content compositions.
- Modal bottom sheet hidden to content-sized detent with fixed-height content: 2 content compositions.
- Modal bottom sheet `invalidateDetents()` with content-sized detent and fixed content: 0 content recompositions.
- Modal bottom sheet detent-list update for content-sized content: 0 content recompositions.
- Modal bottom sheet container resize for a container-based detent: 1 content recomposition.

## Notes
- `RecompositionCount` uses `@NonSkippableComposable`; without it, Compose can skip the marker and hide a recomposition.
- This PR records current behavior instead of changing sheet implementations.

## Verification
- `./gradlew :composeunstyled-bottom-sheet:jvmTest --tests "com.composeunstyled.BottomSheetRecompositionTest" :composeunstyled-modal-bottom-sheet:jvmTest --tests "com.composeunstyled.ModalBottomSheetRecompositionTest"`
- `./gradlew jvmTest spotlessCheck`