### PR TITLE
Fix initial checked switch thumb placement

### DIFF
--- a/composeunstyled-toggle-switch/build.gradle.kts
+++ b/composeunstyled-toggle-switch/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(projects.composeunstyledTest)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -32,9 +32,11 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -127,7 +129,14 @@ fun UnstyledSwitch(
     layout(width, height) {
       placeables.forEach { placeable ->
         val thumbData = placeable.parentData as? SwitchThumbParentData
-        val x = thumbData?.let { it.offset.roundToPx() } ?: 0
+        val x = thumbData?.let {
+          val offset = if (checked && it.hasMeasured.not()) {
+            width - placeable.width
+          } else {
+            it.offset.roundToPx()
+          }
+          offset
+        } ?: 0
         placeable.placeRelative(x = max(0, x), y = 0)
       }
     }
@@ -145,6 +154,7 @@ fun SwitchScope.SwitchThumb(
   val thumbWidth = scope?.thumbWidth ?: 0
   val density = LocalDensity.current
   val hasMeasured = trackWidth > 0 && thumbWidth > 0
+  var hasPlacedAtMeasuredOffset by remember { mutableStateOf(false) }
   val targetOffset = with(density) {
     if (checked && hasMeasured) {
       (trackWidth - thumbWidth).toDp()
@@ -152,11 +162,22 @@ fun SwitchScope.SwitchThumb(
       0.dp
     }
   }
-  val offset by animateDpAsState(targetValue = targetOffset, animationSpec = animationSpec)
+  val offset = if (hasMeasured && hasPlacedAtMeasuredOffset.not()) {
+    SideEffect {
+      hasPlacedAtMeasuredOffset = true
+    }
+    targetOffset
+  } else {
+    val animatedOffset by animateDpAsState(
+      targetValue = targetOffset,
+      animationSpec = animationSpec,
+    )
+    animatedOffset
+  }
 
   Box(
     modifier = modifier
-      .then(SwitchThumbParentDataModifier(offset))
+      .then(SwitchThumbParentDataModifier(offset, hasMeasured))
       // Hide the thumb until the parent has measured the track and thumb,
       // otherwise checked switches briefly draw the thumb at the start.
       .alpha(if (hasMeasured) 1f else 0f),
@@ -167,10 +188,14 @@ fun SwitchScope.SwitchThumb(
 
 private data class SwitchThumbParentData(
   val offset: Dp,
+  val hasMeasured: Boolean,
 )
 
 private data class SwitchThumbParentDataModifier(
   val offset: Dp,
+  val hasMeasured: Boolean,
 ) : ParentDataModifier {
-  override fun Density.modifyParentData(parentData: Any?): Any = SwitchThumbParentData(offset)
+  override fun Density.modifyParentData(
+    parentData: Any?,
+  ): Any = SwitchThumbParentData(offset, hasMeasured)
 }

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -32,24 +32,18 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.ParentDataModifier
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.math.max
+import kotlin.math.roundToInt
 
 @Stable
 interface SwitchScope {
@@ -62,8 +56,6 @@ private class SwitchScopeImpl(
   override val checked: Boolean,
   override val enabled: Boolean,
   override val interactionSource: MutableInteractionSource,
-  val trackWidth: Int,
-  val thumbWidth: Int,
 ) : SwitchScope
 
 @Composable
@@ -77,12 +69,9 @@ fun UnstyledSwitch(
   content: @Composable SwitchScope.() -> Unit,
 ) {
   val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
-  var trackWidth by remember { mutableIntStateOf(0) }
-  var thumbWidth by remember { mutableIntStateOf(0) }
 
   Layout(
     modifier = modifier
-      .onSizeChanged { trackWidth = it.width }
       .then(
         buildModifier {
           if (onCheckedChange != null) {
@@ -104,8 +93,6 @@ fun UnstyledSwitch(
         checked = checked,
         enabled = enabled,
         interactionSource = resolvedInteractionSource,
-        trackWidth = trackWidth,
-        thumbWidth = thumbWidth,
       )
       scope.content()
     },
@@ -115,12 +102,6 @@ fun UnstyledSwitch(
     ->
     val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
     val placeables = measurables.map { it.measure(looseConstraints) }
-    val measuredThumbWidth = placeables
-      .filter { it.parentData is SwitchThumbParentData }
-      .maxOfOrNull { it.width } ?: 0
-    if (thumbWidth != measuredThumbWidth) {
-      thumbWidth = measuredThumbWidth
-    }
     val contentWidth = placeables.maxOfOrNull { it.width } ?: 0
     val contentHeight = placeables.maxOfOrNull { it.height } ?: 0
     val width = contentWidth.coerceIn(constraints.minWidth, constraints.maxWidth)
@@ -130,12 +111,7 @@ fun UnstyledSwitch(
       placeables.forEach { placeable ->
         val thumbData = placeable.parentData as? SwitchThumbParentData
         val x = thumbData?.let {
-          val offset = if (checked && it.hasMeasured.not()) {
-            width - placeable.width
-          } else {
-            it.offset.roundToPx()
-          }
-          offset
+          ((width - placeable.width) * it.offsetFraction).roundToInt()
         } ?: 0
         placeable.placeRelative(x = max(0, x), y = 0)
       }
@@ -149,53 +125,27 @@ fun SwitchScope.SwitchThumb(
   animationSpec: FiniteAnimationSpec<Dp> = snap(),
   content: @Composable () -> Unit = {},
 ) {
-  val scope = this as? SwitchScopeImpl
-  val trackWidth = scope?.trackWidth ?: 0
-  val thumbWidth = scope?.thumbWidth ?: 0
-  val density = LocalDensity.current
-  val hasMeasured = trackWidth > 0 && thumbWidth > 0
-  var hasPlacedAtMeasuredOffset by remember { mutableStateOf(false) }
-  val targetOffset = with(density) {
-    if (checked && hasMeasured) {
-      (trackWidth - thumbWidth).toDp()
-    } else {
-      0.dp
-    }
-  }
-  val offset = if (hasMeasured && hasPlacedAtMeasuredOffset.not()) {
-    SideEffect {
-      hasPlacedAtMeasuredOffset = true
-    }
-    targetOffset
-  } else {
-    val animatedOffset by animateDpAsState(
-      targetValue = targetOffset,
-      animationSpec = animationSpec,
-    )
-    animatedOffset
-  }
+  val offsetFraction by animateDpAsState(
+    targetValue = if (checked) 1.dp else 0.dp,
+    animationSpec = animationSpec,
+  )
 
   Box(
     modifier = modifier
-      .then(SwitchThumbParentDataModifier(offset, hasMeasured))
-      // Hide the thumb until the parent has measured the track and thumb,
-      // otherwise checked switches briefly draw the thumb at the start.
-      .alpha(if (hasMeasured) 1f else 0f),
+      .then(SwitchThumbParentDataModifier(offsetFraction.value)),
   ) {
     content()
   }
 }
 
 private data class SwitchThumbParentData(
-  val offset: Dp,
-  val hasMeasured: Boolean,
+  val offsetFraction: Float,
 )
 
 private data class SwitchThumbParentDataModifier(
-  val offset: Dp,
-  val hasMeasured: Boolean,
+  val offsetFraction: Float,
 ) : ParentDataModifier {
   override fun Density.modifyParentData(
     parentData: Any?,
-  ): Any = SwitchThumbParentData(offset, hasMeasured)
+  ): Any = SwitchThumbParentData(offsetFraction)
 }

--- a/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchRecompositionTest.kt
+++ b/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchRecompositionTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import com.composeunstyled.test.runComposeRecompositionTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ToggleSwitchRecompositionTest {
+  @Test
+  fun togglingCheckedRecomposesThumbContentOnce() = runComposeRecompositionTest {
+    var checked by mutableStateOf(false)
+
+    setContent {
+      UnstyledSwitch(
+        checked = checked,
+        onCheckedChange = { checked = it },
+        modifier = Modifier
+          .width(58.dp)
+          .height(32.dp),
+      ) {
+        SwitchThumb(
+          animationSpec = tween(durationMillis = 1_000),
+          modifier = Modifier.size(24.dp),
+        ) {
+          RecompositionCount("thumb-content")
+          Box(Modifier.size(1.dp))
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts("thumb-content")
+
+    checked = true
+    waitForIdle()
+
+    assertEquals(1, recompositionCount("thumb-content"))
+  }
+
+  @Test
+  fun resizingCheckedSwitchContainerDoesNotRecomposeThumbContent() = runComposeRecompositionTest {
+    var switchWidth by mutableIntStateOf(58)
+
+    setContent {
+      Layout(
+        content = {
+          UnstyledSwitch(
+            checked = true,
+            onCheckedChange = {},
+            modifier = Modifier.height(32.dp),
+          ) {
+            SwitchThumb(
+              animationSpec = tween(durationMillis = 1_000),
+              modifier = Modifier.size(24.dp),
+            ) {
+              RecompositionCount("thumb-content")
+              Box(Modifier.size(1.dp))
+            }
+          }
+        },
+      ) { measurables, _ ->
+        val width = switchWidth
+        val height = 32.dp.roundToPx()
+        val placeable = measurables.single().measure(Constraints.fixed(width, height))
+
+        layout(width, height) {
+          placeable.place(0, 0)
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts("thumb-content")
+
+    switchWidth = 68
+    waitForIdle()
+
+    assertEquals(0, recompositionCount("thumb-content"))
+  }
+}

--- a/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
+++ b/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
@@ -21,6 +21,7 @@
  */
 package com.composeunstyled
 
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -28,9 +29,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
@@ -170,6 +174,37 @@ class ToggleSwitchTest {
     onNodeWithTag("switch").performClick()
     waitForIdle()
 
+    onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(34.dp)
+  }
+
+  @Test
+  fun checkedThumbStartsAtEndWhenUsingAnimationSpec() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val thumbPositions = mutableStateListOf<Int>()
+
+    setContent {
+      UnstyledSwitch(
+        checked = true,
+        onCheckedChange = {},
+        modifier = Modifier
+          .width(58.dp)
+          .height(32.dp)
+          .testTag("switch"),
+      ) {
+        SwitchThumb(
+          animationSpec = tween(durationMillis = 1_000),
+          modifier = Modifier
+            .onPlaced { thumbPositions += it.positionInRoot().x.toInt() }
+            .size(24.dp),
+        ) {
+          Box(Modifier.size(1.dp).testTag("thumb-content"))
+        }
+      }
+    }
+
+    mainClock.advanceTimeByFrame()
+
+    assertEquals(listOf(34), thumbPositions.distinct())
     onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(34.dp)
   }
 


### PR DESCRIPTION
## Summary
- place checked switch thumbs at the end on the first layout pass, including animated thumbs
- remove measurement-backed Compose state from switch thumb placement
- add regression and recomposition tests for checked changes and layout-only resizing

## Verification
- ./gradlew :composeunstyled-toggle-switch:jvmTest spotlessCheck
- ./gradlew :demo:hotReloadDesktopMain
- ./gradlew :demo:hotRunDesktop