### PR TITLE
Add Renovate dependency update config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,13 @@
   "rangeStrategy": "bump",
   "packageRules": [
     {
+      "description": "Disable dependency updates by default.",
+      "matchPackageNames": [
+        "/.*/"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Only propose stable Maven and Gradle releases.",
       "matchDatasources": [
         "maven"
@@ -14,12 +21,12 @@
       "allowedVersions": "!/[-.](alpha|beta|rc|cr|milestone|eap|dev|snapshot|m[0-9]+|M[0-9]+)[-.0-9]*/"
     },
     {
-      "description": "Group Compose Multiplatform updates.",
+      "description": "Only propose Compose Multiplatform updates.",
       "matchPackageNames": [
         "org.jetbrains.compose",
-        "org.jetbrains.kotlin.plugin.compose",
         "/^org\\.jetbrains\\.compose[.:]/"
       ],
+      "enabled": true,
       "groupName": "Compose Multiplatform"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "dependencyDashboard": true,
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "description": "Only propose stable Maven and Gradle releases.",
+      "matchDatasources": [
+        "maven"
+      ],
+      "allowedVersions": "!/[-.](alpha|beta|rc|cr|milestone|eap|dev|snapshot|m[0-9]+|M[0-9]+)[-.0-9]*/"
+    },
+    {
+      "description": "Group Compose Multiplatform updates.",
+      "matchPackageNames": [
+        "org.jetbrains.compose",
+        "org.jetbrains.kotlin.plugin.compose",
+        "/^org\\.jetbrains\\.compose[.:]/"
+      ],
+      "groupName": "Compose Multiplatform"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Renovate recommended config for automated dependency update PRs
- Enable the dependency dashboard
- Disable dependency updates by default, then allow only Compose Multiplatform packages/plugins
- Restrict Maven/Gradle updates to stable releases only and group Compose Multiplatform updates

## Verification
- npx --yes --package renovate renovate-config-validator renovate.json