### PR TITLE
Refresh component API docs

### DIFF
--- a/demo/src/commonMain/kotlin/BottomSheetScrollableContentDemo.kt
+++ b/demo/src/commonMain/kotlin/BottomSheetScrollableContentDemo.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled.demo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.composeunstyled.DragIndication
+import com.composeunstyled.Sheet
+import com.composeunstyled.SheetDetent
+import com.composeunstyled.SheetDetent.Companion.FullyExpanded
+import com.composeunstyled.UnstyledBottomSheet
+import com.composeunstyled.rememberBottomSheetState
+
+@Composable
+fun BottomSheetScrollableContentDemo() {
+  val Peek = SheetDetent("peek") { containerHeight, _ ->
+    containerHeight * 0.45f
+  }
+  val sheetState = rememberBottomSheetState(
+    initialDetent = Peek,
+    detents = listOf(Peek, FullyExpanded),
+  )
+  val items = List(24) { index -> "Item ${index + 1}" }
+
+  UnstyledBottomSheet(
+    state = sheetState,
+    modifier = Modifier.fillMaxSize().padding(top = 12.dp),
+  ) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.TopCenter) {
+      Sheet(
+        modifier = Modifier
+          .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+          .background(Color(0xFFF8FAFC))
+          .border(1.dp, Color(0xFFCACACA), RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+          .widthIn(max = 640.dp)
+          .fillMaxWidth(),
+      ) {
+        Box(Modifier.fillMaxWidth()) {
+          LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(top = 48.dp, bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            items(items) { item ->
+              BasicText(
+                text = item,
+                modifier = Modifier
+                  .fillMaxWidth()
+                  .padding(horizontal = 24.dp)
+                  .background(Color.White, RoundedCornerShape(8.dp))
+                  .border(1.dp, Color(0xFFE4E4E7), RoundedCornerShape(8.dp))
+                  .padding(16.dp),
+                style = TextStyle(
+                  color = Color(0xFF18181B),
+                  fontSize = 14.sp,
+                ),
+              )
+            }
+          }
+          Box(
+            Modifier.fillMaxWidth().padding(top = 22.dp),
+            contentAlignment = Alignment.Center,
+          ) {
+            DragIndication(
+              modifier = Modifier
+                .background(Color(0xFFCACACA), RoundedCornerShape(100))
+                .size(32.dp, 4.dp),
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/demo/src/commonMain/kotlin/CheckboxCustomCheckedIndicatorDemo.kt
+++ b/demo/src/commonMain/kotlin/CheckboxCustomCheckedIndicatorDemo.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled.demo
+
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathMeasure
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.unit.dp
+import com.composeunstyled.UnstyledCheckbox
+
+@Composable
+fun CheckboxCustomCheckedIndicatorDemo() {
+  var checked by remember { mutableStateOf(true) }
+  val checkboxShape = RoundedCornerShape(4.dp)
+  UnstyledCheckbox(
+    checked = checked,
+    onCheckedChange = { checked = it },
+    modifier = Modifier.clip(checkboxShape),
+    accessibilityLabel = "Enable notifications",
+  ) {
+    MaterialCheckboxIndicator(checked = checked)
+  }
+}
+
+@Composable
+private fun MaterialCheckboxIndicator(
+  checked: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  val transition = updateTransition(checked)
+  val boxProgress by transition.animateFloat(
+    transitionSpec = { tween(durationMillis = 450) },
+  ) { isChecked ->
+    if (isChecked) 1f else 0f
+  }
+  val checkProgress by transition.animateFloat(
+    transitionSpec = { tween(durationMillis = 450) },
+  ) { isChecked ->
+    if (isChecked) 1f else 0f
+  }
+  val checkPath = remember { Path() }
+  val checkPathMeasure = remember { PathMeasure() }
+  val visibleCheckPath = remember { Path() }
+
+  Canvas(modifier.size(24.dp)) {
+    val strokeWidth = 2.dp.toPx()
+    val radius = 4.dp.toPx()
+    val boxColor = lerp(Color.Transparent, Color(0xFF18181B), boxProgress)
+    val borderColor = lerp(Color(0xFFCACACA), Color(0xFF18181B), boxProgress)
+    val checkColor = Color.White
+
+    drawRoundRect(
+      color = boxColor,
+      size = size,
+      cornerRadius = CornerRadius(radius),
+      style = Fill,
+    )
+    drawRoundRect(
+      color = borderColor,
+      topLeft = Offset(strokeWidth / 2f, strokeWidth / 2f),
+      size = Size(size.width - strokeWidth, size.height - strokeWidth),
+      cornerRadius = CornerRadius(radius - strokeWidth / 2f),
+      style = Stroke(width = strokeWidth),
+    )
+
+    checkPath.reset()
+    checkPath.moveTo(size.width * 0.2f, size.height * 0.52f)
+    checkPath.lineTo(size.width * 0.42f, size.height * 0.72f)
+    checkPath.lineTo(size.width * 0.8f, size.height * 0.32f)
+
+    visibleCheckPath.reset()
+    checkPathMeasure.setPath(checkPath, false)
+    checkPathMeasure.getSegment(
+      startDistance = 0f,
+      stopDistance = checkPathMeasure.length * checkProgress,
+      destination = visibleCheckPath,
+      startWithMoveTo = true,
+    )
+
+    drawPath(
+      path = visibleCheckPath,
+      color = checkColor,
+      style = Stroke(
+        width = strokeWidth,
+        join = StrokeJoin.Round,
+      ),
+    )
+  }
+}

--- a/demo/src/commonMain/kotlin/CheckboxExtendedIndicatorBoundsDemo.kt
+++ b/demo/src/commonMain/kotlin/CheckboxExtendedIndicatorBoundsDemo.kt
@@ -23,7 +23,9 @@ package com.composeunstyled.demo
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -45,17 +47,18 @@ import com.composeunstyled.UnstyledCheckbox
 import com.composeunstyled.UnstyledIcon
 
 @Composable
-fun CheckboxDemo() {
-  var checked by remember { mutableStateOf(true) }
+fun CheckboxExtendedIndicatorBoundsDemo() {
+  var checked by remember { mutableStateOf(false) }
   val checkboxShape = RoundedCornerShape(4.dp)
   UnstyledCheckbox(
     checked = checked,
     onCheckedChange = { checked = it },
-    modifier = Modifier.clip(checkboxShape),
+    modifier = Modifier.clip(CircleShape),
     accessibilityLabel = "Enable notifications",
   ) {
     CheckedIndicator(
       modifier = Modifier
+        .padding(8.dp)
         .size(24.dp)
         .background(Color(0xFFF8FAFC), checkboxShape)
         .border(1.dp, Color(0xFFCACACA), checkboxShape),

--- a/demo/src/commonMain/kotlin/Demo.kt
+++ b/demo/src/commonMain/kotlin/Demo.kt
@@ -93,9 +93,27 @@ private val availablePrimitives = listOf(
     { BottomSheetDemo() },
     previewOptions = PreviewOptions(padding = PaddingValues(0.dp)),
   ),
+  DemoItem(
+    "Bottom Sheet (Scrollable Content)",
+    "bottom-sheet-scrollable-content",
+    { BottomSheetScrollableContentDemo() },
+    previewOptions = PreviewOptions(padding = PaddingValues(0.dp)),
+  ),
   DemoItem("Bottom Sheet (Modal)", "modal-bottom-sheet", { ModalBottomSheetDemo() }),
+  DemoItem(
+    "Bottom Sheet (Modal, Scrollable Content)",
+    "modal-bottom-sheet-scrollable-content",
+    { ModalBottomSheetScrollableContentDemo() },
+    previewOptions = PreviewOptions(padding = PaddingValues(0.dp)),
+  ),
   DemoItem("Button", "button", { ButtonDemo() }),
   DemoItem("Checkbox", "checkbox", { CheckboxDemo() }),
+  DemoItem("Checkbox (Custom CheckedIndicator)", "checkbox-custom-checked-indicator", {
+    CheckboxCustomCheckedIndicatorDemo()
+  }),
+  DemoItem("Checkbox (extended Indicator bounds)", "checkbox-extended-indicator-bounds", {
+    CheckboxExtendedIndicatorBoundsDemo()
+  }),
   DemoItem("Checkbox (TriState)", "tristatecheckbox", { TriStateCheckboxDemo() }),
   DemoItem("Dialog", "dialog", { DialogDemo() }),
   DemoItem(

--- a/demo/src/commonMain/kotlin/ModalBottomSheetScrollableContentDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalBottomSheetScrollableContentDemo.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled.demo
+
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.composeunstyled.DragIndication
+import com.composeunstyled.Scrim
+import com.composeunstyled.Sheet
+import com.composeunstyled.SheetDetent
+import com.composeunstyled.SheetDetent.Companion.FullyExpanded
+import com.composeunstyled.SheetDetent.Companion.Hidden
+import com.composeunstyled.UnstyledModalBottomSheet
+import com.composeunstyled.rememberModalBottomSheetState
+
+@Composable
+fun ModalBottomSheetScrollableContentDemo() {
+  val Peek = SheetDetent("peek") { containerHeight, _ ->
+    containerHeight * 0.45f
+  }
+  val sheetState = rememberModalBottomSheetState(
+    initialDetent = Peek,
+    detents = listOf(Hidden, Peek, FullyExpanded),
+  )
+  val items = List(24) { index -> "Item ${index + 1}" }
+
+  UnstyledModalBottomSheet(
+    state = sheetState,
+    overlay = {
+      Scrim(
+        scrimColor = Color.Black.copy(0.3f),
+        enter = fadeIn(),
+        exit = fadeOut(),
+      )
+    },
+  ) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.TopCenter) {
+      Sheet(
+        modifier = Modifier
+          .widthIn(max = 640.dp)
+          .fillMaxWidth()
+          .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+          .background(Color(0xFFF8FAFC))
+          .border(1.dp, Color(0xFFCACACA), RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)),
+      ) {
+        Box(Modifier.fillMaxWidth()) {
+          LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(top = 48.dp, bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            items(items) { item ->
+              BasicText(
+                text = item,
+                modifier = Modifier
+                  .fillMaxWidth()
+                  .padding(horizontal = 24.dp)
+                  .background(Color.White, RoundedCornerShape(8.dp))
+                  .border(1.dp, Color(0xFFE4E4E7), RoundedCornerShape(8.dp))
+                  .padding(16.dp),
+                style = TextStyle(
+                  color = Color(0xFF18181B),
+                  fontSize = 14.sp,
+                ),
+              )
+            }
+          }
+          Box(
+            Modifier.fillMaxWidth().padding(top = 22.dp),
+            contentAlignment = Alignment.Center,
+          ) {
+            DragIndication(
+              modifier = Modifier
+                .background(Color(0xFFCACACA), RoundedCornerShape(100))
+                .size(32.dp, 4.dp),
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/pages/bottom-sheet.md
+++ b/docs/pages/bottom-sheet.md
@@ -1,10 +1,16 @@
 ---
 title: Bottom Sheet
-description: A renderless, highly performant foundational component to build Compose Multiplatform bottom sheets with, jam-packed with styling features without compromising on
-  accessibility or keyboard interactions.
+description: A draggable bottom sheet with custom detents.
 ---
 
 <UnstyledDemo id="bottom-sheet" />
+
+## Features
+
+- Custom detents
+- Soft-keyboard support
+- Dynamic content sizing
+- Scrollable content without fixed height
 
 ## Installation
 
@@ -12,457 +18,178 @@ description: A renderless, highly performant foundational component to build Com
 implementation("com.composables:composeunstyled-bottom-sheet")
 ```
 
-## Basic Example
-
-A bottom sheet consists of the following components: `BottomSheet` and the optional `DragIndication`.
-
-The `BottomSheet` component controls the area in which your sheet can be dragged and renders it within that area.
-
-The `DragIndication` is an optional component that can be used within the `BottomSheet`'s contents. It provides a way
-for the user to control the sheet without touch input.
-
-A bottom sheet has a set of specified `Detents`. Each detent specify the height in which the sheet can rest while not
-being dragged.
-
-By default, 2 detents are specified: `Hidden` and `FullyExpanded`.
+## Anatomy
 
 ```kotlin
 val sheetState = rememberBottomSheetState(
-    initialDetent = Hidden,
+  initialDetent = SheetDetent.Hidden,
 )
 
-UnstyledButton(onClick = { sheetState.targetDetent = FullyExpanded }) {
-    BasicText("Show Sheet")
-}
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth(),
-) {
-    Box(
-        modifier = Modifier.fillMaxWidth().height(1200.dp),
-        contentAlignment = Alignment.TopCenter
-    ) {
-        UnstyledDragIndication(Modifier.width(32.dp).height(4.dp))
-    }
+UnstyledBottomSheet(state = sheetState) {
+  Sheet {
+    DragIndication()
+  }
 }
 ```
 
-## Styling
+## Concepts
 
-The bottom sheet renders nothing on the screen by default. It manages a lot of states internally and leaves the styling
-to you.
+- `SheetDetent` defines a height where the sheet can rest.
+- `UnstyledBottomSheet` represents the draggable container the `Sheet` is dragged in.
+- `Sheet` is the rendered bit of the sheet.
+- `DragIndication` adds an interactive handle for expand, collapse, and dismiss actions.
 
-Any sort of styling is done by the `Modifier` of the respective component.
+## Accessibility
 
-Changing the looks of the bottom sheet is done by passing the respective styling `Modifier`s to your `BottomSheet`
-and `DragIndication`:
-
-```kotlin
-val sheetState = rememberBottomSheetState(
-    initialDetent = Hidden,
-)
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier
-        .dropShadow(
-            shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-            shadow = Shadow(
-                radius = 16.dp,
-                spread = 0.dp,
-                color = Color.Black.copy(alpha = 0.14f),
-                offset = DpOffset(x = 0.dp, y = (-3).dp)
-            )
-        )
-        .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
-        .background(Color.White)
-        .widthIn(max = 640.dp)
-        .fillMaxWidth()
-        .imePadding(),
-) {
-    Box(
-        modifier = Modifier.fillMaxWidth().height(1200.dp),
-        contentAlignment = Alignment.TopCenter
-    ) {
-        UnstyledDragIndication(
-            modifier = Modifier
-                .padding(top = 22.dp)
-                .background(Color.Black.copy(0.4f), RoundedCornerShape(100))
-                .width(32.dp)
-                .height(4.dp)
-        )
-    }
-}
-
-```
+Use the `DragIndication` component when your sheet can move between multiple detents. It provides semantic expand,
+collapse, and dismiss actions so users can control the sheet without dragging.
 
 ## Code Examples
 
-### Showing/Hide the bottom sheet
+### Showing and hiding the sheet
 
-The visibility of the sheet is controlled by its state's *targetDetent* property.
-
-Pass `Hidden` to hide it, or `FullyExpanded` to fully expand it:
+Use the `targetDetent` property to animate the sheet to a new detent:
 
 ```kotlin
 val sheetState = rememberBottomSheetState(
-    initialDetent = Hidden,
+  initialDetent = SheetDetent.Hidden,
 )
 
-UnstyledButton(onClick = { sheetState.targetDetent = FullyExpanded }) {
-    BasicText("Show Sheet")
-}
+BasicText(
+  text = "Show sheet",
+  modifier = Modifier.clickable {
+    sheetState.targetDetent = SheetDetent.FullyExpanded
+  }
+)
 
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth(),
-) {
-    Box(
-        modifier = Modifier.fillMaxWidth().height(1200.dp),
-        contentAlignment = Alignment.TopCenter
-    ) {
-        UnstyledButton(onClick = { sheetState.targetDetent = Hidden }) {
-            BasicText("Hide Sheet")
-        }
-    }
+UnstyledBottomSheet(state = sheetState) {
+  Sheet {
+    BasicText(
+      text = "Hide sheet",
+      modifier = Modifier.clickable {
+        sheetState.targetDetent = SheetDetent.Hidden
+      }
+    )
+  }
 }
 ```
 
-Using the `targetDetent` property will cause the sheet to animate to given detent.
+### Waiting for the sheet animation
 
-### Customizing sheet detents
+Use the suspend `animateTo()` function to wait until the sheet animation is done:
 
-The heights in which the bottom sheet needs to stop for dragging purposes is controlled by the sheet's
-state `SheetDetent`s.
+```kotlin
+val scope = rememberCoroutineScope()
 
-To create a new detent, use the `SheetDetent` constructor to pass a unique identifier and a function which calculates
-the height of the detent at a given moment. The calculated value will be capped between `0.dp` and the content's height.
+BasicText(
+  text = "Show sheet",
+  modifier = Modifier.clickable {
+    scope.launch {
+      sheetState.animateTo(SheetDetent.FullyExpanded)
+    }
+  }
+)
+```
 
-**NOTE:** Make sure that the calculation returns _fast_, as this will affect your sheet's performance.
+### Moving the sheet instantly
+
+Use the `jumpTo()` function to move to a detent without animation:
+
+```kotlin
+BasicText(
+  text = "Open immediately",
+  modifier = Modifier.clickable {
+    sheetState.jumpTo(SheetDetent.FullyExpanded)
+  }
+)
+```
+
+### Creating sheets with custom detents
+
+Use the `SheetDetent` constructor to create a new detent. Pass a unique identifier and a function
+that calculates the detent height. The calculated height cannot be smaller than `0.dp`, taller than
+the container, or taller than the sheet content.
+
+Keep this calculation fast. It runs during sheet measurement.
 
 Make sure to pass your new detent when creating your bottom sheet state:
 
 ```kotlin
-val Peek = SheetDetent(identifier = "peek") { containerHeight, sheetHeight ->
-    containerHeight * 0.6f
-}
-
-val sheetState = rememberBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Hidden, Peek, FullyExpanded)
-)
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth(),
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(Color.White)
-            .height(1200.dp),
-        contentAlignment = Alignment.TopCenter
-    ) {
-        UnstyledDragIndication(
-            modifier = Modifier
-                .padding(top = 22.dp)
-                .background(Color.Black.copy(0.4f), RoundedCornerShape(100))
-                .width(32.dp)
-                .height(4.dp)
-        )
-    }
-}
-```
-
-### Drawing behind the nav bar
-
-The BottomSheet component works as a normal component and does not do anything special when it comes to System UI. This
-way you have full control
-over how you want your layout to be rendered.
-
-Nice looking bottom sheets tend to draw behind the platform's navigation bar while keeping their content above the
-navigation bar.
-
-The following code example showcases how to draw the bottom sheet behind the nav bar while ensuring its content is never
-blocked by the nav bar's buttons.
-
-At the same time, we make sure that the bottom sheet is never drawn behind the nav bars on landscape mode (for visual
-purposes):
-
-```kotlin
-val sheetState = rememberBottomSheetState(
-    initialDetent = FullyExpanded,
-)
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth()
-        .padding(
-            WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
-                .asPaddingValues()
-        )
-        .navigationBarsPadding(),
-) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        UnstyledDragIndication()
-        BasicText("Here is some content")
-    }
-}
-```
-
-### Working with the soft-keyboard
-
-Add the `Modifier.imePadding()` in the contents of your sheet to make sure its contents are always drawn above the soft
-keyboard.
-
-Here is a styled example of a 'Add note' sheet:
-
-```kotlin
-val sheetState = rememberBottomSheetState(
-    initialDetent = FullyExpanded,
-)
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth()
-        .padding(
-            // make sure the sheet is not behind nav bars on landscape
-            WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
-                .asPaddingValues()
-        )
-        .background(Color.White),
-) {
-    Column(
-        modifier = Modifier.fillMaxWidth()
-            .padding(16.dp)
-            // make sure the contents of the sheet is always above the nav bar
-            .navigationBarsPadding()
-            // draw the contents above the soft keyboard
-            .imePadding()
-    ) {
-        UnstyledDragIndication(Modifier.align(Alignment.CenterHorizontally))
-
-        var text by remember { mutableStateOf("") }
-        UnstyledTextField(
-            value = text,
-            onValueChange = { text = it },
-            modifier = Modifier.fillMaxWidth()
-        )
-        UnstyledButton(
-            onClick = { /* TODO */ },
-            shape = RoundedCornerShape(4.dp),
-            contentPadding = PaddingValues(4.dp),
-            modifier = Modifier.align(Alignment.End)
-        ) {
-            BasicText(
-                text = "Save note",
-                style = TextStyle.Default.copy(color = Color.White)
-            )
-        }
-    }
-}
-
-```
-
-### Scrollable sheets
-
-Add any scrollable component within the contents of your sheet. `BottomSheet` supports nesting scrolling out of the box:
-
-```kotlin
-val sheetState = rememberBottomSheetState(
-    initialDetent = FullyExpanded,
-)
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth()
-        .background(Color.White),
-) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        UnstyledDragIndication(Modifier.width(32.dp).height(4.dp))
-        LazyColumn {
-            repeat(50) {
-                item { BasicText("Item #${(it + 1)}", modifier = Modifier.padding(10.dp)) }
-            }
-        }
-    }
-}
-```
-
-<p class="border-l-4 pl-4 border-orange-500 flex flex-col gap-2 unstyled-warning">
-<strong class="text-orange-800 unstyled-warning-title">⚠️ Scrollable content must have a fixed height</strong>
-<span>The current implementation does not automatically handle dynamic content height of scrollable content. As a workaround, you must use a fixed height for your content.</span>
-<span>If this affects you, <a href="https://github.com/composablehorizons/compose-unstyled/issues/134">react to the respected feature request.</a></span>
-</p>
-
-### Adding transitions
-
-Pass your own `AnimationSpec` when creating your sheet's state:
-
-```kotlin
 val Peek = SheetDetent("peek") { containerHeight, sheetHeight ->
-    containerHeight * 0.6f
+  containerHeight * 0.6f
 }
 
 val sheetState = rememberBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Peek, FullyExpanded),
-    animationSpec = spring(
-        dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow
+  initialDetent = Peek,
+  detents = listOf(SheetDetent.Hidden, Peek, SheetDetent.FullyExpanded),
+)
+
+UnstyledBottomSheet(state = sheetState) {
+  Sheet {
+    DragIndication()
+  }
+}
+```
+
+### Updating detents after the state is created
+
+Use the `invalidateDetents()` function to recalculate sheet detents. This is useful when a custom
+detent reads a measured value that can change, such as a header height:
+
+```kotlin
+val peekHeight = remember { mutableStateOf(96.dp) }
+val Peek = remember {
+  SheetDetent("peek") { _, _ -> peekHeight.value }
+}
+
+val sheetState = rememberBottomSheetState(
+  initialDetent = Peek,
+  detents = listOf(Peek, SheetDetent.FullyExpanded),
+)
+
+LaunchedEffect(peekHeight.value) {
+  sheetState.invalidateDetents()
+}
+```
+
+### Using scrollable sheet content
+
+Use a scrollable layout inside the `Sheet` component to make content scroll within the current detent height:
+
+<UnstyledDemo id="bottom-sheet-scrollable-content" />
+
+### Working with the soft keyboard
+
+Use the `offsetForIme` parameter to automatically move the sheet above the soft keyboard:
+
+```kotlin
+var value by remember { mutableStateOf("") }
+
+UnstyledBottomSheet(
+  state = sheetState,
+  offsetForIme = true,
+) {
+  Sheet {
+    BasicTextField(
+      value = value,
+      onValueChange = { value = it },
     )
-)
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth()
-        .background(Color.White)
-        .height(1200.dp),
-) {
+  }
 }
 ```
 
-### Listening to state changes
+### Customizing sheet animation between detents
 
-Use the sheet's state `currentDetent` to observe for state changes. This value returns the current detent the sheet is
-currently rested at.
-
-The `targetDetent` value returns the next detent the sheet is approaching (ie while being dragged).
-
-```kotlin
-val Peek = SheetDetent("peek") { containerHeight, sheetHeight ->
-    containerHeight * 0.6f
-}
-
-val sheetState = rememberBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Peek, FullyExpanded),
-)
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth()
-        .background(Color.White)
-        .height(1200.dp),
-) {
-    Column {
-        BasicText("Current Detent = ${sheetState.currentDetent.identifier}")
-        BasicText("Target Detent = ${sheetState.targetDetent.identifier}")
-    }
-}
-```
-
-### Listening to dragging progress
-
-Use the state's `offset` value to listen to how far the sheet has moved within its container.
-
-If you are interested in listening to dragging events between detents, use the state's `progress` value instead:
-
-```kotlin
-val Peek = SheetDetent("peek") { containerHeight, sheetHeight ->
-    containerHeight * 0.6f
-}
-
-val sheetState = rememberBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Peek, FullyExpanded),
-)
-
-val alpha by animateFloatAsState(targetValue = sheetState.offset)
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth()
-        .alpha(alpha)
-        .background(Color.White)
-        .height(1200.dp),
-) {
-}
-```
-
-### Jumping to detent immediately
-
-Use the `jumpTo()` function to move the sheet to the desired detent without any animation:
+Use the `animationSpec` parameter to customize the default animation between detents:
 
 ```kotlin
 val sheetState = rememberBottomSheetState(
-    initialDetent = Hidden,
+  initialDetent = SheetDetent.Hidden,
+  animationSpec = spring(
+    dampingRatio = Spring.DampingRatioMediumBouncy,
+    stiffness = Spring.StiffnessLow,
+  ),
 )
-
-UnstyledButton(onClick = { sheetState.jumpTo(FullyExpanded) }) {
-    BasicText("Show Sheet")
-}
-
-BottomSheet(
-    state = sheetState,
-    modifier = Modifier.fillMaxWidth(),
-) {
-    Box(
-        modifier = Modifier.fillMaxWidth().height(1200.dp),
-        contentAlignment = Alignment.TopCenter
-    ) {
-        UnstyledButton(onClick = { sheetState.jumpTo(Hidden) }) {
-            BasicText("Hide Sheet")
-        }
-    }
-}
 ```
-
-## Keyboard Interactions
-
-The `BottomSheet` component does not have any keyboard interactions, as it is 100% controlled by touch input.
-
-We strongly recommended to always include the `DragIndication` component within your sheet's content which enables the
-following keyboard interactions:
-
-<style>
-.keyboard-key {
-  background-color: #EEEEEE;
-  color: black;
-  text-align: center;
-  border-radius: 4px;
-}
-
-.md-typeset__table {
-   min-width: 100%;
-}
-
-.md-typeset table:not([class]) {
-    display: table;
-}
-
-.parameter {
-    white-space: nowrap
-}
-</style>
-
-| Key                                           | Action                                          |
-|-----------------------------------------------|-------------------------------------------------|
-| <div class="keyboard-key">Tab</div>           | Moves focus to or away from the drag indication |
-| <div class="keyboard-key">Space / Enter</div> | Toggles between the available sheet's detents   |
 
 <ApiReference id="bottom-sheet" />
-
-## Android Interop: WebView is not scrollable
-
-Using an Android View `WebView` inside of a `BottomSheet` will block the `WebView`'s scrolling.
-
-This is a bug with the Android <> Compose interop. To fix the issue, make sure to use a `Modifier.verticalScroll()` on your `AndroidView` that holds the `WebView`:
-
-```kotlin
-@Composable
-fun WebView(modifier: Modifier = Modifier) {
-    AndroidView(
-        modifier = modifier
-            .verticalScroll(rememberScrollState()),
-        factory = {
-            android.webkit.WebView(it)
-        }
-    )
-}
-```

--- a/docs/pages/button.md
+++ b/docs/pages/button.md
@@ -1,6 +1,6 @@
 ---
 title: Button
-description: An accessible clickable component used to create buttons with the styling of your choice. Comes with opinionated styling options such as content padding, shape and content color.
+description: A button component for custom button styles.
 ---
 
 <UnstyledDemo id="button" />
@@ -11,98 +11,34 @@ description: An accessible clickable component used to create buttons with the s
 implementation("com.composables:composeunstyled-button")
 ```
 
-## Basic Example
-
-You can create your own buttons using the `Button` component.
+## Anatomy
 
 ```kotlin
-UnstyledButton(
-    onClick = { /* TODO */ },
-    backgroundColor = Color(0xFFFFFFFF),
-    contentColor = Color(0xFF020817),
-    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-    shape = RoundedCornerShape(12.dp),
-) {
-    BasicText("Submit")
+UnstyledButton(onClick = onClick) {
 }
 ```
 
-## Styling
+## Concepts
 
-The Button renders nothing on the screen by default. It handles all accessibility semantics for you and comes with opinionated styling options, which covers most button needs out of the box.
+- `UnstyledButton` represents the clickable button surface.
 
-The `shape` of the button is used to clip the button for you, so that the touch indicator within the bounds of the button.
+## Accessibility
 
-The `borderColor` and `borderWidth` parameters place a border to the button. These take the given shape into consideration as opposed to using the respective Modifier alone.
-
-The `backgroundColor` sets the color of the button's surface.
-
-The `contentColor` specifies the color to use for the button's content. Components such as [Text](typography.md), [Text Field](textfield.md), [Icon](icon.md) will use this color to render their content.
-
-The `contentPadding` parameter places padding within the bounds of the button. Using the `Modifier.padding()` modifier will cause the button to have a visual margin instead, due to the way of ordering Modifiers in compose works.
-
-The `Button` component lays its contents horizontally and centers its contents horizontally and vertically.
-
-```kotlin
-UnstyledButton(
-    onClick = { /* TODO */ },
-    backgroundColor = Color(0xFFFFFFFF),
-    contentColor = Color(0xFF020817),
-    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-    shape = RoundedCornerShape(12.dp),
-) {
-    BasicText("Submit")
-}
-```
+`UnstyledButton` uses `Role.Button` by default. Enter and Space activate it.
 
 ## Code Examples
 
-### Icon Button
+### Disabling a button
 
-```kotlin
-UnstyledButton(onClick = { /* TODO */ }) {
-    // icon from composeicons.com/icons/lucide/pencil
-    UnstyledIcon(Pencil, contentDescription = null)
-    Spacer(Modifier.width(12.dp))
-    BasicText("Compose")
-}
-```
-
-### Outlined Button
+Use the `enabled` parameter to prevent button activation:
 
 ```kotlin
 UnstyledButton(
-    onClick = { /* TODO */ },
-    borderColor = Color.Gray,
-    borderWidth = 1.dp,
-    backgroundColor = Color.Transparent,
-    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-    shape = RoundedCornerShape(6.dp)
+  enabled = false,
+  onClick = { submit() },
 ) {
-    BasicText("Outline")
+  BasicText("Submit")
 }
 ```
-
-### Text Button
-
-```kotlin
-UnstyledButton(
-    onClick = { /* TODO */ },
-    backgroundColor = Color.Transparent,
-    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-    shape = RoundedCornerShape(6.dp)
-) {
-    BasicText("Text")
-}
-
-
-```
-
-## Keyboard Interactions
-
-| Key                                   | Description                                                   |
-|---------------------------------------|---------------------------------------------------------------|
-| <div class="keyboard-key">Enter</div> | Activates the button, triggering the onClick event.            |
-| <div class="keyboard-key">Space</div> | Activates the button, triggering the onClick event.            |
 
 <ApiReference id="button" />

--- a/docs/pages/checkbox.md
+++ b/docs/pages/checkbox.md
@@ -1,9 +1,16 @@
 ---
 title: Checkbox
-description: A foundational component used to build checkboxes in Jetpack Compose and Compose Multiplatform. Accessible out of the box and fully renderless, so that you can apply any styling you like.
+description: A checkbox component with full control over the indicator, bounds, and checked animation.
 ---
 
 <UnstyledDemo id="checkbox" />
+
+## Features
+
+- Custom interaction bounds
+- Custom checked indicator
+- Animated checked content
+- Accessibility label
 
 ## Installation
 
@@ -11,71 +18,99 @@ description: A foundational component used to build checkboxes in Jetpack Compos
 implementation("com.composables:composeunstyled-checkbox")
 ```
 
-## Basic Example
-
-To create a checkbox use the `Checkbox` component. To toggle it you can either click it, or press Enter or Spacebar on your keyboard, while the checkbox is focused.
-
-Depending on its state, the checkbox will show its `checkIcon` or not.
+## Anatomy
 
 ```kotlin
-var checked by remember { mutableStateOf(false) }
-
 UnstyledCheckbox(
-    checked = checked,
-    onCheckedChange = { checked = it },
-    shape = RoundedCornerShape(4.dp),
-    backgroundColor = Color.White,
-    contentColor = Color.Black
+  checked = checked,
+  onCheckedChange = onCheckedChange,
 ) {
-    // will be shown if checked
-    UnstyledIcon(Check, contentDescription = null)
+  CheckedIndicator {
+  }
 }
 ```
 
-## Styling
+## Concepts
 
-Every component in Compose Unstyled is renderless. They all handle all UX pattern's logic, internal state, accessibility and keyboard interactions for you, but they do not display any information on the screen.
+- `UnstyledCheckbox` represents the interactive bounds of the checkbox.
+- `CheckedIndicator` represents the visible checked state. It automatically shows and hides its
+  content based on the `UnstyledCheckbox` state.
+- Give `CheckedIndicator` a fixed size when its content only exists while checked. Without a fixed
+  size, the checkbox can change layout size when the indicator appears or disappears.
 
-This is by design so that you can style your components exactly to your needs.
+## Accessibility
 
-Most of the times, styling is done using `Modifiers` of your choise. However, sometimes this is not enough due to the order of the `Modifier`s affecting the visual outcome.
+Screen readers will automatically read any text placed inside `UnstyledCheckbox`.
 
-For such cases we provide specific styling parameters.
+Use the `accessibilityLabel` parameter when the checkbox has no visible text label.
 
+## Code Examples
 
-## Code Example
+### Making an entire row checkable
 
-Below is a detailed example from `CheckboxDemo.kt`:
+Use the `UnstyledCheckbox` component as the row container to make the full row toggleable. This is useful when the label should also toggle the checkbox:
 
 ```kotlin
-@Composable
-fun CheckboxDemo() {
-    Box(
-        modifier = Modifier.fillMaxSize().background(Brush.linearGradient(listOf(Color(0xFF8E2DE2), Color(0xFF4A00E0)))),
-        contentAlignment = Alignment.Center
-    ) {
-        var checked by remember { mutableStateOf(false) }
-        UnstyledCheckbox(
-            checked = checked,
-            onCheckedChange = { checked = it },
-            shape = RoundedCornerShape(4.dp),
-            backgroundColor = Color.White,
-            borderWidth = 1.dp,
-            borderColor = Color.Black.copy(0.33f),
-            modifier = Modifier.size(24.dp),
-            contentDescription = "Add olives"
-        ) {
-            UnstyledIcon(Check, contentDescription = null)
-        }
+UnstyledCheckbox(
+  checked = checked,
+  onCheckedChange = { checked = it },
+) {
+  Row {
+    CheckedIndicator {
+      BasicText("✓")
     }
+
+    BasicText("Accept all terms")
+  }
 }
 ```
 
-## Keyboard Interactions
+### Creating larger checkbox interaction bounds
 
-| Key                                   | Description                                                   |
-|---------------------------------------|---------------------------------------------------------------|
-| <div class="keyboard-key">Enter</div> | Toggles the checkbox, triggering its onCheckedChange callback |
-| <div class="keyboard-key">Space</div> | Toggles the checkbox, triggering its onCheckedChange callback |
+Use padding on the `CheckedIndicator` component to place the visible checkbox inside a larger
+interaction area. This is useful when the ripple or touch target should be larger than the visible
+checkbox:
+
+<UnstyledDemo id="checkbox-extended-indicator-bounds" />
+
+### Animating the checked indicator
+
+Use the `enter` and `exit` parameters on `CheckedIndicator` to animate the checked content.
+
+```kotlin
+UnstyledCheckbox(
+  checked = checked,
+  onCheckedChange = { checked = it },
+) {
+  CheckedIndicator(
+    enter = fadeIn(),
+    exit = fadeOut(),
+  ) {
+    BasicText("Selected")
+  }
+}
+```
+
+### Creating a custom checked indicator animation
+
+Use the `checked` state value to draw your own indicator instead of `CheckedIndicator`. This is useful when your design system needs a custom checkmark animation:
+
+<UnstyledDemo id="checkbox-custom-checked-indicator" />
+
+### Labeling an icon-only checkbox
+
+Use the `accessibilityLabel` parameter when the checkbox content has no text:
+
+```kotlin
+UnstyledCheckbox(
+  checked = checked,
+  onCheckedChange = { checked = it },
+  accessibilityLabel = "Enable notifications",
+) {
+  CheckedIndicator {
+    BasicText("✓")
+  }
+}
+```
 
 <ApiReference id="checkbox" />

--- a/docs/pages/dialog.md
+++ b/docs/pages/dialog.md
@@ -1,9 +1,16 @@
 ---
 title: Dialog
-description: An unstyled Dialog component that can be used to implement Dialogs with the styling of your choice. Supports edge-to-edge rendering, enter/exit transitions and keyboard interactions out of the box.
+description: A modal dialog component with dismiss behavior and panel transitions.
 ---
 
 <UnstyledDemo id="dialog" />
+
+## Features
+
+- Modal focus behavior
+- Outside-click dismiss
+- Back and Escape dismiss
+- Panel enter and exit transitions
 
 ## Installation
 
@@ -11,267 +18,104 @@ description: An unstyled Dialog component that can be used to implement Dialogs 
 implementation("com.composables:composeunstyled-dialog")
 ```
 
-## Basic Example
-
-A dialog consists of the following components: `Dialog`, `DialogPanel` and the optional `Scrim`.
-
-The `Dialog` controls the visibility of the dialog via the `DialogState` object.
-
-The `DialogPanel` is a container component that renders the dialog's panel and its contents.
-
-The optional `Scrim` component is used to add layer behind the dialog and dim the rest of the UI.
-
-```kotlin
-val dialogState = rememberDialogState()
-
-Box {
-    UnstyledButton(onClick= { dialogState.visible = true }) {
-        BasicText("Show Dialog")
-    }
-    UnstyledDialog(state = dialogState) {
-        UnstyledDialogPanel(
-            modifier = Modifier
-                .displayCutoutPadding()
-                .systemBarsPadding()
-                .widthIn(min = 280.dp, max = 560.dp)
-                .padding(20.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .border(1.dp, Color(0xFFE4E4E4), RoundedCornerShape(12.dp))
-                .background(Color.White),
-        ) {
-            Column {
-                Column(Modifier.padding(start = 24.dp, top = 24.dp, end = 24.dp)) {
-                    BasicText(
-                        text = "Update Available",
-                        style = TextStyle(fontWeight = FontWeight.Medium)
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    BasicText(
-                        text = "A new version of the app is available. Please update to the latest version.",
-                        style = TextStyle(color = Color(0xFF474747))
-                    )
-                }
-                Spacer(Modifier.height(24.dp))
-                UnstyledButton(
-                    onClick = { /* TODO */ },
-                    modifier = Modifier.padding(12.dp).align(Alignment.End),
-                    shape = RoundedCornerShape(4.dp),
-                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp)
-                ) {
-                    BasicText(
-                        text = "Update",
-                        style = TextStyle(color = Color(0xFF6699FF)))
-                }
-            }
-        }
-    }
-}
-```
-
-## Styling
-
-Any sort of styling is done by the `Modifier` of the respective component.
-
-Changing the looks of the dialog's panel is done by passing the respective styling `Modifier`s to your `DialogPanel`:
-
-```kotlin
-UnstyledDialog(state = rememberDialogState(visible = true)) {
-    UnstyledDialogPanel(
-        modifier = Modifier.systemBarsPadding()
-            .widthIn(min = 280.dp, max = 560.dp)
-            .padding(20.dp)
-            .clip(RoundedCornerShape(12.dp))
-            .border(1.dp, Color(0xFFE4E4E4), RoundedCornerShape(12.dp))
-            .background(Color.White)
-    ) {
-        Column {
-            BasicText("Something important happened")
-            UnstyledButton(onClick = { /* TODO */ }) {
-                BasicText("Got it")
-            }
-        }
-    }
-}
-```
-
-## Code Examples
-
-### Showing/Hide the dialog
-
-Pass your own `DialogState` to the `Dialog` and change the *visible* property according to your needs:
-
-```kotlin
-val state = rememberDialogState()
-
-UnstyledButton(onClick = { state.visible = true }) {
-    BasicText("Show dialog")
-}
-UnstyledDialog(state = state) {
-    DialogPanel {
-        Column {
-            BasicText("Something important happened")
-            UnstyledButton(onClick = { state.visible = false }) {
-                BasicText("Got it")
-            }
-        }
-    }
-}
-```
-
-The Dialog will also be automatically dismissed by default if the user taps outside the DialogPanel or presses the '
-Escape' or 'Back' button on their device.
-
-In override to override this behavior pass the `DialogProperties` object to the Dialog with the desired properties:
+## Anatomy
 
 ```kotlin
 UnstyledDialog(
-    state = rememberDialogState(),
-    properties = DialogProperties(dismissOnClickOutside = false, dismissOnBackPress = false)
+  visible = visible,
+  onDismissRequest = { visible = false },
 ) {
-    // TODO the rest of your dialog
+  DialogPanel {
+  }
 }
 ```
 
-### Adding a scrim
+## Concepts
 
-Use the `Scrim` component within your `Dialog`:
+- `UnstyledDialog` renders dialog content in a modal layer.
+- `DialogPanel` renders the focusable dialog content.
+
+## Accessibility
+
+Use the `paneTitle` parameter on `DialogPanel` when the dialog has a clear title.
+
+## Code Examples
+
+### Showing and hiding a dialog
+
+Use the `visible` parameter to show the dialog and the `onDismissRequest` callback to update that state:
 
 ```kotlin
-val state = rememberDialogState()
+var visible by remember { mutableStateOf(false) }
 
-UnstyledButton(onClick = { state.visible = true }) {
-    BasicText("Show dialog")
-}
-UnstyledDialog(state = state) {
-    Scrim()
-    DialogPanel {
-        Column {
-            BasicText("Something important happened")
-            UnstyledButton(onClick = { state.visible = false }) {
-                BasicText("Got it")
-            }
-        }
-    }
+BasicText(
+  text = "Show dialog",
+  modifier = Modifier.clickable { visible = true },
+)
+
+UnstyledDialog(
+  visible = visible,
+  onDismissRequest = { visible = false },
+) {
+  DialogPanel {
+    BasicText("Dialog content")
+  }
 }
 ```
 
-The `Scrim` is customizable and you can pass any *scrimColor*, and *enter*/*exit* transitions that matches your design
-specs.
+### Adding an overlay behind a dialog
 
-### Scrollable dialogs
-
-Add any scrollable component such as `LazyColumn` to the contents of your dialog:
+Use the `overlay` parameter to render content behind the dialog panel. Use the optional
+[Scrim](/compose-unstyled/scrim) module for a ready-made scrim. For custom modal-layer content that
+needs to coordinate enter and exit animations, see [Modal](/compose-unstyled/modal).
 
 ```kotlin
-val state = rememberDialogState()
-
-UnstyledButton(onClick = { state.visible = true }) {
-    BasicText("Show dialog")
-}
-UnstyledDialog(state = state) {
-    DialogPanel {
-        Column {
-            LazyColumn(Modifier.height(320.dp)) {
-                item { BasicText("Something important happened") }
-                repeat(100) { i ->
-                    item { BasicText("Update number ${i}") }
-                }
-            }
-            UnstyledButton(onClick = { state.visible = false }) {
-                BasicText("Got it")
-            }
-        }
-    }
+UnstyledDialog(
+  visible = visible,
+  onDismissRequest = { visible = false },
+  overlay = { Scrim() },
+) {
+  DialogPanel {
+    BasicText("Dialog content")
+  }
 }
 ```
 
-### Full-screen dialogs
+### Changing dismiss behavior
 
-Pass a `Modifier.fillMaxSize()` to the `DialogPanel`'s modifier parameter. Make sure to pass
-the `Modifier.systemBarsPadding()` and `Modifier.displayCutoutPadding()` or any related inset Modifier so that the
-dialog is not drawn behind any system
-bars (such as status and navigation bar on Android):
+Use the `properties` parameter to control how the dialog can be dismissed:
 
 ```kotlin
-UnstyledDialog(state = rememberDialogState(visible = true)) {
-    UnstyledDialogPanel(
-        modifier = Modifier
-            .displayCutoutPadding()
-            .systemBarsPadding()
-            .fillMaxSize()
-    ) {
-        Column {
-            BasicText("This is a full screen dialog")
-            UnstyledButton(onClick = { state.visible = false }) {
-                BasicText("Got it")
-            }
-        }
-    }
+UnstyledDialog(
+  visible = visible,
+  onDismissRequest = { visible = false },
+  properties = DialogProperties(
+    dismissOnBackPress = false,
+    dismissOnClickOutside = false,
+  ),
+) {
+  DialogPanel {
+    BasicText("Dialog content")
+  }
 }
 ```
 
-### Adding transitions
+### Animating the dialog panel
 
-Add any *enter*/*exit* transitions into the `DialogPanel` and `Scrim` to control how they appear on the screen when they
-enter and exit the composition:
+Use the `enter` and `exit` parameters on `DialogPanel` to animate the dialog panel:
 
 ```kotlin
-UnstyledDialog(state = rememberDialogState(visible = true)) {
-    Scrim(enter = fadeIn(), exit = fadeOut())
-    UnstyledDialogPanel(
-        enter = scaleIn(initialScale = 0.8f) + fadeIn(tween(durationMillis = 250)),
-        exit = scaleOut(targetScale = 0.6f) + fadeOut(tween(durationMillis = 150)),
-    ) {
-        // TODO the dialog's contents
-    }
+UnstyledDialog(
+  visible = visible,
+  onDismissRequest = { visible = false },
+) {
+  DialogPanel(
+    enter = fadeIn(),
+    exit = fadeOut(),
+  ) {
+    BasicText("Dialog content")
+  }
 }
 ```
-
-### Styling the system bars
-
-**Android only**
-
-Dialogs do not change the color of the system UI when displayed. [All modals](modal.md) in Unstyled expose a `LocalModalWindow` composition local,
-which provides you with the Android `Window` that hosts the dialog, so that you can customize the System UI according to
-your needs.
-
-[View to Android demo on Github](https://github.com/composablehorizons/compose-unstyled/tree/main/demo-system-ui-styling)
-
-```kotlin
-UnstyledDialog(rememberDialogState()) {
-    DialogPanel {
-        val window = LocalModalWindow.current
-        LaunchedEffect(Unit) {
-            // change system bars to transparent
-            window.statusBarColor = Color.Transparent.toArgb()
-            window.navigationBarColor = Color.Transparent.toArgb()
-
-            // don't forget to update the icons too
-            val windowInsetsController = WindowInsetsControllerCompat(window, window.decorView)
-            windowInsetsController.isAppearanceLightStatusBars = true
-            windowInsetsController.isAppearanceLightNavigationBars = true
-        }
-        BasicText("Transparent bars. So cool 😎 ", modifier = Modifier.navigationBarsPadding())
-    }
-}
-```
-
-## Keyboard Interactions
-
-<style>
-.keyboard-key {
-  background-color: #EEEEEE;
-  color: black;
-  text-align: center;
-  border-radius: 4px;
-}
-</style>
-
-| Key                                         | Description                                                                                  |
-|---------------------------------------------|----------------------------------------------------------------------------------------------|
-| <div class="keyboard-key">Esc</div>         | Closes any open dialogs, if the *dismissOnBackPress* of `DialogProperties()` is set to true. |
-| <div class="keyboard-key">Back</div>        | Closes any open dialogs, if the *dismissOnBackPress* of `DialogProperties()` is set to true. |
-| <div class="keyboard-key">Tab</div>         | Cycles through the dialog's contents.                                                        |
-| <div class="keyboard-key">Shift + Tab</div> | Cycles through the dialog's contents in backwards order.                                     |
 
 <ApiReference id="dialog" />

--- a/docs/pages/disclosure.md
+++ b/docs/pages/disclosure.md
@@ -1,6 +1,6 @@
 ---
 title: Disclosure
-description: An unstyled Disclosure component that can be used to build disclosures with the styling of your choice in your Compose Multiplatform apps. Comes with accessibility baked in, animation support and it is fully customizable.
+description: An expandable content component with a dedicated trigger and content slot.
 ---
 
 <UnstyledDemo id="disclosure" />
@@ -11,145 +11,74 @@ description: An unstyled Disclosure component that can be used to build disclosu
 implementation("com.composables:composeunstyled-disclosure")
 ```
 
-## Basic Example
-
-The Disclosure component consists of a `Disclosure`, a `DisclosureHeading`, and a `DisclosurePanel`.
-
-The `Disclosure` component holds its state and the rest of the components. It also sets up important semantics for
-accessibility.
-
-The `DisclosureHeading` is a button which will reveal or hide the `DisclosurePanel` when clicked, according to the
-disclosure's state:
+## Anatomy
 
 ```kotlin
-Disclosure {
-    DisclosureHeading {
-        BasicText("What is the return policy?")
-    }
-    DisclosurePanel {
-        BasicText("Our return policy allows returns within 30 days of purchase with a receipt.")
-    }
+UnstyledDisclosure(
+  expanded = expanded,
+  onExpandedChange = onExpandedChange,
+) {
+  DisclosureButton {
+  }
+
+  DisclosedContent {
+  }
 }
 ```
 
-## Styling
+## Concepts
 
-The Disclosure renders nothing on the screen by default. It handles the UX pattern of a disclosure for you and leaves
-any styling for you to handle.
+- `UnstyledDisclosure` represents an expandable region.
+- `DisclosureButton` renders the trigger that toggles the disclosure.
+- `DisclosedContent` renders content only while the disclosure is expanded.
 
-We provide some styling parameters to ensure that your content's interaction indicators look great according to the
-styling you need.
+## Accessibility
 
-Changing the styling of the disclosure is done by passing the respective `Modifier`s to your `DisclosureHeading` and
-`DisclosurePanel`:
-
-```kotlin
-val state = rememberDisclosureState()
-
-UnstyledDisclosure(state = state) {
-    UnstyledDisclosureHeading(
-        modifier = Modifier
-            .background(Color.LightGray)
-            .padding(16.dp)
-            .dropShadow(
-                shape = RoundedCornerShape(8.dp),
-                shadow = Shadow(
-                    radius = 12.dp,
-                    spread = 0.dp,
-                    color = Color.Black.copy(alpha = 0.12f),
-                    offset = DpOffset(x = 0.dp, y = 4.dp)
-                )
-            ),
-        shape = RoundedCornerShape(8.dp),
-        contentPadding = PaddingValues(vertical = 12.dp, horizontal = 16.dp)
-    ) {
-        val degrees by animateFloatAsState(if (state.expanded) -180f else 0f, tween())
-
-        BasicText("What is Compose Unstyled?")
-
-        // icon from composeicons.com/icons/lucide/chevron-down
-        UnstyledIcon(
-            imageVector = ChevronDown,
-            contentDescription = null,
-            modifier = Modifier.rotate(degrees)
-        )
-    }
-    UnstyledDisclosurePanel(
-        enter = expandVertically(
-            spring(
-                stiffness = Spring.StiffnessMediumLow,
-                visibilityThreshold = IntSize.VisibilityThreshold
-            )
-        ),
-        exit = shrinkVertically()
-    ) {
-        BasicText(
-            "Compose Unstyled is a collection of unstyled, accessible UI components for Jetpack Compose and Compose Multiplatform.",
-            modifier = Modifier.padding(16.dp).alpha(0.66f)
-        )
-    }
-}
-```
+Use `DisclosureButton` for the disclosure trigger so assistive technology receives expand and collapse actions.
 
 ## Code Examples
 
-### Showing/Hide the disclosure
+### Showing hidden content
 
-To manually show or hide the disclosure panel, use the `expanded` property of the `Disclosure` state.
-
-To create your own controlled state use the `rememberDisclosureState()` function and pass it to the `Disclosure`
-composable.
-
-Then use the `DisclosureHeading` variant with the `onClick` parameter to toggle the state manually.
-
-**Important:** the `DisclosureHeading` with the `onClick` parameter does not set the collapse/expanded actions to the
-heading as you might want to customize the behavior. These are important for accessibility and you would need to set
-them yourself, if you chose to use this variant.
+Use the `expanded` parameter to control whether `DisclosedContent` is visible:
 
 ```kotlin
-val state = rememberDisclosureState()
+var expanded by remember { mutableStateOf(false) }
 
-UnstyledDisclosure(state = state) {
-    UnstyledDisclosureHeading(onClick = { state.expanded = state.expanded.not() }) {
-        BasicText("What is the return policy?")
-    }
-    DisclosurePanel {
-        BasicText("Our return policy allows returns within 30 days of purchase with a receipt.")
-    }
+UnstyledDisclosure(
+  expanded = expanded,
+  onExpandedChange = { expanded = it },
+) {
+  DisclosureButton {
+    BasicText(if (expanded) "Hide details" else "Show details")
+  }
+
+  DisclosedContent {
+    BasicText("Details")
+  }
 }
 ```
 
-### Adding transitions
+### Animating disclosed content
 
-You can add transitions to the disclosure panel to animate its expansion and collapse:
+Use the `enter` and `exit` parameters on `DisclosedContent` to animate the disclosed content:
 
 ```kotlin
-Disclosure {
-    DisclosureHeading {
-        BasicText("What is Compose Unstyled?")
-    }
-    UnstyledDisclosurePanel(
-        enter = expandVertically(
-            spring(
-                stiffness = Spring.StiffnessMediumLow,
-                visibilityThreshold = IntSize.VisibilityThreshold
-            )
-        ),
-        exit = shrinkVertically()
-    ) {
-        BasicText(
-            "Compose Unstyled is a collection of unstyled, accessible UI components for Jetpack Compose and Compose Multiplatform.",
-            modifier = Modifier.padding(16.dp).alpha(0.66f)
-        )
-    }
+UnstyledDisclosure(
+  expanded = expanded,
+  onExpandedChange = { expanded = it },
+) {
+  DisclosureButton {
+    BasicText("Details")
+  }
+
+  DisclosedContent(
+    enter = expandVertically(),
+    exit = shrinkVertically(),
+  ) {
+    BasicText("Hidden content")
+  }
 }
 ```
-
-## Keyboard Interactions
-
-| Key                                   | Description                                                   |
-|---------------------------------------|---------------------------------------------------------------|
-| <div class="keyboard-key">Enter</div> | Toggles the disclosure between expanded and collapsed states. |
-| <div class="keyboard-key">Space</div> | Toggles the disclosure between expanded and collapsed states. |
 
 <ApiReference id="disclosure" />

--- a/docs/pages/dropdown-menu.md
+++ b/docs/pages/dropdown-menu.md
@@ -1,9 +1,16 @@
 ---
 title: Dropdown Menu
-description: An unstyled component for Jetpack Compose and Compose Multiplatform that can be used to implement Dropdown Menus with the styling of your choice. Fully accessible, supports keyboard navigation and open/close animations.
+description: An anchored menu component with keyboard navigation and custom placement.
 ---
 
 <UnstyledDemo id="dropdown-menu" />
+
+## Features
+
+- Anchor-based placement
+- Keyboard menu navigation
+- Auto-dismiss on outside click
+- Panel enter and exit transitions
 
 ## Installation
 
@@ -11,171 +18,158 @@ description: An unstyled component for Jetpack Compose and Compose Multiplatform
 implementation("com.composables:composeunstyled-dropdown-menu")
 ```
 
-## Basic Example
-
-Use `UnstyledDropdownMenu` with a controlled `expanded` value. The `anchor` slot renders the trigger, and the `panel` slot renders the floating menu content.
+## Anatomy
 
 ```kotlin
-val options = listOf("United States", "Greece", "Indonesia", "United Kingdom")
-var selected by remember { mutableStateOf(0) }
-var expanded by remember { mutableStateOf(false) }
-
 UnstyledDropdownMenu(
-    expanded = expanded,
-    onExpandedChange = { expanded = it },
-    anchor = {
-        UnstyledButton(onClick = { expanded = true }) {
-            BasicText("Options")
-        }
-    },
-    panel = {
-        DropdownMenuPanel(
-            modifier = Modifier
-                .width(320.dp)
-                .background(Color.White, RoundedCornerShape(4.dp))
-                .padding(4.dp),
-            exit = fadeOut()
-        ) {
-            options.forEachIndexed { index, option ->
-                MenuItem(
-                    onClick = {
-                        selected = index
-                        expanded = false
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    BasicText(option, modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp, horizontal = 4.dp))
-                }
-            }
-        }
+  expanded = expanded,
+  onExpandedChange = onExpandedChange,
+  panel = {
+    DropdownMenuPanel {
+      MenuItem(onClick = onClick) {
+      }
     }
+  },
+  anchor = {
+  },
 )
 ```
+
+## Concepts
+
+- `UnstyledDropdownMenu` marks the anchor area and renders the floating menu when expanded.
+  - The `anchor` slot renders the content the menu is positioned against.
+  - The `panel` slot renders the floating menu content.
+- `DropdownMenuPanel` renders the menu surface.
+- `MenuItem` renders an item inside `DropdownMenuPanel`.
+
+## Accessibility
+
+Dropdown menu handles keyboard interactions out of the box. Pressing Arrow Down opens the menu and
+focuses the first item. Pressing Arrow Down and Arrow Up moves focus to the next and previous item.
+Home moves focus to the first item. End moves focus to the last item. Escape closes the menu. Use
+`MenuItem` for focusable menu actions.
 
 ## Code Examples
 
-### Toggling the Menu
+### Opening and closing a dropdown menu
 
-Change the controlled `expanded` value to show or hide the menu:
+Use the `expanded` parameter to show the menu and the `onExpandedChange` callback to update that state:
 
 ```kotlin
 var expanded by remember { mutableStateOf(false) }
 
 UnstyledDropdownMenu(
-    expanded = expanded,
-    onExpandedChange = { expanded = it },
-    anchor = {
-        UnstyledButton(onClick = { expanded = true }) {
-            BasicText("Toggle the menu")
-        }
-    },
-    panel = {
-        DropdownMenuPanel {
-            MenuItem(onClick = { expanded = false }) {
-                BasicText("Close this menu")
-            }
-        }
+  expanded = expanded,
+  onExpandedChange = { expanded = it },
+  panel = {
+    DropdownMenuPanel {
+      MenuItem(onClick = { expanded = false }) {
+        BasicText("Close")
+      }
     }
+  },
+  anchor = {
+    BasicText(
+      text = "Open menu",
+      modifier = Modifier.clickable { expanded = true },
+    )
+  },
 )
 ```
 
-### Positioning the menu
+### Positioning a dropdown menu
 
-Use `side`, `alignment`, `sideOffset`, and `alignmentOffset` to place the panel relative to the anchor.
+Use the `side`, `alignment`, `sideOffset`, and `alignmentOffset` parameters to place the menu panel relative to the anchor:
 
 ```kotlin
 UnstyledDropdownMenu(
-    expanded = expanded,
-    onExpandedChange = { expanded = it },
-    side = AnchorSide.Bottom,
-    alignment = AnchorAlignment.End,
-    sideOffset = 8.dp,
-    anchor = {
-        UnstyledButton(onClick = { expanded = true }) {
-            BasicText("Toggle the menu")
-        }
-    },
-    panel = {
-        DropdownMenuPanel {
-            MenuItem(onClick = { /* TODO */ }) {
-                BasicText("Option")
-            }
-        }
+  expanded = expanded,
+  onExpandedChange = { expanded = it },
+  side = AnchorSide.Bottom,
+  alignment = AnchorAlignment.End,
+  sideOffset = 8.dp,
+  panel = {
+    DropdownMenuPanel {
+      MenuItem(onClick = { select() }) {
+        BasicText("Item")
+      }
     }
+  },
+  anchor = {
+    BasicText("Open menu")
+  },
 )
 ```
 
-## Styling
+### Closing the menu after clicking an item
 
-Compose Unstyled does not draw the menu trigger, panel, or items for you. Apply visual styling to the anchor content, `DropdownMenuPanel`, and each `MenuItem` modifier.
-
-```kotlin
-DropdownMenuPanel(
-    modifier = Modifier
-        .width(320.dp)
-        .border(1.dp, Color(0xFFE0E0E0), RoundedCornerShape(4.dp))
-        .background(Color.White, RoundedCornerShape(4.dp))
-        .padding(4.dp)
-) {
-    MenuItem(
-        onClick = { /* TODO */ },
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        BasicText("Option", modifier = Modifier.padding(vertical = 8.dp, horizontal = 4.dp))
-    }
-}
-```
-
-## Animating the Menu
-
-Modify the `enter` and `exit` parameters of `DropdownMenuPanel` to customize how the dropdown appears and disappears.
+`MenuItem` closes the menu after click by default by calling the dropdown's `onExpandedChange`
+callback with `false`:
 
 ```kotlin
-DropdownMenuPanel(
-    modifier = Modifier
-        .width(320.dp)
-        .background(Color.White, RoundedCornerShape(4.dp))
-        .padding(4.dp),
-    enter = scaleIn(tween(durationMillis = 120, easing = LinearOutSlowInEasing), initialScale = 0.8f, transformOrigin = TransformOrigin(0f, 0f)) + fadeIn(tween(durationMillis = 30)),
-    exit = scaleOut(tween(durationMillis = 1, delayMillis = 75), targetScale = 1f) + fadeOut(tween(durationMillis = 75))
-) {
-    MenuItem(onClick = { /* TODO */ }) {
-        BasicText("Option 1")
-    }
-    MenuItem(onClick = { /* TODO */ }) {
-        BasicText("Option 2")
-    }
-}
-```
-
-## Styling touch presses and focus
-
-`MenuItem` uses the default Compose mechanism for touch and focus feedback. Pass `indication` or provide a custom `LocalIndication` when you need a different interaction effect.
-
-```kotlin
-CompositionLocalProvider(LocalIndication provides rememberRipple()) {
+UnstyledDropdownMenu(
+  expanded = expanded,
+  onExpandedChange = { expanded = it },
+  panel = {
     DropdownMenuPanel {
-        MenuItem(onClick = { /* TODO */ }) {
-            BasicText("Close this menu")
-        }
+      MenuItem(onClick = { select() }) {
+        BasicText("Item")
+      }
     }
-}
+  },
+  anchor = {
+    BasicText("Open menu")
+  },
+)
 ```
 
-## Keyboard Interactions
+### Keeping the menu open after clicking an item
 
-<style>
-.keyboard-key {
-  background-color: #EEEEEE;
-  color: black;
-  text-align: center;
-  border-radius: 4px;
-}
-</style>
+Use the `closeOnClick` parameter when a menu item should update state without dismissing the menu:
 
-| Key                                   | Description                                                                                                                 |
-|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| <div class="keyboard-key">Enter</div> | Opens the menu from the anchor. Performs a click when a `MenuItem` is focused. |
-| <div class="keyboard-key">⬇</div>     | Opens the menu from the anchor. Moves focus to the next `MenuItem` when the panel is expanded. |
-| <div class="keyboard-key">⬆</div>     | Moves focus to the previous `MenuItem` when the panel is expanded. |
-| <div class="keyboard-key">Esc</div>   | Closes the menu when the panel is expanded. |
+```kotlin
+UnstyledDropdownMenu(
+  expanded = expanded,
+  onExpandedChange = { expanded = it },
+  panel = {
+    DropdownMenuPanel {
+      MenuItem(
+        closeOnClick = false,
+        onClick = { enabled = enabled.not() },
+      ) {
+        BasicText("Toggle option")
+      }
+    }
+  },
+  anchor = {
+    BasicText("Open menu")
+  },
+)
+```
+
+### Animating the dropdown menu
+
+Use the `enter` and `exit` parameters on `DropdownMenuPanel` to animate the menu panel:
+
+```kotlin
+UnstyledDropdownMenu(
+  expanded = expanded,
+  onExpandedChange = { expanded = it },
+  panel = {
+    DropdownMenuPanel(
+      enter = fadeIn(),
+      exit = fadeOut(),
+    ) {
+      MenuItem(onClick = { select() }) {
+        BasicText("Item")
+      }
+    }
+  },
+  anchor = {
+    BasicText("Open menu")
+  },
+)
+```
+
+<ApiReference id="dropdown-menu" />

--- a/docs/pages/icon.md
+++ b/docs/pages/icon.md
@@ -1,6 +1,6 @@
 ---
 title: Icon
-description: A component for rendering iconography with the tinting of your choice.
+description: An icon component for tinted painter, bitmap, and vector assets.
 ---
 
 <UnstyledDemo id="icon" />
@@ -11,22 +11,35 @@ description: A component for rendering iconography with the tinting of your choi
 implementation("com.composables:composeunstyled-icon")
 ```
 
-## Basic Example
-
-Basic example using Icons from the Material Extended Library:
+## Anatomy
 
 ```kotlin
 UnstyledIcon(
-    imageVector = Icons.Rounded.Favorite,
-    contentDescription = "This song is in your favorites",
-    tint = Color(0xFF9E9E9E),
+  imageVector = icon,
+  contentDescription = "Favorite",
 )
 ```
 
-<style>
-.parameter {
-    white-space: nowrap
-}
-</style>
+## Concepts
+
+- `UnstyledIcon` renders an icon from an `ImageVector`, `Painter`, or `ImageBitmap`.
+
+## Accessibility
+
+Pass a short `contentDescription` for icons that communicate meaning. Use `null` for decorative icons.
+
+## Code Examples
+
+### Tinting an icon
+
+Use the `tint` parameter to apply one color to the icon:
+
+```kotlin
+UnstyledIcon(
+  imageVector = favoriteIcon,
+  contentDescription = "Favorite",
+  tint = Color.Red,
+)
+```
 
 <ApiReference id="icon" />

--- a/docs/pages/modal-bottom-sheet.md
+++ b/docs/pages/modal-bottom-sheet.md
@@ -1,9 +1,18 @@
 ---
 title: Modal Bottom Sheet
-description: A stackable, renderless, highly performant foundational component to build modal bottom sheets with, jam-packed with styling features without compromising on accessibility or keyboard interactions.
+description: A dismissible modal bottom sheet with custom detents.
 ---
 
 <UnstyledDemo id="modal-bottom-sheet" />
+
+## Features
+
+- Custom detents
+- Custom overlay content
+- Back press and outside click dismissal
+- Dynamic content sizing
+- Soft-keyboard support
+- Scrollable content without fixed height
 
 ## Installation
 
@@ -11,518 +20,216 @@ description: A stackable, renderless, highly performant foundational component t
 implementation("com.composables:composeunstyled-modal-bottom-sheet")
 ```
 
-## Basic Example
-
-A modal bottom sheet consists of the following components: `ModalBottomSheet`, `Sheet` and the optional `Scrim`
-and `DragIndication`.
-
-The `ModalBottomSheet` controls the visibility of the modal bottom sheet. It renders its contents above any other
-layouts without having to worry about nesting.
-
-The `Sheet` is a container component that renders the bottom sheet and its contents.
-
-The `Scrim` component is used to add layer behind the dialog and dim the rest of the UI.
-
-The `DragIndication` can be used within the `Sheet`'s contents. It provides a way
-for the user to control the sheet without touch input.
-
-A bottom sheet has a set of specified `Detents`. Each detent specify the height in which the sheet can rest while not
-being dragged.
-
-By default, 2 detents are specified: `Hidden` and `FullyExpanded`.
+## Anatomy
 
 ```kotlin
 val sheetState = rememberModalBottomSheetState(
-    initialDetent = Hidden,
-)
-
-UnstyledButton(onClick = { sheetState.currentDetent = FullyExpanded }) {
-    BasicText("Show Sheet")
-}
-
-UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(modifier = Modifier.fillMaxWidth().background(Color.White)) {
-        Box(
-            modifier = Modifier.fillMaxWidth().height(1200.dp),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            UnstyledDragIndication()
-        }
-    }
-}
-```
-
-## Styling
-
-The modal bottom sheet renders nothing on the screen by default. It manages a lot of states internally and leaves the
-styling
-to you.
-
-Any sort of styling is done by the `Modifier` of the respective component.
-
-Changing the looks of the bottom sheet is done by passing the respective styling `Modifier`s to your `Sheet`, `Scrim`
-and `DragIndication`:
-
-```kotlin
-val sheetState = rememberModalBottomSheetState(
-    initialDetent = FullyExpanded,
+  initialDetent = SheetDetent.Hidden,
 )
 
 UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(
-        modifier = Modifier
-            .dropShadow(
-                shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-                shadow = Shadow(
-                    radius = 16.dp,
-                    spread = 0.dp,
-                    color = Color.Black.copy(alpha = 0.14f),
-                    offset = DpOffset(x = 0.dp, y = (-3).dp)
-                )
-            )
-            .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
-            .background(Color.White)
-            .widthIn(max = 640.dp)
-            .fillMaxWidth()
-            .imePadding(),
-    ) {
-        Box(
-            modifier = Modifier.fillMaxWidth().height(1200.dp),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            UnstyledDragIndication(
-                modifier = Modifier
-                    .padding(top = 22.dp)
-                    .background(Color.Black.copy(0.4f), RoundedCornerShape(100))
-                    .width(32.dp)
-                    .height(4.dp)
-            )
-        }
-    }
+  Sheet {
+    DragIndication()
+  }
 }
 ```
+
+## Concepts
+
+- `SheetDetent` defines a height where the sheet can rest.
+- `UnstyledModalBottomSheet` represents the modal layer the sheet is rendered in.
+- `Sheet` is the rendered bit of the sheet.
+- `DragIndication` adds an interactive handle for expand, collapse, and dismiss actions.
+
+## Accessibility
+
+Use `DragIndication` when your sheet can move between multiple detents. It provides semantic expand, collapse, and dismiss actions so users can control the sheet without dragging.
 
 ## Code Examples
 
-### Showing/Hide the bottom sheet
+### Showing and hiding a modal bottom sheet
 
-The visibility of the sheet is controlled by its state's *currentDetent* property.
-
-Pass `Hidden` to hide it, or `FullyExpanded` to fully expand it:
+Use the `targetDetent` property to animate the modal sheet to a new detent:
 
 ```kotlin
 val sheetState = rememberModalBottomSheetState(
-    initialDetent = Hidden,
+  initialDetent = SheetDetent.Hidden,
 )
 
-UnstyledButton(onClick = { sheetState.currentDetent = FullyExpanded }) {
-    BasicText("Show Sheet")
-}
-
-UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(
-        state = sheetState,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Box(
-            modifier = Modifier.fillMaxWidth().height(1200.dp),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            UnstyledButton(onClick = { sheetState.currentDetent = Hidden }) {
-                BasicText("Hide Sheet")
-            }
-        }
-    }
-}
-```
-
-Using the `currentDetent` property will cause the sheet to animate to given detent.
-
-### Customizing sheet heights
-
-The heights in which the bottom sheet needs to stop for dragging purposes is controlled by the sheet's
-state `SheetDetent`s.
-
-To create a new detent, use the `SheetDetent` constructor to pass a unique identifier and a function which calculates
-the height of the detent at a given moment. The calculated value will be capped between `0.dp` and the content's height.
-
-**NOTE:** Make sure that the calculation returns _fast_, as this will affect your sheet's performance.
-
-Make sure to pass your new detent when creating your bottom sheet state:
-
-```kotlin
-val Peek = SheetDetent(identifier = "peek") { containerHeight, sheetHeight ->
-    containerHeight * 0.6f
-}
-
-val sheetState = rememberModalBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Hidden, Peek, FullyExpanded)
+BasicText(
+  text = "Show sheet",
+  modifier = Modifier.clickable {
+    sheetState.targetDetent = SheetDetent.FullyExpanded
+  },
 )
 
 UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(modifier = Modifier.fillMaxWidth()) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(Color.White)
-                .height(1200.dp),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            UnstyledDragIndication(
-                modifier = Modifier
-                    .padding(top = 22.dp)
-                    .background(Color.Black.copy(0.4f), RoundedCornerShape(100))
-                    .width(32.dp)
-                    .height(4.dp)
-            )
-        }
-    }
-}
-```
-
-### Adding a scrim
-
-Use the `Scrim` component within your `ModalBottomSheet`:
-
-```kotlin
-val sheetState = rememberModalBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Hidden, Peek, FullyExpanded)
-)
-
-UnstyledModalBottomSheet(state = sheetState) {
-    Scrim()
-    Sheet(
-        modifier = Modifier.fillMaxWidth()
-            .background(Color.White)
-            .height(1200.dp)
-    ) {
-    }
-}
-```
-
-### Drawing behind the nav bar
-
-The ModalBottomSheet component is a modal component. When displayed on the screen, it dims the navigation bars and
-protect its icons.
-
-Other than that, you have full control over how you want sheet and its contents to be rendered on the screen.
-
-Nice looking bottom sheets tend to draw behind the platform's navigation bar while keeping their content above the
-navigation bar.
-
-The following code example showcases how to draw the bottom sheet behind the nav bar while ensuring its content is never
-blocked by the nav bar's buttons.
-
-At the same time, we make sure that the bottom sheet is never drawn behind the nav bars on landscape mode (for visual
-purposes):
-
-```kotlin
-val sheetState = rememberModalBottomSheetState(
-    initialDetent = FullyExpanded,
-)
-
-UnstyledModalBottomSheet(state = sheetState) {
-    Box(Modifier.padding(
-        // make sure the sheet is not behind nav bars on landscape
-        WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
-            .asPaddingValues()
-    )) {
-        Sheet(
-            modifier = Modifier.fillMaxWidth().navigationBarsPadding(),
-        ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                UnstyledDragIndication()
-                BasicText("Here is some content")
-            }
-        }
-    }
-}
-```
-
-### Working with the soft-keyboard
-
-Add the `Modifier.imePadding()` in the contents of your sheet, to make sure that its contents are always draw above the
-soft keyboard.
-
-Here is a styled example of a 'Add note' sheet:
-
-```kotlin
-val sheetState = rememberModalBottomSheetState(
-    initialDetent = FullyExpanded,
-)
-UnstyledModalBottomSheet(state = sheetState) {
-   Box(Modifier.padding(
-       // make sure the sheet is not behind nav bars on landscape
-       WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
-           .asPaddingValues()
-   )) {
-        Sheet(
-            modifier = Modifier.fillMaxWidth()
-                .background(Color.White),
-        ) {
-            Column(
-                modifier = Modifier.fillMaxWidth()
-                    .padding(16.dp)
-                    // make sure the contents of the sheet is always above the nav bar
-                    .navigationBarsPadding()
-                    // draw the contents above the soft keyboard
-                    .imePadding()
-            ) {
-                UnstyledDragIndication(Modifier.align(Alignment.CenterHorizontally))
-
-                var text by remember { mutableStateOf("") }
-                UnstyledTextField(
-                    value = text,
-                    onValueChange = { text = it },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                UnstyledButton(
-                    onClick = { /* TODO */ },
-                    shape = RoundedCornerShape(4.dp),
-                    contentPadding = PaddingValues(4.dp),
-                    modifier = Modifier.align(Alignment.End)
-                ) {
-                    BasicText(
-                        text = "Save note",
-                        style = TextStyle.Default.copy(color = Color.White)
-                    )
-                }
-            }
-        }
-    }}
-```
-
-### Scrollable sheets
-
-Add any scrollable component within the contents of your sheet. `BottomSheet` supports nesting scrolling out of the box:
-
-```kotlin
-val sheetState = rememberModalBottomSheetState(
-    initialDetent = FullyExpanded,
-)
-UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(
-        modifier = Modifier.fillMaxWidth()
-            .background(Color.White),
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            UnstyledDragIndication(Modifier.width(32.dp).height(4.dp))
-            LazyColumn {
-                repeat(50) {
-                    item { BasicText("Item #${(it + 1)}", modifier = Modifier.padding(10.dp)) }
-                }
-            }
-        }
-    }
-}
-```
-
-<p class="border-l-4 pl-4 border-orange-500 flex flex-col gap-2 unstyled-warning">
-<strong class="text-orange-800 unstyled-warning-title">⚠️ Scrollable content must have a fixed height</strong>
-<span>The current implementation does not automatically handle dynamic content height of scrollable content. As a workaround, you must use a fixed height for your content.</span>
-<span>If this affects you, <a href="https://github.com/composablehorizons/compose-unstyled/issues/134">react to the respected feature request.</a></span>
-</p>
-
-### Adding transitions
-
-Pass your own `AnimationSpec` when creating your sheet's state:
-
-```kotlin
-val Peek = SheetDetent("peek") { containerHeight, sheetHeight ->
-    containerHeight * 0.6f
-}
-
-val sheetState = rememberModalBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Peek, FullyExpanded),
-    animationSpec = spring(
-        dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow
+  Sheet {
+    BasicText(
+      text = "Hide sheet",
+      modifier = Modifier.clickable {
+        sheetState.targetDetent = SheetDetent.Hidden
+      },
     )
-)
-UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(
-        modifier = Modifier.fillMaxWidth()
-            .background(Color.White)
-            .height(1200.dp),
-    ) {
-    }
+  }
 }
 ```
 
-### Listening to state changes
+### Waiting for modal bottom sheet animations
 
-Use the sheet's state `currentDetent` to observe for state changes. This value returns the current detent the sheet is
-currently rested at.
+Use the suspend `animateTo()` function to wait until the sheet animation is done:
 
-The `targetDetent` value returns the next detent the sheet is approaching (ie while being dragged).
+```kotlin
+val scope = rememberCoroutineScope()
+
+BasicText(
+  text = "Show sheet",
+  modifier = Modifier.clickable {
+    scope.launch {
+      sheetState.animateTo(SheetDetent.FullyExpanded)
+    }
+  },
+)
+```
+
+### Opening a modal bottom sheet instantly
+
+Use the `jumpTo()` function to move to a detent without animation:
+
+```kotlin
+BasicText(
+  text = "Open immediately",
+  modifier = Modifier.clickable {
+    sheetState.jumpTo(SheetDetent.FullyExpanded)
+  },
+)
+```
+
+### Adding an overlay behind a modal bottom sheet
+
+Use the `overlay` parameter to render content behind the modal sheet. Use the optional
+[Scrim](/compose-unstyled/scrim) module for a ready-made scrim. For custom modal-layer content that
+needs to coordinate enter and exit animations, see [Modal](/compose-unstyled/modal).
+
+```kotlin
+UnstyledModalBottomSheet(
+  state = sheetState,
+  overlay = { Scrim() },
+) {
+  Sheet {
+    BasicText("Sheet content")
+  }
+}
+```
+
+### Creating modal bottom sheets with custom detents
+
+Use the `SheetDetent` constructor to create a new detent. Pass a unique identifier and a function
+that calculates the detent height. The calculated height cannot be smaller than `0.dp`, taller than
+the container, or taller than the sheet content.
+
+Keep this calculation fast. It runs during sheet measurement.
 
 ```kotlin
 val Peek = SheetDetent("peek") { containerHeight, sheetHeight ->
-    containerHeight * 0.6f
+  minOf(containerHeight * 0.4f, sheetHeight)
 }
 
 val sheetState = rememberModalBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Peek, FullyExpanded),
+  initialDetent = SheetDetent.Hidden,
+  detents = listOf(SheetDetent.Hidden, Peek, SheetDetent.FullyExpanded),
 )
-UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(
-        modifier = Modifier.fillMaxWidth()
-            .background(Color.White)
-            .height(1200.dp),
-    ) {
-        Column {
-            BasicText("Current Detent = ${sheetState.currentDetent.identifier}")
-            BasicText("Target Detent = ${sheetState.targetDetent.identifier}")
-        }
-    }
-}
 ```
 
-### Listening to dragging progress
+### Updating modal bottom sheet detents after layout changes
 
-Use the state's `offset` value to listen to how far the sheet has moved within its container.
-
-If you are interested in listening to dragging events between detents, use the state's `progress` value instead:
+Use the `invalidateDetents()` function to recalculate sheet detents. This is useful when a custom
+detent reads a measured value that can change, such as a header height:
 
 ```kotlin
-val Peek = SheetDetent("peek") { containerHeight, sheetHeight ->
-    containerHeight * 0.6f
+var peekHeight by remember { mutableStateOf(120.dp) }
+
+val Peek = remember {
+  SheetDetent("peek") { _, _ -> peekHeight }
 }
 
 val sheetState = rememberModalBottomSheetState(
-    initialDetent = Peek,
-    detents = listOf(Peek, FullyExpanded),
+  initialDetent = Peek,
+  detents = listOf(Peek, SheetDetent.FullyExpanded),
 )
 
-val alpha by animateFloatAsState(targetValue = sheetState.offset)
-
-UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(
-        modifier = Modifier.fillMaxWidth()
-            .alpha(alpha)
-            .background(Color.White)
-            .height(1200.dp),
-    ) {
-    }
+LaunchedEffect(peekHeight) {
+  sheetState.invalidateDetents()
 }
 ```
 
-### Jumping to detent immediately
+### Building modal bottom sheets with scrollable content
 
-Use the `jumpTo()` function to move the sheet to the desired detent without any animation.
+Use a scrollable layout inside the `Sheet` component to make content scroll within the current detent height:
 
-**NOTE:** It is not currently possible to make the sheet enter the screen without an animation.
+<UnstyledDemo id="modal-bottom-sheet-scrollable-content" />
+
+### Moving a modal bottom sheet above the soft keyboard
+
+Use the `offsetForIme` parameter on `ModalBottomSheetProperties` to automatically move the sheet above the soft keyboard:
+
+```kotlin
+val textState = rememberTextFieldState()
+
+UnstyledModalBottomSheet(
+  state = sheetState,
+  properties = ModalBottomSheetProperties(offsetForIme = true),
+) {
+  Sheet {
+    BasicTextField(state = textState)
+  }
+}
+```
+
+### Disabling back press and outside click dismissal
+
+Use the `properties` parameter to control how the modal sheet can be dismissed:
+
+```kotlin
+UnstyledModalBottomSheet(
+  state = sheetState,
+  properties = ModalBottomSheetProperties(
+    dismissOnBackPress = false,
+    dismissOnClickOutside = false,
+  ),
+) {
+  Sheet {
+    BasicText("Sheet content")
+  }
+}
+```
+
+### Reacting to modal bottom sheet dismissal
+
+Use the `onDismiss` parameter to run code when the sheet is dismissed:
+
+```kotlin
+UnstyledModalBottomSheet(
+  state = sheetState,
+  onDismiss = { selectedItem = null },
+) {
+  Sheet {
+    BasicText("Sheet content")
+  }
+}
+```
+
+### Customizing modal bottom sheet animation between detents
+
+Use the `animationSpec` parameter to customize the default animation between detents. Use the
+`dismissAnimationSpec` parameter to customize the animation used when the modal sheet is dismissed:
 
 ```kotlin
 val sheetState = rememberModalBottomSheetState(
-    initialDetent = FullyExpanded,
+  initialDetent = SheetDetent.Hidden,
+  animationSpec = tween(durationMillis = 300),
+  dismissAnimationSpec = tween(durationMillis = 180),
 )
-
-UnstyledModalBottomSheet(state = sheetState) {
-    Sheet(modifier = Modifier.fillMaxWidth()) {
-        Box(
-            modifier = Modifier.fillMaxWidth().height(1200.dp),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            UnstyledButton(onClick = { sheetState.jumpTo(Hidden) }) {
-                BasicText("Hide Sheet")
-            }
-        }
-    }
-}
 ```
-
-### Styling the system bars
-
-**Android only**
-
-ModalBottomSheet will not change the color of your system UI when displayed. [All modals](modal.md) in Unstyled expose a `LocalModalWindow` composition local,
-which provides you with the Android `Window` that hosts the dialog, so that you can customize the System UI according to
-your needs.
-
-[View to Android demo on Github](https://github.com/composablehorizons/compose-unstyled/tree/main/demo-system-ui-styling)
-
-```kotlin
-UnstyledModalBottomSheet(rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded)) {
-    Sheet(Modifier.fillMaxWidth()) {
-        val window = LocalModalWindow.current
-        LaunchedEffect(Unit) {
-            // change system bars to transparent
-            window.statusBarColor = Color.Transparent.toArgb()
-            window.navigationBarColor = Color.Black.copy(0.33f).toArgb()
-
-            // don't forget to update the icons too
-            val windowInsetsController = WindowInsetsControllerCompat(window, window.decorView)
-            windowInsetsController.isAppearanceLightStatusBars = true
-            windowInsetsController.isAppearanceLightNavigationBars = false
-        }
-        BasicText(
-            "Transparent status bar, darkened navbars. Easy-peasy 😎 ",
-            modifier = Modifier.navigationBarsPadding()
-        )
-    }
-}
-```
-
-## Keyboard Interactions
-
-The `BottomSheet` component does not have any keyboard interactions, as it is 100% controlled by touch input.
-
-We strongly recommended to always include the `DragIndication` component within your sheet's content which enables the
-following keyboard interactions:
-
-<style>
-.keyboard-key {
-  background-color: #EEEEEE;
-  color: black;
-  text-align: center;
-  border-radius: 4px;
-}
-
-.md-typeset__table {
-   min-width: 100%;
-}
-
-.md-typeset table:not([class]) {
-    display: table;
-}
-
-.parameter {
-    white-space: nowrap
-}
-</style>
-
-| Key                                           | Action                                          |
-|-----------------------------------------------|-------------------------------------------------|
-| <div class="keyboard-key">Tab</div>           | Moves focus to or away from the drag indication |
-| <div class="keyboard-key">Space / Enter</div> | Toggles between the available sheet's detents   |
 
 <ApiReference id="modal-bottom-sheet" />
-
-## Android Interop: WebView is not scrollable
-
-Using an Android View `WebView` inside of a `BottomSheet` will block the `WebView`'s scrolling.
-
-This is a bug with the Android <> Compose interop. To fix the issue, make sure to use a `Modifier.verticalScroll()` on your `AndroidView` that holds the `WebView`:
-
-```kotlin
-@Composable
-fun WebView(modifier: Modifier = Modifier) {
-    AndroidView(
-        modifier = modifier
-            .verticalScroll(rememberScrollState()),
-        factory = {
-            android.webkit.WebView(it)
-        }
-    )
-}
-```

--- a/docs/pages/modal.md
+++ b/docs/pages/modal.md
@@ -1,6 +1,6 @@
 ---
 title: Modal
-description: "Modals are the building blocks for components such as dialogs, alerts and modal bottom sheets.  They create their own window and block interaction with the rest of the interface until removed from the composition. They create their own window and block interaction with the rest of the interface until removed from the composition. You can think of a modal as "layer" than a component."
+description: A low-level modal layer for blocking background interaction.
 ---
 
 <UnstyledDemo id="modal" />
@@ -11,88 +11,60 @@ description: "Modals are the building blocks for components such as dialogs, ale
 implementation("com.composables:composeunstyled-modal")
 ```
 
-## Basic Example
-
-To create a modal use the `Modal` component.
-
-Modals do not render anything on the screen by default. However, they draw their contents on a separate window.
-
-As soon as a modal becomes active, it will move focus to its contents.
+## Anatomy
 
 ```kotlin
-Modal {
-    Box(
-        modifier = Modifier.padding(10.dp).background(Color.White),
-        contentAlignment = Alignment.TopCenter
-    ) {
-        UnstyledDragIndication(Modifier.width(32.dp).height(4.dp))
-    }
+Modal(state = state) {
+  Modifier.modalFragment()
 }
 ```
+
+## Concepts
+
+- `ModalState` controls whether the modal is visible.
+- `Modal` renders content in a modal layer.
+- `modalFragment()` marks content that should keep the modal mounted during transitions.
+
+## Accessibility
+
+Use higher-level components such as `Dialog` or `UnstyledModalBottomSheet` when you need built-in dismiss behavior and semantics.
 
 ## Code Examples
 
-### Dismiss Modal on `Escape`
+### Showing modal content
 
-Use the `onKeyEvent` parameter to handle key presses.
-
-Note that in order to receive any key events, you need at least one focusable target within your modal (such as
-a [Button](button.md)):
+Use the `rememberModalState()` function to create the modal state:
 
 ```kotlin
-var showModal by remember { mutableStateOf(true) }
+val state = rememberModalState(initiallyVisible = true)
 
-UnstyledButton(onClick = { showModal = true }) {
-    BasicText("Show Modal")
-}
-
-if (showModal) {
-    Modal(
-        onKeyEvent = {
-            if (it.key == Key.Escape) {
-                if (it.type == KeyEventType.KeyDown) {
-                    showModal = false
-                }
-                true
-            }
-            false
-        }
-    ) {
-        Box(
-            modifier = Modifier.padding(),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            UnstyledButton(onClick = { showModal = false }) {
-                BasicText("Dismiss Modal")
-            }
-        }
-    }
+Modal(state = state) {
+  Box(Modifier.modalFragment()) {
+    BasicText("Modal content")
+  }
 }
 ```
 
-### Styling the system bars
+### Closing a modal from Escape
 
-Modals on Android create their own [`Window`](https://developer.android.com/reference/android/view/Window) to render
-their contents. To hold its reference you can use the `LocalModalWindow` composition local from within the contents of the modal.
-
-This is handy for when you need to style the status bar and/or navigation bars, while the modal is active.
-
-This API exists only on the Android target:
+Use the `onKeyEvent` parameter to handle keyboard dismissal:
 
 ```kotlin
-Modal {
-    val window = LocalModalWindow.current
-
-    LaunchedEffect(Unit) {
-        // change system bars to transparent
-        window.statusBarColor = Color.Transparent.toArgb()
-        window.navigationBarColor = Color.Transparent.toArgb()
-
-        // don't forget to update the icons too
-        val windowInsetsController = WindowInsetsControllerCompat(window, window.decorView)
-        windowInsetsControllerCompat.isAppearanceLightStatusBars = true
-        windowInsetsControllerCompat.isAppearanceLightNavigationBars = true
+Modal(
+  state = state,
+  onKeyEvent = { event ->
+    if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+      state.transitionState.targetState = false
+      true
+    } else {
+      false
     }
-    BasicText("Transparent bars. So cool 😎 ", modifier = Modifier.navigationBarsPadding())
+  },
+) {
+  Box(Modifier.modalFragment()) {
+    BasicText("Modal content")
+  }
 }
 ```
+
+<ApiReference id="modal" />

--- a/docs/pages/portal.md
+++ b/docs/pages/portal.md
@@ -1,11 +1,9 @@
 ---
 title: Portal
-description: Render content into a same-window portal.
+description: A same-window portal utility for rendering content from one place in composition into a shared host.
 ---
 
-`PortalHost` and `Portal` let you render content later in the same Compose hierarchy without changing the parent layout.
-
-Use portals for floating or overlay UI that should escape local layout constraints but still stay in the same window, such as custom menus, popovers, teaching bubbles, or non-modal overlays.
+<UnstyledDemo/>
 
 ## Installation
 
@@ -13,52 +11,72 @@ Use portals for floating or overlay UI that should escape local layout constrain
 implementation("com.composables:composeunstyled-portal")
 ```
 
-## Host content
-
-Wrap the part of your app that should support portals with `PortalHost`.
+## Anatomy
 
 ```kotlin
-@Composable
-fun App() {
-    PortalHost(Modifier.fillMaxSize()) {
-        AppContent()
-    }
+PortalHost {
+  Portal {
+    BasicText("Portal content")
+  }
 }
 ```
 
-`PortalHost` lays out its normal `content` first. Any active `Portal` entries are rendered after that content inside a `Box` that matches the host size.
+## General Usage
 
-## Render into the portal
+- `PortalHost` provides the destination where portal content is rendered.
+- `Portal` sends content to the nearest `PortalHost`, or renders nothing when no host is available.
 
-Call `Portal` from inside a `PortalHost` subtree.
+## Code Examples
+
+### Rendering content in a portal
+
+Place `PortalHost` above the content that needs to render portals:
 
 ```kotlin
-@Composable
-fun PopoverExample(expanded: Boolean) {
-    Button(onClick = { /* update expanded */ }) {
-        Text("Open")
-    }
+PortalHost {
+  BasicText("Screen content")
 
-    if (expanded) {
-        Portal {
-            Box(
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.24f))
-            )
-        }
-    }
+  Portal {
+    BasicText("Portal content")
+  }
 }
 ```
 
-The portal content is registered while the composable is in the composition and removed automatically when it leaves the composition.
+### Showing portal content conditionally
 
-## Missing host
+Add or remove the `Portal` from composition to control whether its content is rendered:
 
-If `Portal` is used outside a `PortalHost`, it returns without rendering content. Add a `PortalHost` around the app surface, screen, or component subtree that owns the floating content.
+```kotlin
+var showPortal by remember { mutableStateOf(false) }
 
-## Portal vs Modal
+PortalHost {
+  BasicText(
+    text = "Show portal",
+    modifier = Modifier.clickable { showPortal = true }
+  )
 
-Use `Portal` when content should stay in the same window and you only need a rendering layer.
+  if (showPortal) {
+    Portal {
+      BasicText("Portal content")
+    }
+  }
+}
+```
 
-Use `Modal`, `UnstyledDialog`, or `UnstyledModalBottomSheet` when you need modal lifecycle, focus, accessibility, or platform window behavior.
+### Hosting multiple portals
+
+A single `PortalHost` can render content from multiple `Portal` calls:
+
+```kotlin
+PortalHost {
+  Portal {
+    BasicText("First portal")
+  }
+
+  Portal {
+    BasicText("Second portal")
+  }
+}
+```
+
+<ApiReference id="portal" />

--- a/docs/pages/progressindicator.md
+++ b/docs/pages/progressindicator.md
@@ -1,6 +1,6 @@
 ---
 title: Progress Indicator
-description: A foundational component used to display progress in a linear bar format in Jetpack Compose and Compose Multiplatform. Accessible out of the box and fully renderless, so that you can apply any styling you like.
+description: A progress indicator component for determinate and indeterminate loading states.
 ---
 
 <UnstyledDemo id="progressindicator" />
@@ -11,54 +11,54 @@ description: A foundational component used to display progress in a linear bar f
 implementation("com.composables:composeunstyled-progress")
 ```
 
-## Basic Example
-
-To create a progress indicator use the `UnstyledProgress` component. It sets up the required accessibility semantics according to the given `progress`.
-
-The `Indicator` child component fills itself to the current progress.
+## Anatomy
 
 ```kotlin
-UnstyledProgress(
-    progress = 0.5f,
-    modifier = Modifier
-        .width(400.dp)
-        .height(24.dp)
-        .dropShadow(
-            shape = RoundedCornerShape(100),
-            shadow = Shadow(
-                radius = 8.dp,
-                spread = 0.dp,
-                color = Color.Black.copy(alpha = 0.14f),
-                offset = DpOffset(x = 0.dp, y = 2.dp)
-            )
-        )
-        .background(Color(0xff176153), RoundedCornerShape(100)),
-) {
-    Indicator(
-        Modifier.background(
-            color = Color(0xffb6eabb),
-            shape = RoundedCornerShape(100)
-        )
-    )
+UnstyledProgress(progress = progress) {
+  Indicator()
 }
 ```
 
-## Styling
+## Concepts
 
-Every component in Compose Unstyled is renderless. They handle all UX pattern logic, internal state, accessibility (
-according to ARIA standards), and keyboard interactions for you, but they do not render any UI to the screen.
+- `UnstyledProgress()` represents the visible bounds of the progress including the track.
+- `Indicator` fills the available width by the current progress value.
 
-This is by design so that you can style your components exactly to your needs.
+## Accessibility
 
-Most of the time, styling is done using `Modifiers` of your choice. However, sometimes this is not enough due to the
-order of the `Modifier`s affecting the visual outcome.
+`UnstyledProgress` applies the appropriate accessibility semantics based on whether the `progress`
+parameter is provided.
 
-For such cases we provide specific styling parameters or optional components.
+## Code Examples
 
-### Styling the track and fill
+### Creating a determinate progress indicator
 
-`UnstyledProgress` owns the accessibility semantics and exposes the current progress to its content.
+Use the `progress` parameter when the current progress value is known:
 
-It is up to you to render the progress track and fill any way you like. Apply track styling to the `UnstyledProgress` modifier and fill styling to `Indicator`.
+```kotlin
+UnstyledProgress(progress = 0.4f) {
+  Indicator()
+}
+```
+
+### Creating an indeterminate progress indicator
+
+Use the overload without the `progress` parameter when the current progress value is unknown:
+
+```kotlin
+UnstyledProgress {
+  BasicText("Loading")
+}
+```
+
+### Drawing a custom indicator
+
+Use the `ProgressScope.progress` property when the indicator needs custom measurement:
+
+```kotlin
+UnstyledProgress(progress = progress) {
+  Box(Modifier.fillMaxWidth(progress))
+}
+```
 
 <ApiReference id="progressindicator" />

--- a/docs/pages/radiogroup.md
+++ b/docs/pages/radiogroup.md
@@ -1,9 +1,15 @@
 ---
 title: Radio Group
-description: A foundational component for creating accessible radio groups in Jetpack Compose and Compose Multiplatform. Comes with full accessibility features and keyboard navigation, while letting you handle the styling to your liking.
+description: A radio group component for single-choice selection.
 ---
 
 <UnstyledDemo id="radiogroup" />
+
+## Features
+
+- Generic radio values
+- Arrow-key focus movement
+- Animated selected indicator
 
 ## Installation
 
@@ -11,150 +17,80 @@ description: A foundational component for creating accessible radio groups in Je
 implementation("com.composables:composeunstyled-radio-group")
 ```
 
-## Basic Example
-
-To create a radio group use the `RadioGroup` component. Each radio option should be represented using the `Radio`
-component.
-
-The radio group handles its own state and sets important accessibility semantics.
-
-You are free to represent a radio as anything you like, such as a checkbox icon or a typical radio like the following example:
-
-```kotlin
-val values = listOf("Light", "Dark", "System")
-val groupState = rememberRadioGroupState(initialValue = values[0])
-
-UnstyledRadioGroup(
-    state = groupState,
-    contentDescription = "Theme selection"
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        values.forEach { text ->
-            val selected = groupState.selectedOption == text
-            UnstyledRadioButton(
-                value = text,
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(vertical = 12.dp, horizontal = 16.dp),
-                shape = RoundedCornerShape(8.dp),
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(20.dp)
-                        .dropShadow(
-                            shape = CircleShape,
-                            shadow = Shadow(
-                                radius = 8.dp,
-                                spread = 0.dp,
-                                color = Color.Black.copy(alpha = 0.14f),
-                                offset = DpOffset(x = 0.dp, y = 2.dp)
-                            )
-                        )
-                        .clip(CircleShape)
-                        .background(
-                            if (selected) Color(0xFFB23A48) else Color.White
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Box(
-                        Modifier
-                            .size(8.dp)
-                            .clip(CircleShape)
-                            .alpha(if (selected) 1f else 0f)
-                            .background(Color.White)
-                    )
-                }
-                Spacer(Modifier.width(16.dp))
-                BasicText(text)
-            }
-        }
-    }
-}
-
-```
-
-## Styling
-
-Every component in Compose Unstyled is renderless. They handle all UX pattern logic, internal state, accessibility (
-according to ARIA standards), and keyboard interactions for you, but they do not render any UI to the screen.
-
-This is by design so that you can style your components exactly to your needs.
-
-Most of the time, styling is done using `Modifiers` of your choice. However, sometimes this is not enough due to the
-order of the `Modifier`s affecting the visual outcome.
-
-For such cases we provide specific styling parameters.
-
-## Code Example
-
-### Toggle radio manually
-
-You can control selection yourself by using the `Radio` overload with the `selected`/`onSelectedChange` params.
+## Anatomy
 
 ```kotlin
 UnstyledRadioGroup(
-    state = groupState,
-    contentDescription = "Theme selection"
+  value = value,
+  onValueChange = onValueChange,
 ) {
-    Column(
-        horizontalAlignment = Alignment.Start,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        values.forEach { text ->
-            val selected = groupState.selectedOption == text
-            UnstyledRadioButton(
-                selected = groupState.selectedOption == text,
-                onSelectedChange = { groupState.selectedOption = text },
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(vertical = 12.dp, horizontal = 16.dp),
-                shape = RoundedCornerShape(8.dp),
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(20.dp)
-                        .dropShadow(
-                            shape = CircleShape,
-                            shadow = Shadow(
-                                radius = 8.dp,
-                                spread = 0.dp,
-                                color = Color.Black.copy(alpha = 0.14f),
-                                offset = DpOffset(x = 0.dp, y = 2.dp)
-                            )
-                        )
-                        .clip(CircleShape)
-                        .background(
-                            if (selected) Color(0xFFB23A48) else Color.White
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Box(
-                        Modifier
-                            .size(8.dp)
-                            .clip(CircleShape)
-                            .alpha(if (selected) 1f else 0f)
-                            .background(Color.White)
-                    )
-                }
-                Spacer(Modifier.width(16.dp))
-                BasicText(text)
-            }
-        }
+  RadioButton(value) {
+    SelectedIndicator {
     }
+  }
 }
-
 ```
 
-## Keyboard Interactions
+## Concepts
 
-| Key                                   | Description                                                                                             |
-|---------------------------------------|---------------------------------------------------------------------------------------------------------|
-| <div class="keyboard-key">Enter</div> | Selects the radio button, triggering its onSelectedChange callback                                      |
-| <div class="keyboard-key">Space</div> | Selects the radio button, triggering its onSelectedChange callback                                      |
-| <div class="keyboard-key">⬇</div>     | Moves focus to the next radio button. If focus is on the last button, it moves to the first button.     |
-| <div class="keyboard-key">➡</div>     | Moves focus to the next radio button. If focus is on the last button, it moves to the first button.     |
-| <div class="keyboard-key">⬆</div>     | Moves focus to the previous radio button. If focus is on the first button, it moves to the last button. |
-| <div class="keyboard-key">⬅</div>     | Moves focus to the previous radio button. If focus is on the first button, it moves to the last button. |
+- `UnstyledRadioGroup` groups radio options for one selected value.
+- `RadioButton` renders an option inside the group.
+- `SelectedIndicator` renders only when its radio button is selected.
+
+## Accessibility
+
+Use `accessibilityLabel` when the radio group does not contain a readable group label.
+
+## Code Examples
+
+### Selecting one radio option
+
+Use the `value` parameter on each `RadioButton` to connect it to the group value:
+
+```kotlin
+var selected by remember { mutableStateOf("small") }
+
+UnstyledRadioGroup(
+  value = selected,
+  onValueChange = { selected = it },
+) {
+  RadioButton("small") {
+    BasicText("Small")
+  }
+
+  RadioButton("large") {
+    BasicText("Large")
+  }
+}
+```
+
+### Rendering the selected indicator
+
+Use the `SelectedIndicator` component to render content only for the selected option:
+
+```kotlin
+RadioButton("large") {
+  SelectedIndicator {
+    BasicText("Selected")
+  }
+
+  BasicText("Large")
+}
+```
+
+### Animating the selected indicator
+
+Use the `enter` and `exit` parameters on `SelectedIndicator` to animate the selected indicator:
+
+```kotlin
+RadioButton("large") {
+  SelectedIndicator(
+    enter = fadeIn(),
+    exit = fadeOut(),
+  ) {
+    BasicText("Selected")
+  }
+}
+```
 
 <ApiReference id="radiogroup" />

--- a/docs/pages/scrim.md
+++ b/docs/pages/scrim.md
@@ -1,104 +1,9 @@
 ---
 title: Scrim
-description: A renderless modal scrim primitive for dimming content behind modal surfaces.
+description: A modal scrim that follows the modal transition state.
 ---
 
-```kotlin
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.composeunstyled.Modal
-import com.composeunstyled.UnstyledButton
-import com.composeunstyled.Scrim
-import com.composeunstyled.modalFragment
-import com.composeunstyled.rememberModalState
-
-@Composable
-fun ScrimExample() {
-    val modalState = rememberModalState(initiallyVisible = false)
-
-    Box(Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
-        UnstyledButton(
-            onClick = { modalState.transitionState.targetState = true },
-            borderColor = Color(0xFF18181B),
-            borderWidth = 1.dp,
-            backgroundColor = Color.Transparent,
-            contentPadding = PaddingValues(horizontal = 18.dp, vertical = 11.dp),
-            shape = RoundedCornerShape(12.dp)
-        ) {
-            BasicText(
-                text = "Show Scrim",
-                style = TextStyle(
-                    color = Color(0xFF18181B),
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.SemiBold
-                )
-            )
-        }
-    }
-
-    Modal(state = modalState) {
-        Scrim(
-            scrimColor = Color.Black.copy(alpha = 0.24f),
-            enter = fadeIn(tween(durationMillis = 220)),
-            exit = fadeOut(tween(durationMillis = 180))
-        )
-        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Column(
-                Modifier
-                    .modalFragment()
-                    .widthIn(max = 280.dp)
-                    .padding(20.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                BasicText(
-                    text = "Background content is dimmed.",
-                    style = TextStyle(
-                        color = Color.White,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Medium
-                    )
-                )
-                UnstyledButton(
-                    onClick = { modalState.transitionState.targetState = false },
-                    borderColor = Color.White,
-                    borderWidth = 1.dp,
-                    backgroundColor = Color.Transparent,
-                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp),
-                    shape = RoundedCornerShape(10.dp)
-                ) {
-                    BasicText(
-                        text = "Dismiss",
-                        style = TextStyle(
-                            color = Color.White,
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Medium
-                        )
-                    )
-                }
-            }
-        }
-    }
-}
-```
+<UnstyledDemo id="scrim" />
 
 ## Installation
 
@@ -106,24 +11,52 @@ fun ScrimExample() {
 implementation("com.composables:composeunstyled-scrim")
 ```
 
-## Basic Example
-
-Use `Scrim` inside modal content when you want to dim everything behind the modal surface.
+## Anatomy
 
 ```kotlin
-Modal {
-    Scrim()
-
-    Box(
-        modifier = Modifier
-            .padding(24.dp)
-            .background(Color.White, RoundedCornerShape(16.dp))
-    ) {
-        BasicText("Modal content")
-    }
+Modal(state = state) {
+  Scrim()
 }
 ```
 
-## Styling
+## Concepts
 
-The scrim renders a full-size layer using the current modal state. Pass `scrimColor`, `enter`, and `exit` to customize its color and transitions.
+- `Scrim` renders a modal overlay inside `Modal`.
+- `Scrim` follows the modal transition state.
+
+## Code Examples
+
+### Adding a scrim to a modal
+
+Use the `Scrim` component inside `Modal` content:
+
+```kotlin
+Modal(state = state) {
+  Scrim()
+}
+```
+
+### Changing scrim color
+
+Use the `scrimColor` parameter to change the overlay color:
+
+```kotlin
+Modal(state = state) {
+  Scrim(scrimColor = Color.Black.copy(alpha = 0.4f))
+}
+```
+
+### Animating a scrim
+
+Use the `enter` and `exit` parameters to animate the scrim with the modal state:
+
+```kotlin
+Modal(state = state) {
+  Scrim(
+    enter = fadeIn(),
+    exit = fadeOut(),
+  )
+}
+```
+
+<ApiReference id="scrim" />

--- a/docs/pages/scrollarea.md
+++ b/docs/pages/scrollarea.md
@@ -1,9 +1,16 @@
 ---
 title: Scrollbars
-description: Foundational, renderless vertical and horizontal scrollbar components with customizable thumbs. Supports Column, Row, LazyColumn, LazyRow, LazyVerticalGrid and LazyHorizontalGrid.
+description: Scrollbar components for scroll state, lazy lists, and lazy grids.
 ---
 
 <UnstyledDemo id="scrollbars" />
+
+## Features
+
+- ScrollState support
+- LazyListState support
+- LazyGridState support
+- Draggable scrollbar thumbs
 
 ## Installation
 
@@ -11,242 +18,112 @@ description: Foundational, renderless vertical and horizontal scrollbar componen
 implementation("com.composables:composeunstyled-scrollbars")
 ```
 
-## Basic Example
-
-Scrollbars consist of the following components: `rememberScrollbarState`, `UnstyledVerticalScrollbar`, `UnstyledHorizontalScrollbar`, and `Thumb`.
-
-`rememberScrollbarState` adapts a `ScrollState`, `LazyListState`, or `LazyGridState` into the state used by scrollbar primitives.
-
-The `UnstyledVerticalScrollbar`/`UnstyledHorizontalScrollbar` components represent the track of the scrollbar and accept a thumb
-component.
-
-The `Thumb` represents the thumb of a scrollbar and will automatically sync their position and size according to the
-scrolled position of the connected scrollbar state.
-
-Here is a simple example of adding vertical scrollbar to a `LazyColumn`:
+## Anatomy
 
 ```kotlin
-val lazyListState = rememberLazyListState()
-val state = rememberScrollbarState(lazyListState)
+val scrollbarState = rememberScrollbarState(scrollState)
 
-Box {
-    LazyColumn(state = lazyListState, modifier = Modifier.fillMaxSize()) {
-        repeat(50) { i ->
-            item {
-                BasicText("Item #${i}")
-            }
-        }
-    }
-    UnstyledVerticalScrollbar(
-        scrollbarState = state,
-        modifier = Modifier.align(Alignment.TopEnd)
-            .fillMaxHeight()
-            .width(4.dp)
-    ) {
-        Thumb(Modifier.background(Color.LightGray))
-    }
+UnstyledVerticalScrollbar(scrollbarState) {
+  Thumb()
 }
 ```
+
+## Concepts
+
+- `ScrollbarState` represents the scroll position used by a scrollbar.
+- `UnstyledVerticalScrollbar` renders a vertical scrollbar.
+- `UnstyledHorizontalScrollbar` renders a horizontal scrollbar.
+- `Thumb` renders the draggable thumb inside a scrollbar.
 
 ## Code Examples
 
-### Add scrollbars to LazyLists
+### Adding scrollbars to LazyColumn
 
-Create a scrollbar state from your `LazyColumn` or `LazyList` state and pass it to the scrollbar:
+Use the `rememberScrollbarState(LazyListState)` function to connect a scrollbar to lazy list scroll position:
 
 ```kotlin
-val lazyListState = rememberLazyListState()
-val state = rememberScrollbarState(lazyListState)
+val listState = rememberLazyListState()
+val scrollbarState = rememberScrollbarState(listState)
 
-Box {
-    LazyColumn(state = lazyListState, modifier = Modifier.fillMaxSize()) {
-        repeat(50) { i ->
-            item {
-                BasicText("Item #${i}")
-            }
-        }
-    }
-    UnstyledVerticalScrollbar(
-        scrollbarState = state,
-        modifier = Modifier.align(Alignment.TopEnd)
-            .fillMaxHeight()
-            .width(4.dp)
-    ) {
-        Thumb(Modifier.background(Color.LightGray))
-    }
+LazyColumn(state = listState) {
+  items(100) { index ->
+    BasicText("Item $index")
+  }
+}
+
+UnstyledVerticalScrollbar(scrollbarState) {
+  Thumb()
 }
 ```
 
-### Add scrollbars to LazyGrids
+### Adding scrollbars to LazyVerticalGrid
 
-Create a scrollbar state from your `LazyVerticalGrid` or `LazyHorizontalGrid` state and pass it to the scrollbar:
+Use the `rememberScrollbarState(LazyGridState)` function to connect a scrollbar to lazy grid scroll position:
 
 ```kotlin
-val lazyGridState = rememberLazyGridState()
-val state = rememberScrollbarState(lazyGridState)
+val gridState = rememberLazyGridState()
+val scrollbarState = rememberScrollbarState(gridState)
 
-Box {
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(3),
-        state = lazyGridState,
-        modifier = Modifier.fillMaxSize()
-    ) {
-        repeat(50) { i ->
-            item {
-                Box(
-                    Modifier.padding(4.dp).size(48.dp).background(Color.LightGray, RoundedCornerShape(8.dp)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    BasicText(i.toString())
-                }
-            }
-        }
-    }
-    UnstyledVerticalScrollbar(
-        scrollbarState = state,
-        modifier = Modifier.align(Alignment.TopEnd).fillMaxHeight()
-    ) {
-        Thumb(
-            modifier = Modifier.background(Color.Black.copy(0.3f), RoundedCornerShape(100)),
-        )
-    }
+LazyVerticalGrid(
+  columns = GridCells.Fixed(2),
+  state = gridState,
+) {
+  items(100) { index ->
+    BasicText("Item $index")
+  }
+}
+
+UnstyledVerticalScrollbar(scrollbarState) {
+  Thumb()
 }
 ```
 
-### Add scrollbars to Column and Row
+### Adding scrollbars to scrollable content
 
-Create a scrollbar state from the scroll state you pass to `verticalScroll` or `horizontalScroll`:
+Use the `rememberScrollbarState(ScrollState)` function for content that uses a regular scroll state:
 
 ```kotlin
 val scrollState = rememberScrollState()
-val state = rememberScrollbarState(scrollState)
+val scrollbarState = rememberScrollbarState(scrollState)
 
-Box {
-    Column(
-        modifier = Modifier.fillMaxSize().verticalScroll(scrollState)
-    ) {
-        repeat(50) { i ->
-            BasicText(i.toString())
-        }
-    }
-    UnstyledVerticalScrollbar(
-        scrollbarState = state,
-        modifier = Modifier.align(Alignment.TopEnd).fillMaxHeight()
-    ) {
-        Thumb(
-            modifier = Modifier.background(
-                Color.Black.copy(0.3f), RoundedCornerShape(100)
-            ),
-        )
-    }
+Column(Modifier.verticalScroll(scrollState)) {
+  repeat(100) { index ->
+    BasicText("Item $index")
+  }
+}
+
+UnstyledVerticalScrollbar(scrollbarState) {
+  Thumb()
 }
 ```
 
-### Styling the scrollbar and thumb
+### Hiding the scrollbar while idle
 
-Pass any styling you need to the `Modifier` of your `Scrollbar` component.
-
-You can customize the looks of your thumb using the modifier of the `Thumb` component.
-
-Here is an example of a semi-transparent scrollbar, with a fully rounded, semi-transparent thumb:
+Use the `thumbVisibility` parameter to hide the thumb when the user is not interacting with the scrollable content:
 
 ```kotlin
-val lazyListState = rememberLazyListState()
-val state = rememberScrollbarState(lazyListState)
-
-Box {
-    LazyColumn(state = lazyListState, modifier = Modifier.fillMaxSize()) {
-        repeat(50) { i ->
-            item {
-                BasicText("Item #${i}")
-            }
-        }
-    }
-    UnstyledVerticalScrollbar(
-        scrollbarState = state,
-        modifier = Modifier.align(Alignment.TopEnd)
-            .background(Color.Black.copy(0.1f))
-            .fillMaxHeight()
-            .width(12.dp)
-            .padding(2.dp)
-    ) {
-        Thumb(Modifier.background(Color.Black.copy(0.3f), RoundedCornerShape(100)))
-    }
+UnstyledVerticalScrollbar(scrollbarState) {
+  Thumb(
+    thumbVisibility = ThumbVisibility.HideWhileIdle(
+      enter = fadeIn(),
+      exit = fadeOut(),
+      hideDelay = 500.milliseconds,
+    ),
+  )
 }
 ```
 
-### Automatically hide the scrollbar
+### Supporting reverse layout
 
-By default, the scrollbar will always remain visible on the screen.
-
-To modify this behavior, pass the customization you need using the `thumbVisibility` parameter of the `Thumb` component.
-
-Here is an example of automatically hiding the scrollbar while idling for 0.5 seconds:
+Use the `reverseLayout` parameter when the scrollable content uses reverse layout:
 
 ```kotlin
-val lazyListState = rememberLazyListState()
-val state = rememberScrollbarState(lazyListState)
-
-Box {
-    LazyColumn(state = lazyListState, modifier = Modifier.fillMaxSize()) {
-        repeat(50) { i ->
-            item {
-                BasicText("Item #${i}")
-            }
-        }
-    }
-    UnstyledVerticalScrollbar(
-        scrollbarState = state,
-        modifier = Modifier.align(Alignment.TopEnd).fillMaxHeight()
-    ) {
-        Thumb(
-            modifier = Modifier.background(Color.Black.copy(0.3f), RoundedCornerShape(100)),
-            thumbVisibility = ThumbVisibility.HideWhileIdle(
-                enter = fadeIn(),
-                exit = fadeOut(),
-                hideDelay = 2.seconds
-            )
-        )
-    }
+UnstyledVerticalScrollbar(
+  scrollbarState = scrollbarState,
+  reverseLayout = true,
+) {
+  Thumb()
 }
 ```
 
-### Overscroll behavior
-
-Scrollbars no longer own scrolling layout or overscroll behavior. Apply overscroll behavior to the scrollable component itself using Compose Foundation's scroll APIs.
-
-### Disable thumb dragging
-
-By default, pressing on the thumb causes the connected content to scroll.
-
-To disable this behavior, pass `enabled = false` to the `Thumb` component:
-
-```kotlin
-val lazyListState = rememberLazyListState()
-val state = rememberScrollbarState(lazyListState)
-
-Box {
-    LazyColumn(state = lazyListState, modifier = Modifier.fillMaxSize()) {
-        repeat(50) { i ->
-            item {
-                BasicText("Item #${i}")
-            }
-        }
-    }
-    UnstyledVerticalScrollbar(
-        scrollbarState = state,
-        modifier = Modifier.align(Alignment.TopEnd).fillMaxHeight()
-    ) {
-        Thumb(
-            modifier = Modifier.background(Color.Black.copy(0.3f), RoundedCornerShape(100)),
-            enabled = false
-        )
-    }
-}
-```
-
-<style>
-.parameter {
-    white-space: nowrap
-}
-</style>
+<ApiReference id="scrollarea" />

--- a/docs/pages/separators.md
+++ b/docs/pages/separators.md
@@ -1,6 +1,6 @@
 ---
 title: Separators
-description: Horizontal and Vertical separator component for visually separating content.
+description: Horizontal and vertical separators with caller-defined color and thickness.
 ---
 
 <UnstyledDemo id="separators" />
@@ -11,20 +11,30 @@ description: Horizontal and Vertical separator component for visually separating
 implementation("com.composables:composeunstyled-separators")
 ```
 
-## Basic Example
-
-Basic example showing a horizontal separator:
+## Anatomy
 
 ```kotlin
-UnstyledHorizontalSeparator(color = Color(0xFF9E9E9E))
+UnstyledHorizontalSeparator(color = Color.Black)
 
-UnstyledVerticalSeparator(color = Color(0xFF9E9E9E))
+UnstyledVerticalSeparator(color = Color.Black)
 ```
 
-<style>
-.parameter {
-    white-space: nowrap
-}
-</style>
+## Concepts
+
+- `UnstyledHorizontalSeparator` renders a horizontal line.
+- `UnstyledVerticalSeparator` renders a vertical line.
+
+## Code Examples
+
+### Changing separator thickness
+
+Use the `thickness` parameter to change the line thickness:
+
+```kotlin
+UnstyledHorizontalSeparator(
+  color = Color.Black,
+  thickness = 2.dp,
+)
+```
 
 <ApiReference id="separators" />

--- a/docs/pages/slider.md
+++ b/docs/pages/slider.md
@@ -1,9 +1,16 @@
 ---
 title: Slider
-description: A foundational component used to create sliders with the styling of your choice.  Accessible, keyboard interactions included, just bring the styling.
+description: A slider component with custom track and thumb slots.
 ---
 
 <UnstyledDemo id="slider" />
+
+## Features
+
+- Horizontal and vertical sliders
+- Discrete step support
+- Custom track and thumb slots
+- Keyboard and screen reader value changes
 
 ## Installation
 
@@ -11,183 +18,102 @@ description: A foundational component used to create sliders with the styling of
 implementation("com.composables:composeunstyled-slider")
 ```
 
-## Basic Example
-
-To create a slider, use `UnstyledSlider` with a controlled value. The slider handles accessibility semantics and keyboard interactions.
+## Anatomy
 
 ```kotlin
-var value by remember { mutableStateOf(0.5f) }
-
 UnstyledSlider(
-    value = value,
-    onValueChange = { value = it },
-    modifier = Modifier.width(300.dp),
-    track = { state ->
-        Box(
-            Modifier
-                .fillMaxWidth()
-                .height(8.dp)
-                .background(Color.Gray)
-        )
-    },
-    thumb = { state ->
-        Box(
-            Modifier
-                .size(20.dp)
-                .background(Color.White, CircleShape)
-        )
-    }
+  value = value,
+  onValueChange = onValueChange,
+  track = {
+  },
+  thumb = {
+  },
 )
 ```
 
-## Styling
+## Concepts
 
-Every component in Compose Unstyled is renderless. They handle all UX pattern logic, internal state, accessibility (according to ARIA standards), and keyboard interactions for you, but they do not render any UI to the screen.
+- `UnstyledSlider` represents the interactive range users can drag or adjust.
+- `SliderState` is passed to the track and thumb slots.
+- The `track` slot renders below the thumb.
+- The `thumb` slot renders at the current slider offset.
 
-This is by design so that you can style your components exactly to your needs.
+## Accessibility
 
-Most of the time, styling is done using `Modifiers` of your choice. However, sometimes this is not enough due to the order of the `Modifier`s affecting the visual outcome.
+`UnstyledSlider` exposes progress semantics and supports arrow keys, Page Up, Page Down, Home, and End.
 
-For such cases we provide specific styling parameters.
+## Code Examples
 
-## Code Example
+### Creating a stepped slider
 
-### Change Progress Manually
-
-You can manually change the progress of the slider by updating the controlled value.
+Use the `steps` parameter to snap the slider value to discrete stops:
 
 ```kotlin
-var value by remember { mutableStateOf(0.5f) }
-
-UnstyledButton(onClick = { value = (value + 0.1f).coerceAtMost(1f) }) {
-    BasicText("Increase")
-}
-
 UnstyledSlider(
-    value = value,
-    onValueChange = { value = it },
-    track = { state ->
-        Box(
-            Modifier
-                .fillMaxWidth()
-                .height(8.dp)
-                .background(Color.LightGray)
-        )
-    },
-    thumb = { state ->
-        Box(
-            Modifier
-                .size(20.dp)
-                .background(Color.White, CircleShape)
-        )
-    }
+  value = value,
+  onValueChange = { value = it },
+  steps = 4,
+  track = { state ->
+    BasicText("${state.value}")
+  },
+  thumb = { state ->
+    BasicText("${state.value}")
+  },
 )
 ```
 
-### React to Hover Events
+### Using a custom value range
 
-A common pattern is to show a hover effect on the slider thumb. You can achieve this by using the `hoverable` modifier and `MutableInteractionSource` to react to hover events.
+Use the `valueRange` parameter when the slider value is not from `0f` to `1f`:
 
 ```kotlin
-var value by remember { mutableStateOf(0.5f) }
-
 UnstyledSlider(
-    value = value,
-    onValueChange = { value = it },
-    track = { state ->
-        Box(
-            Modifier
-                .fillMaxWidth()
-                .height(8.dp)
-                .background(Color.LightGray)
-        )
-    },
-    thumb = { state ->
-        val thumbInteractionSource = remember { MutableInteractionSource() }
-        val isHovered by thumbInteractionSource.collectIsHoveredAsState()
-        val glowColor by animateColorAsState(
-            if (isFocused || isHovered) Color.White.copy(0.33f) else Color.Transparent
-        )
-
-        // box to hold the 'glow' effect
-        Box(
-            modifier = Modifier.size(36.dp).clip(CircleShape).background(glowColor).padding(8.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Box(
-                Modifier
-                    .size(20.dp)
-                    .dropShadow(
-                        shape = CircleShape,
-                        shadow = Shadow(
-                            radius = 8.dp,
-                            spread = 0.dp,
-                            color = Color.Black.copy(alpha = 0.14f),
-                            offset = DpOffset(x = 0.dp, y = 2.dp)
-                        )
-                    )
-                    .hoverable(thumbInteractionSource)
-                    .background(Color.White, CircleShape)
-            )
-        }
-    }
+  value = volume,
+  onValueChange = { volume = it },
+  valueRange = 0f..100f,
+  track = { state ->
+    BasicText("${state.value}")
+  },
+  thumb = { state ->
+    BasicText("${state.value}")
+  },
 )
 ```
 
-### Resize Thumb on Drag
+### Creating a vertical slider
 
-A common slider pattern is to resize the slider thumb when it is dragged. This can be achieved using the `animateDpAsState` to smoothly transition the size of the thumb.
+Use the `orientation` parameter to make the slider vertical:
 
 ```kotlin
-var value by remember { mutableStateOf(0.5f) }
-val interactionSource = remember { MutableInteractionSource() }
-val isPressed by interactionSource.collectIsPressedAsState()
-
 UnstyledSlider(
-    interactionSource = interactionSource,
-    value = value,
-    onValueChange = { value = it },
-    track = { state ->
-        Box(
-            Modifier
-                .fillMaxWidth()
-                .height(8.dp)
-                .background(Color.LightGray)
-        )
-    },
-    thumb = { state ->
-        val thumbSize by animateDpAsState(targetValue = if (isPressed) 20.dp else 18.dp)
-
-        Box(
-            modifier = Modifier.size(36.dp).clip(CircleShape),
-            contentAlignment = Alignment.Center
-        ) {
-            Box(
-                Modifier
-                    .size(thumbSize)
-                    .dropShadow(
-                        shape = CircleShape,
-                        shadow = Shadow(
-                            radius = 8.dp,
-                            spread = 0.dp,
-                            color = Color.Black.copy(alpha = 0.14f),
-                            offset = DpOffset(x = 0.dp, y = 2.dp)
-                        )
-                    )
-                    .background(Color.White, CircleShape)
-            )
-        }
-    }
+  value = value,
+  onValueChange = { value = it },
+  orientation = Orientation.Vertical,
+  track = { state ->
+    BasicText("${state.value}")
+  },
+  thumb = { state ->
+    BasicText("${state.value}")
+  },
 )
 ```
 
-## Keyboard Interactions
+### Running code after value changes finish
 
-| Key                                   | Description                                                                                             |
-|---------------------------------------|---------------------------------------------------------------------------------------------------------|
-| <div class="keyboard-key">⬆</div>     | Increases the slider value.                                                                             |
-| <div class="keyboard-key">⬇</div>     | Decreases the slider value.                                                                             |
-| <div class="keyboard-key">Home</div>  | Sets the slider to the minimum value.                                                                   |
-| <div class="keyboard-key">End</div>   | Sets the slider to the maximum value.                                                                   |
+Use the `onValueChangeFinished` callback to react after drag, tap, keyboard, or screen reader changes finish:
+
+```kotlin
+UnstyledSlider(
+  value = value,
+  onValueChange = { value = it },
+  onValueChangeFinished = { save(value) },
+  track = { state ->
+    BasicText("${state.value}")
+  },
+  thumb = { state ->
+    BasicText("${state.value}")
+  },
+)
+```
 
 <ApiReference id="slider" />

--- a/docs/pages/stack.md
+++ b/docs/pages/stack.md
@@ -1,130 +1,9 @@
 ---
 title: Stack
-description: A flexible Compose layout composable that arranges its children either horizontally or vertically, providing a unified API that abstracts over Row and Column layouts.
+description: A single layout component for horizontal and vertical stacks.
 ---
 
-```kotlin
-import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.composables.icons.lucide.Lucide
-import com.composeunstyled.CrossAxisAlignment
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-import com.composeunstyled.UnstyledCheckbox
-import com.composeunstyled.UnstyledIcon
-import com.composeunstyled.theme.rememberColoredIndication
-
-@Composable
-fun StackExample() {
-    var isVertical by remember { mutableStateOf(false) }
-    val interactionSource = remember { MutableInteractionSource() }
-
-    @Composable
-    fun StackItem(label: String) {
-        Box(
-            modifier = Modifier
-                .size(56.dp)
-                .background(Color(0xFF18181B), RoundedCornerShape(12.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText(
-                label,
-                style = TextStyle(
-                    color = Color.White,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.SemiBold
-                )
-            )
-        }
-    }
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(24.dp),
-        contentAlignment = Alignment.TopCenter
-    ) {
-        Stack(
-            orientation = StackOrientation.Vertical,
-            spacing = 24.dp,
-            crossAxisAlignment = CrossAxisAlignment.Center
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.toggleable(
-                    value = isVertical,
-                    interactionSource = interactionSource,
-                    indication = rememberColoredIndication(
-                        color = Color.White,
-                        hoveredAlpha = 0.33f,
-                        focusedAlpha = 0.33f,
-                        pressedAlpha = 0.33f
-                    ),
-                    role = Role.Checkbox,
-                    onValueChange = { isVertical = it }
-                )
-            ) {
-                UnstyledCheckbox(
-                    checked = isVertical,
-                    onCheckedChange = null,
-                    shape = RoundedCornerShape(6.dp),
-                    backgroundColor = Color.White,
-                    borderColor = Color.Black.copy(alpha = 0.1f),
-                    borderWidth = 1.dp,
-                    modifier = Modifier.size(28.dp),
-                    contentDescription = "Use vertical orientation"
-                ) {
-                    UnstyledIcon(
-                        Lucide.Check,
-                        contentDescription = null,
-                        tint = Color(0xFF18181B),
-                        modifier = Modifier.size(16.dp)
-                    )
-                }
-                Spacer(Modifier.width(12.dp))
-                BasicText(
-                    "Vertical orientation",
-                    style = TextStyle(color = Color(0xFF18181B), fontSize = 14.sp)
-                )
-            }
-            Stack(
-                orientation = if (isVertical) StackOrientation.Vertical else StackOrientation.Horizontal,
-                spacing = 12.dp,
-                crossAxisAlignment = CrossAxisAlignment.Center
-            ) {
-                StackItem("A")
-                StackItem("B")
-                StackItem("C")
-            }
-        }
-    }
-}
-```
-
-<ApiReference id="stack" />
+<UnstyledDemo id="stack" />
 
 ## Installation
 
@@ -132,586 +11,68 @@ fun StackExample() {
 implementation("com.composables:composeunstyled-stack")
 ```
 
+## Anatomy
+
+```kotlin
+Stack {
+}
+```
+
+## Concepts
+
+- `Stack` renders children in one horizontal or vertical layout.
+- The `weight()` modifier distributes remaining space in the current stack orientation.
 
 ## Code Examples
 
-### Basic Example
+### Creating a vertical stack
 
-Use `Stack` to arrange its children horizontally by default:
-
-```kotlin
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-import androidx.compose.foundation.text.BasicText
-
-@Composable
-fun StackBasicExample() {
-    Stack(spacing = 12.dp) {
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("0", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("1", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("2", style = TextStyle(color = Color.White))
-        }
-    }
-}
-```
-
-```kotlin
-import com.composeunstyled.Stack
-```
-
-```kotlin
-Stack {
-    Box(/*...*/) {
-        BasicText("0")
-    }
-    Box(/*...*/) {
-        BasicText("1")
-    }
-    Box(/*...*/) {
-        BasicText("2")
-    }
-}
-```
-
-### Orientation
-
-Use `orientation` with the desired `StackOrientation` to arrange children vertically or horizontally:
-
-```kotlin
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-import androidx.compose.foundation.text.BasicText
-
-@Composable
-fun StackVerticalExample() {
-    Stack(
-        orientation = StackOrientation.Vertical,
-        spacing = 12.dp
-    ) {
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("0", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("1", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("2", style = TextStyle(color = Color.White))
-        }
-    }
-}
-```
-
-```kotlin
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-```
+Use the `orientation` parameter to arrange content vertically:
 
 ```kotlin
 Stack(orientation = StackOrientation.Vertical) {
-    Box(/*...*/) {
-        BasicText("0")
-    }
-    Box(/*...*/) {
-        BasicText("1")
-    }
-    Box(/*...*/) {
-        BasicText("2")
-    }
+  BasicText("One")
+  BasicText("Two")
 }
 ```
 
-### Main Axis Arrangement
+### Adding space between items
 
-Use `mainAxisArrangement` to control how children are distributed along the main axis.
+Use the `spacing` parameter to add equal space between children:
 
 ```kotlin
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import com.composeunstyled.MainAxisArrangement
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-import androidx.compose.foundation.text.BasicText
-
-@Composable
-fun StackMainAxisExample() {
-    Stack(
-        orientation = StackOrientation.Horizontal,
-        mainAxisArrangement = MainAxisArrangement.SpaceBetween,
-        modifier = Modifier.fillMaxWidth(0.5f)
-    ) {
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("0", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("1", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("2", style = TextStyle(color = Color.White))
-        }
-    }
+Stack(spacing = 12.dp) {
+  BasicText("One")
+  BasicText("Two")
 }
 ```
 
-```kotlin
-import com.composeunstyled.MainAxisArrangement
-import com.composeunstyled.Stack
-```
+### Aligning stack content
 
-```kotlin
-Stack(mainAxisArrangement = MainAxisArrangement.SpaceBetween) {
-    Box(/*...*/) {
-        BasicText("0")
-    }
-    Box(/*...*/) {
-        BasicText("1")
-    }
-    Box(/*...*/) {
-        BasicText("2")
-    }
-}
-```
-
-### Cross Axis Alignment
-
-Use `crossAxisAlignment` to align children on the perpendicular axis.
-
-```kotlin
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import com.composeunstyled.CrossAxisAlignment
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-import androidx.compose.foundation.text.BasicText
-
-@Composable
-fun StackCrossAxisExample() {
-    Stack(
-        orientation = StackOrientation.Horizontal,
-        crossAxisAlignment = CrossAxisAlignment.Center,
-        spacing = 12.dp
-    ) {
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("0", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.width(48.dp).height(80.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("1", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.width(48.dp).height(64.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("2", style = TextStyle(color = Color.White))
-        }
-    }
-}
-```
-
-```kotlin
-import com.composeunstyled.CrossAxisAlignment
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-```
+Use the `mainAxisArrangement` and `crossAxisAlignment` parameters to align children:
 
 ```kotlin
 Stack(
-    orientation = StackOrientation.Horizontal,
-    crossAxisAlignment = CrossAxisAlignment.Center,
+  mainAxisArrangement = MainAxisArrangement.Center,
+  crossAxisAlignment = CrossAxisAlignment.Center,
 ) {
-    Box(/*...*/) {
-        BasicText("0")
-    }
-    Box(/*...*/) {
-        BasicText("1")
-    }
-    Box(/*...*/) {
-        BasicText("2")
-    }
+  BasicText("One")
+  BasicText("Two")
 }
 ```
 
-### Spacing
+### Weighting stack children
 
-Use `spacing` to control the amount of spacing between children.
-
-```kotlin
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import com.composeunstyled.Stack
-import androidx.compose.foundation.text.BasicText
-
-@Composable
-fun StackSpacingExample() {
-    Stack(spacing = 48.dp) {
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("0", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("1", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("2", style = TextStyle(color = Color.White))
-        }
-    }
-}
-```
-
-```kotlin
-import com.composeunstyled.Stack
-```
-
-```kotlin
-Stack(spacing = 48.dp) {
-    Box(/*...*/) {
-        BasicText("0")
-    }
-    Box(/*...*/) {
-        BasicText("1")
-    }
-    Box(/*...*/) {
-        BasicText("2")
-    }
-}
-```
-
-### Weights
-
-Use `Modifier.weight()` on any children within the `StackScope` to control its size relative to other children in the Stack.
-
-```kotlin
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-import androidx.compose.foundation.text.BasicText
-
-@Composable
-fun StackWeightsExample() {
-    Stack(
-        orientation = StackOrientation.Horizontal,
-        spacing = 12.dp,
-        modifier = Modifier.width(500.dp)
-    ) {
-        Box(
-            modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("1f", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.weight(1f).height(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("1f", style = TextStyle(color = Color.White))
-        }
-        Box(
-            modifier = Modifier.weight(2f).height(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            BasicText("2f", style = TextStyle(color = Color.White))
-        }
-    }
-}
-```
-
-```kotlin
-import com.composeunstyled.Stack
-```
+Use the `weight()` modifier inside `Stack` content to distribute remaining space:
 
 ```kotlin
 Stack {
-    Box(Modifier.size(48.dp)) {
-        BasicText("1f")
-    }
-    Box(Modifier.weight(1f)/*...*/) {
-        BasicText("1f")
-    }
-    Box(Modifier.weight(2f)/*...*/) {
-        BasicText("2f")
-    }
+  BasicText(
+    text = "Primary",
+    modifier = Modifier.weight(1f),
+  )
+  BasicText("Secondary")
 }
 ```
 
-
-### Responsive design
-
-Use `orientation` to dynamically change how the `Stack` lays out its children based on screen size.
-
-To get context about the screen size, use [`currentWindowContainerSize()`](window-container-size):
-
-```kotlin
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.AlignHorizontalDistributeCenter
-import com.composables.icons.lucide.AlignVerticalDistributeCenter
-import com.composables.icons.lucide.Lucide
-import com.composeunstyled.UnstyledButton
-import com.composeunstyled.UnstyledIcon
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-import androidx.compose.foundation.text.BasicText
-import com.composeunstyled.outline
-
-@Composable
-fun StackResponsiveExample() {
-    var isHorizontal by remember { mutableStateOf(true) }
-
-    Stack(
-        orientation = StackOrientation.Vertical,
-        spacing = 16.dp,
-        crossAxisAlignment = com.composeunstyled.CrossAxisAlignment.Center
-    ) {
-        Box(
-            modifier = Modifier
-                .width(300.dp)
-                .border(1.dp, Color(0xFFE5E7EB), RoundedCornerShape(100))
-                .background(Color(0xFFF3F4F6), RoundedCornerShape(100))
-                .padding(start = 4.dp)
-                .padding(8.dp)
-        ) {
-            Stack(
-                orientation = StackOrientation.Horizontal,
-                mainAxisArrangement = com.composeunstyled.MainAxisArrangement.SpaceBetween,
-                crossAxisAlignment = com.composeunstyled.CrossAxisAlignment.Center,
-                modifier = Modifier.width(300.dp - 16.dp)
-            ) {
-                BasicText("Orientation")
-
-                Stack(
-                    orientation = StackOrientation.Horizontal,
-                    spacing = 4.dp
-                ) {
-                    UnstyledButton(
-                        onClick = { isHorizontal = true },
-                        backgroundColor = if (isHorizontal) Color.White else Color.Transparent,
-                        shape = RoundedCornerShape(50),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
-                        modifier = Modifier
-                            .size(40.dp)
-                            .then(
-                                if (isHorizontal) {
-                                    Modifier.outline(
-                                        width = 1.dp,
-                                        color = Color(0xFFD1D5DB),
-                                        shape = RoundedCornerShape(50)
-                                    )
-                                } else {
-                                    Modifier
-                                }
-                            )
-                    ) {
-                        UnstyledIcon(
-                            imageVector = Lucide.AlignHorizontalDistributeCenter,
-                            contentDescription = "Horizontal orientation",
-                            modifier = Modifier.size(24.dp),
-                            tint = if (isHorizontal) Color.Black else Color(0xFF6B7280)
-                        )
-                    }
-
-                    UnstyledButton(
-                        onClick = { isHorizontal = false },
-                        backgroundColor = if (!isHorizontal) Color.White else Color.Transparent,
-                        shape = RoundedCornerShape(50),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
-                        modifier = Modifier
-                            .size(40.dp)
-                            .then(
-                                if (!isHorizontal) {
-                                    Modifier.outline(
-                                        width = 1.dp,
-                                        color = Color(0xFFD1D5DB),
-                                        shape = RoundedCornerShape(50)
-                                    )
-                                } else {
-                                    Modifier
-                                }
-                            )
-                    ) {
-                        UnstyledIcon(
-                            imageVector = Lucide.AlignVerticalDistributeCenter,
-                            contentDescription = "Vertical orientation",
-                            modifier = Modifier.size(24.dp),
-                            tint = if (!isHorizontal) Color.Black else Color(0xFF6B7280)
-                        )
-                    }
-                }
-            }
-        }
-
-        Box(
-            modifier = Modifier.width(200.dp).height(200.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Stack(
-                orientation = if (isHorizontal) {
-                    StackOrientation.Horizontal
-                } else {
-                    StackOrientation.Vertical
-                },
-                spacing = 12.dp
-            ) {
-                Box(
-                    modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    BasicText("0", style = TextStyle(color = Color.White))
-                }
-                Box(
-                    modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    BasicText("1", style = TextStyle(color = Color.White))
-                }
-                Box(
-                    modifier = Modifier.size(48.dp).background(Color(0xFF3B82F6), RoundedCornerShape(4.dp)),
-                    contentAlignment = Alignment.Center
-                ) {
-                    BasicText("2", style = TextStyle(color = Color.White))
-                }
-            }
-        }
-    }
-}
-```
-
-```kotlin
-import com.composeunstyled.Stack
-import com.composeunstyled.StackOrientation
-import com.composeunstyled.currentWindowContainerSize
-```
-
-```kotlin
-val containerSize = currentWindowContainerSize()
-val orientation = if (containerSize.width >= 600.dp) {
-    StackOrientation.Horizontal
-} else {
-    StackOrientation.Vertical
-}
-
-Stack(
-    orientation = orientation,
-    spacing = 16.dp
-) {
-    Box(/*...*/) {
-        BasicText("0")
-    }
-    Box(/*...*/) {
-        BasicText("1")
-    }
-    Box(/*...*/) {
-        BasicText("2")
-    }
-}
-```
+<ApiReference id="stack" />

--- a/docs/pages/tabgroup.md
+++ b/docs/pages/tabgroup.md
@@ -1,9 +1,16 @@
 ---
 title: Tab Group
-description: A foundational component used to create tab groups for navigation in Jetpack Compose and Compose Multiplatform. Comes with accessibility and keyboard navigation baked in.
+description: A tab group component with generic tab keys and keyboard navigation.
 ---
 
 <UnstyledDemo id="tabgroup" />
+
+## Features
+
+- Generic tab keys
+- Horizontal and vertical tab lists
+- Automatic or manual activation
+- Focus handoff to panels
 
 ## Installation
 
@@ -11,208 +18,109 @@ description: A foundational component used to create tab groups for navigation i
 implementation("com.composables:composeunstyled-tab-group")
 ```
 
-## Basic Example
-
-To create a tab group, use the `TabGroup` component.
-
-The `TabList` component hosts the tabs. For each tab include its contents within a `TabPanel` with the same key as the tab.
-
-It is important to pass an ordered list of the keys in the `rememberTabGroupState()`. This order is used for cycling through tabs using the keyboard.
+## Anatomy
 
 ```kotlin
-val categories = listOf("Trending", "Latest", "Popular")
+val tabs = listOf("account", "billing")
 
-val state = rememberTabGroupState(
-    selectedTab = categories.first(),
-    orderedTabs = categories
-)
-
-UnstyledTabGroup(state = state) {
-    TabList {
-        categories.forEach { key ->
-            UnstyledTab(key = key) {
-                BasicText("Tab $key")
-            }
-        }
+UnstyledTabGroup(
+  selectedTab = selectedTab,
+  onSelectedTabChange = onSelectedTabChange,
+  tabs = tabs,
+) {
+  TabList {
+    tabs.forEach { tab ->
+      Tab(tab) {
+      }
     }
+  }
 
-    categories.forEach { key ->
-        UnstyledTabPanel(key = key) {
-            BasicText("Content for $key")
-        }
+  tabs.forEach { tab ->
+    TabPanel(tab) {
     }
+  }
 }
 ```
 
-## Styling
+## Concepts
 
-Every component in Compose Unstyled is renderless. They handle all UX pattern logic, internal state, accessibility (according to ARIA standards), and keyboard interactions for you, but they do not render any UI to the screen.
+- `UnstyledTabGroup` represents a set of tabs and panels grouped by key.
+- `TabList` renders the group of tabs.
+- `Tab` renders one tab inside `TabList`.
+- `TabPanel` renders the panel for the selected tab key.
 
-This is by design so that you can style your components exactly to your needs.
+## Accessibility
 
-Most of the time, styling is done using `Modifiers` of your choice. However, sometimes this is not enough due to the order of the `Modifier`s affecting the visual outcome.
+Keep `tabs` in the same order as the visual tabs. `TabList` uses that order for arrow-key navigation, Home, and End.
 
-For such cases we provide specific styling parameters.
+## Code Examples
 
-## Code Example
+### Selecting tabs manually
 
-### Disabling a Tab
-
-You can disable a tab by setting the `enabled` parameter to `false` in the `Tab` component.
+Use the `selectedTab` parameter to control the active tab:
 
 ```kotlin
-val state = rememberTabGroupState(selectedTab = "Tab 2", orderedTabs = listOf("Tab 1", "Tab 2", "Tab 3"))
+val tabs = listOf("account", "billing")
+var selectedTab by remember { mutableStateOf("account") }
 
-UnstyledTabGroup(state = state) {
-    TabList {
-        UnstyledTab(key = "Tab 1", enabled = false, modifier = Modifier.alpha(0.4f)) {
-            BasicText("Tab 1")
-        }
-        UnstyledTab(key = "Tab 2") {
-            BasicText("Tab 2")
-        }
-        UnstyledTab(key = "Tab 3") {
-            BasicText("Tab 3")
-        }
+UnstyledTabGroup(
+  selectedTab = selectedTab,
+  onSelectedTabChange = { selectedTab = it },
+  tabs = tabs,
+) {
+  TabList {
+    tabs.forEach { tab ->
+      Tab(tab) {
+        BasicText(tab)
+      }
     }
+  }
 
-    UnstyledTabPanel(key = "Tab 1") {
-        BasicText("Contents 1")
-    }
-    UnstyledTabPanel(key = "Tab 2") {
-        BasicText("Contents 2")
-    }
-    UnstyledTabPanel(key = "Tab 3") {
-        BasicText("Contents 3")
-    }
+  TabPanel("account") {
+    BasicText("Account")
+  }
+
+  TabPanel("billing") {
+    BasicText("Billing")
+  }
 }
 ```
 
-### Displaying Tabs Vertically
+### Creating vertical tabs
 
-To display tabs vertically, wrap them into a `Column`. Make sure to pass `Vertical` to the orientation parameter of the `TabList`. This will update the keyboard handling so that users can cycle through tabs by pressing the up and down keys:
+Use the `orientation` parameter on `TabList` to change arrow-key navigation for vertical tabs:
 
 ```kotlin
-val state = rememberTabGroupState(selectedTab = "Tab 2", orderedTabs = listOf("Tab 1", "Tab 2", "Tab 3"))
-
-UnstyledTabGroup(state = state) {
-    UnstyledTabList(orientation = Orientation.Vertical) {
-        Column {
-            UnstyledTab(key = "Tab 1") {
-                BasicText("Tab 1")
-            }
-            UnstyledTab(key = "Tab 2") {
-                BasicText("Tab 2")
-            }
-            UnstyledTab(key = "Tab 3") {
-                BasicText("Tab 3")
-            }
-        }
+TabList(orientation = Orientation.Vertical) {
+  tabs.forEach { tab ->
+    Tab(tab) {
+      BasicText(tab)
     }
-
-    UnstyledTabPanel(key = "Tab 1") {
-        BasicText("Contents 1")
-    }
-    UnstyledTabPanel(key = "Tab 2") {
-        BasicText("Contents 2")
-    }
-    UnstyledTabPanel(key = "Tab 3") {
-        BasicText("Contents 3")
-    }
+  }
 }
 ```
 
-### Specifying the Default Tab
+### Requiring click activation
 
-Specify the default tab by setting the `selectedTab` parameter in `rememberTabGroupState`.
+Use the `activateOnFocus` parameter when arrow-key focus should not select tabs:
 
 ```kotlin
-val state = rememberTabGroupState(selectedTab = "Tab 2", orderedTabs = listOf("Tab 1", "Tab 2", "Tab 3"))
-
-UnstyledTabGroup(state = state) {
-    TabList {
-        UnstyledTab(key = "Tab 1", enabled = false) {
-            BasicText("Tab 1")
-        }
-        UnstyledTab(key = "Tab 2") {
-            BasicText("Tab 2")
-        }
-        UnstyledTab(key = "Tab 3") {
-            BasicText("Tab 3")
-        }
-    }
-
-    UnstyledTabPanel(key = "Tab 1") {
-        BasicText("Content for Tab 1")
-    }
-    UnstyledTabPanel(key = "Tab 2") {
-        BasicText("Content for Tab 2")
-    }
-    UnstyledTabPanel(key = "Tab 3") {
-        BasicText("Content for Tab 3")
-    }
+Tab("billing", activateOnFocus = false) {
+  BasicText("Billing")
 }
 ```
 
-### Changing Tabs Manually
+### Disabling a tab
 
-You can change tabs programmatically by setting the `selectedTab` property of the `TabGroupState`.
+Use the `enabled` parameter to keep a tab visible but unavailable:
 
 ```kotlin
-val state = rememberTabGroupState(selectedTab = "Tab 2", orderedTabs = listOf("Tab 1", "Tab 2", "Tab 3"))
-
-UnstyledButton(onClick = { state.selectedTab = "Tab 3" }) {
-    BasicText("Go to Tab 3")
-}
-
-UnstyledTabGroup(state = state) {
-    TabList {
-        UnstyledTab(key = "Tab 1", enabled = false) {
-            BasicText("Tab 1")
-        }
-        UnstyledTab(key = "Tab 2") {
-            BasicText("Tab 2")
-        }
-        UnstyledTab(key = "Tab 3") {
-            BasicText("Tab 3")
-        }
-    }
-
-    UnstyledTabPanel(key = "Tab 1") {
-        BasicText("Content for Tab 1")
-    }
-    UnstyledTabPanel(key = "Tab 2") {
-        BasicText("Content for Tab 2")
-    }
-    UnstyledTabPanel(key = "Tab 3") {
-        BasicText("Content for Tab 3")
-    }
+Tab(
+  key = "billing",
+  enabled = false,
+) {
+  BasicText("Billing")
 }
 ```
-
-## Keyboard Interactions
-
-For the tab list:
-
-| Key                                   | Description                                                                                             |
-|---------------------------------------|---------------------------------------------------------------------------------------------------------|
-| <div class="keyboard-key">Tab</div>  | When focus moves into the tab list, places focus on the active tab element. When the tab list contains the focus, moves focus to the next element in the page tab sequence outside the tablist, which is the tabpanel unless the first element containing meaningful content inside the tabpanel is focusable. |
-| <div class="keyboard-key">⬅</div>    | Moves focus to the previous tab. If focus is on the first tab, moves focus to the last tab. Optionally, activates the newly focused tab. |
-| <div class="keyboard-key">➡</div>    | Moves focus to the next tab. If focus is on the last tab element, moves focus to the first tab. Optionally, activates the newly focused tab. |
-| <div class="keyboard-key">Space</div> / <div class="keyboard-key">Enter</div> | Activates the tab if it was not activated automatically on focus. |
-| <div class="keyboard-key">Home</div> | Moves focus to the first tab. Optionally, activates the newly focused tab. |
-| <div class="keyboard-key">End</div>  | Moves focus to the last tab. Optionally, activates the newly focused tab. |
-
-<style>
-.keyboard-key {
-  background-color: #EEEEEE;
-  color: black;
-  text-align: center;
-  border-radius: 4px;
-  padding: 2px 6px;
-  margin: 0 2px;
-  display: inline-block;
-}
-</style>
 
 <ApiReference id="tabgroup" />

--- a/docs/pages/textfield.md
+++ b/docs/pages/textfield.md
@@ -1,9 +1,16 @@
 ---
 title: Text Field
-description: A themable component to build text fields with the styling of your choice. Supports placeholders, leading and trailing slots out of the box along with accessibility labels (visual or not).
+description: A text field component with placeholders, transformations, and text styling hooks.
 ---
 
 <UnstyledDemo id="textfield" />
+
+## Features
+
+- State-based text input
+- Placeholder slot
+- Input and output transformations
+- Text style parameters
 
 ## Installation
 
@@ -11,167 +18,91 @@ description: A themable component to build text fields with the styling of your 
 implementation("com.composables:composeunstyled-text-field")
 ```
 
-## Basic Example
-
-To create a text field, use the `TextField` component with `TextFieldState` and use the `TextInput()` component within its content scope.
-
-The `TextField` itself groups together every part of the text field in order to make sense for screen reader technology.
-
-Other than the `TextInput` which handles the part of the text field the user can enter text at, it can contain elements
-such as `Text` for a visual label.
+## Anatomy
 
 ```kotlin
-val state = remember { TextFieldState() }
-
-UnstyledTextField(
-    state = state,
-    singleLine = true
-) {
-    TextInput()
+UnstyledTextField(state = state) {
+  TextInput()
 }
 ```
 
-## Styling
+## Concepts
 
-Every component in Compose Unstyled is renderless. They handle all UX pattern logic, internal state, accessibility (
-according to ARIA standards), and keyboard interactions for you, but they do not render any UI to the screen.
+- `UnstyledTextField` represents the text field container.
+- `TextInput` renders the editable text and optional placeholder.
 
-This is by design so that you can style your components exactly to your needs.
+## Accessibility
 
-Most of the time, styling is done using `Modifiers` of your choice. However, sometimes this is not enough due to the
-order of the `Modifier`s affecting the visual outcome.
-
-For such cases we provide specific styling parameters.
+Use `accessibilityLabel` when the text field does not include a readable label in its content.
 
 ## Code Examples
 
-### Consistent typography through your app
+### Adding placeholder text
 
-It is recommended to use the provided `LocalTextStyle` in order to maintain consistent text styling across your app.
-
-If you need to override a text style for specific cases, you can either override a specific parameter via the `Text`
-modifier or pass an entire different style via the `style` parameter:
+Use the `placeholder` parameter on `TextInput` to render content while the field is empty:
 
 ```kotlin
-val state = remember { TextFieldState() }
+val state = rememberTextFieldState()
 
-CompositionLocalProvider(LocalTextStyle provides TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Medium)) {
-    Column {
-        // this text field will use the provided Text Style
-        UnstyledTextField(
-            state = state,
-        ) {
-            // the provided text style will be used in the text input
-            TextInput()
-        }
-        BasicText("So will this text")
-
-        BasicText("This text is also styled, but slightly modified", style = TextStyle(letterSpacing = 2.sp))
-
-        BasicText("This text is completely different", style = TextStyle())
-    }
+UnstyledTextField(state = state) {
+  TextInput(
+    placeholder = {
+      BasicText("Email")
+    },
+  )
 }
 ```
 
-### Specifying Input Type
+### Creating a single-line text field
 
-You can specify the input type for the `TextField` using the `keyboardOptions` parameter. For example, to specify an
-email input type:
+Use the `lineLimits` parameter to restrict input to one line:
 
 ```kotlin
-val state = remember { TextFieldState() }
-
 UnstyledTextField(
-    state = state,
-    modifier = Modifier.fillMaxWidth(),
-    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
+  state = state,
+  lineLimits = TextFieldLineLimits.SingleLine,
 ) {
-    TextInput(
-        placeholder = { BasicText("Email") }
-    )
+  TextInput()
 }
 ```
 
-### Adding a Trailing Icon
+### Setting the keyboard type
 
-You can add a trailing icon to the `TextField` to provide additional functionality, such as toggling password
-visibility:
+Use the `keyboardOptions` parameter to request a specific software keyboard:
 
 ```kotlin
-val state = remember { TextFieldState() }
-var showPassword by remember { mutableStateOf(false) }
-
 UnstyledTextField(
-    state = state,
+  state = state,
+  keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
 ) {
-    TextInput(
-        placeholder = { BasicText("Password") },
-        trailing = {
-            UnstyledButton(
-                onClick = { showPassword = !showPassword },
-                backgroundColor = Color.Transparent,
-                contentPadding = PaddingValues(4.dp),
-                shape = RoundedCornerShape(4.dp)
-            ) {
-                UnstyledIcon(
-                    imageVector = if (showPassword) EyeOff else Eye,
-                    contentDescription = if (showPassword) "Hide password" else "Show password",
-                    tint = Color(0xFF757575)
-                )
-            }
-        }
-    )
+  TextInput()
 }
 ```
 
-### Handling Password Input
+### Styling entered text
 
-To handle password input, you can use the `visualTransformation` parameter to obscure the text:
+Use the text style parameters to set the style of the editable text:
 
 ```kotlin
-val state = remember { TextFieldState() }
-var showPassword by remember { mutableStateOf(false) }
-
 UnstyledTextField(
-    state = state,
-    visualTransformation = if (showPassword) VisualTransformation.None else PasswordVisualTransformation(),
+  state = state,
+  fontWeight = FontWeight.Medium,
+  textColor = Color.Black,
 ) {
-    TextInput(
-        placeholder = { BasicText("Password") },
-        trailing = {
-            UnstyledButton(
-                onClick = { showPassword = !showPassword },
-                backgroundColor = Color.Transparent,
-                contentPadding = PaddingValues(4.dp),
-                shape = RoundedCornerShape(4.dp)
-            ) {
-                UnstyledIcon(
-                    imageVector = if (showPassword) EyeOff else Eye,
-                    contentDescription = if (showPassword) "Hide password" else "Show password",
-                    tint = Color(0xFF757575)
-                )
-            }
-        }
-    )
+  TextInput()
 }
 ```
 
-### Adding an Invisible Label
+### Labeling an icon-only text field
 
-You can add an invisible label to your text field for accessibility purposes.
-
-This is particularly useful when you want to provide context for screen readers without showing a visual label:
+Use the `accessibilityLabel` parameter when the visible text field has no text label:
 
 ```kotlin
-val state = remember { TextFieldState() }
-
 UnstyledTextField(
-    state = state,
+  state = state,
+  accessibilityLabel = "Search",
 ) {
-    TextInput(
-        label = "Email address", // This label is only visible to screen readers
-        placeholder = { BasicText("Enter your email") }
-    )
+  TextInput()
 }
 ```
 

--- a/docs/pages/toggleswitch.md
+++ b/docs/pages/toggleswitch.md
@@ -1,6 +1,6 @@
 ---
-title: ToggleSwitch
-description: A foundational unstyled component used to implement toggle switches in Jetpack Compose and Compose Multiplatform. Comes with accessibility features baked in and full styling options.
+title: Toggle Switch
+description: A switch component with an animated thumb slot.
 ---
 
 <UnstyledDemo id="toggleswitch" />
@@ -11,147 +11,85 @@ description: A foundational unstyled component used to implement toggle switches
 implementation("com.composables:composeunstyled-toggle-switch")
 ```
 
-## Basic Example
-
-To create a toggle switch, use the `UnstyledSwitch` component. It handles its own state and sets important accessibility
-semantics.
-
-`SwitchThumb` is animated according to the switch's state:
+## Anatomy
 
 ```kotlin
-var toggled by remember { mutableStateOf(false) }
-
 UnstyledSwitch(
-    checked = toggled,
-    onCheckedChange = { toggled = it },
-    modifier = Modifier
-        .width(58.dp)
-        .height(30.dp)
-        .background(Color.Gray, RoundedCornerShape(100))
-        .padding(4.dp),
+  checked = checked,
+  onCheckedChange = onCheckedChange,
 ) {
-    SwitchThumb {
-        Box(
-            Modifier
-                .size(22.dp)
-                .dropShadow(
-                    shape = CircleShape,
-                    shadow = Shadow(
-                        radius = 8.dp,
-                        spread = 0.dp,
-                        color = Color.Black.copy(alpha = 0.14f),
-                        offset = DpOffset(x = 0.dp, y = 2.dp)
-                    )
-                )
-                .background(Color.White, CircleShape)
-        )
-    }
+  SwitchThumb {
+  }
 }
 ```
 
-## Styling
+## Concepts
 
-Every component in Compose Unstyled is renderless. They handle all UX pattern logic, internal state, accessibility (
-according to ARIA standards), and keyboard interactions for you, but they do not render any UI to the screen.
+- `UnstyledSwitch` represents the interactive switch.
+- `SwitchThumb` places thumb content at the start or end of the switch layout.
 
-This is by design so that you can style your components exactly to your needs.
+## Accessibility
 
-Most of the time, styling is done using `Modifiers` of your choice. However, sometimes this is not enough due to the
-order of the `Modifier`s affecting the visual outcome.
-
-For such cases we provide specific styling parameters.
+Use the `onCheckedChange` parameter to make the switch interactive. Set it to `null` only when an
+accessible parent component owns the toggle interaction.
 
 ## Code Examples
 
-### Toggle with Animated Color
+### Toggling a switch
+
+Use the `checked` and `onCheckedChange` parameters to control switch state:
 
 ```kotlin
-var toggled by remember { mutableStateOf(false) }
-
-val animatedColor by animateColorAsState(
-    if (toggled) Color(0xFF2196F3) else Color(0xFFE0E0E0)
-)
+var checked by remember { mutableStateOf(false) }
 
 UnstyledSwitch(
-    checked = toggled,
-    onCheckedChange = { toggled = it },
-    modifier = Modifier
-        .width(58.dp)
-        .height(30.dp)
-        .background(animatedColor, RoundedCornerShape(100))
-        .padding(4.dp),
+  checked = checked,
+  onCheckedChange = { checked = it },
 ) {
-    SwitchThumb {
-        Box(
-            Modifier
-                .size(22.dp)
-                .dropShadow(
-                    shape = CircleShape,
-                    shadow = Shadow(
-                        radius = 8.dp,
-                        spread = 0.dp,
-                        color = Color.Black.copy(alpha = 0.14f),
-                        offset = DpOffset(x = 0.dp, y = 2.dp)
-                    )
-                )
-                .background(Color.White, CircleShape)
-            )
-    }
+  SwitchThumb {
+    BasicText(if (checked) "On" else "Off")
+  }
 }
 ```
 
-### Toggle Switch Manually
+### Animating the switch thumb
 
-You might want to change the `checked` state of the switch manually.
-
-This is a common scenario when the interaction does not start from the switch itself, but rather an entire Row or
-button.
-
-To do this, pass `null` to the `onCheckedChange` parameter. Make sure to use the `selectable()` modifier, as it provides
-important accessibility semantics:
+Use the `animationSpec` parameter on `SwitchThumb` to change the thumb animation:
 
 ```kotlin
-var toggled by remember { mutableStateOf(false) }
-
-Row(
-    Modifier
-        .selectable(
-            selected = toggled,
-            onClick = { toggled = !toggled },
-            indication = null,
-            interactionSource = remember { MutableInteractionSource() },
-            role = Role.Switch
-        ),
-    horizontalArrangement = Arrangement.SpaceBetween,
-    verticalAlignment = Alignment.CenterVertically
+UnstyledSwitch(
+  checked = checked,
+  onCheckedChange = { checked = it },
 ) {
-    BasicText("Toggle Switch")
-    UnstyledSwitch(
-        checked = toggled,
-        onCheckedChange = null,
-        modifier = Modifier
-            .width(58.dp)
-            .height(30.dp)
-            .background(if (toggled) Color.Green else Color.Red, RoundedCornerShape(100))
-            .padding(4.dp),
-    ) {
-        SwitchThumb {
-            Box(
-                Modifier
-                    .size(22.dp)
-                    .dropShadow(
-                        shape = CircleShape,
-                        shadow = Shadow(
-                            radius = 8.dp,
-                            spread = 0.dp,
-                            color = Color.Black.copy(alpha = 0.14f),
-                            offset = DpOffset(x = 0.dp, y = 2.dp)
-                        )
-                    )
-                    .background(Color.White, CircleShape)
-            )
-        }
+  SwitchThumb(animationSpec = tween(durationMillis = 200)) {
+    BasicText(if (checked) "On" else "Off")
+  }
+}
+```
+
+### Moving toggle behavior to a parent
+
+Use the `onCheckedChange` parameter with `null` when a parent toggleable surface owns the
+interaction. This is useful when the switch is only the visual control inside a larger row.
+
+```kotlin
+Row(
+  modifier = Modifier.toggleable(
+    value = checked,
+    role = Role.Switch,
+    onValueChange = { checked = it },
+  ),
+) {
+  BasicText("Notifications")
+
+  UnstyledSwitch(
+    checked = checked,
+    onCheckedChange = null,
+  ) {
+    SwitchThumb {
+      BasicText(if (checked) "On" else "Off")
     }
+  }
 }
 ```
 

--- a/docs/pages/tooltip.md
+++ b/docs/pages/tooltip.md
@@ -1,9 +1,16 @@
 ---
 title: Tooltip
-description: A non-interactive popup component that displays contextual information when an element is focused, hovered, or long-pressed. Comes with tons of customization options such as animation support, arrow (caret) support and handle screen reader announcements out of the box.
+description: A tooltip component for contextual help on hover, focus, and long press.
 ---
 
 <UnstyledDemo id="tooltip" />
+
+## Features
+
+- Focus, hover, and long-press triggers
+- Non-modal tooltip panel
+- Collision-aware positioning
+- Screen reader announcements
 
 ## Installation
 
@@ -11,245 +18,112 @@ description: A non-interactive popup component that displays contextual informat
 implementation("com.composables:composeunstyled-tooltip")
 ```
 
-```kotlin
-import com.composeunstyled.UnstyledTooltip
-import com.composeunstyled.UnstyledTooltipPanel
-```
+## Anatomy
 
 ```kotlin
-@Composable
-fun ArrowUp(modifier: Modifier = Modifier, color: Color) {
-    Canvas(modifier = modifier.size(8.dp, 4.dp)) {
-        val path = Path().apply {
-            moveTo(size.width / 2f, 0f)
-            lineTo(0f, size.height)
-            lineTo(size.width, size.height)
-            close()
-        }
-        drawPath(path, color = color)
-    }
-}
-
-@Composable
-fun TooltipExample() {
-    UnstyledTooltip(
-        placement = RelativeAlignment.TopCenter,
-        panel = {
-            UnstyledTooltipPanel(
-                modifier = Modifier.zIndex(15f),
-                arrow = { direction ->
-                    // Draw your arrow pointing towards the given direction
-                    val degrees = when (direction) {
-                        TooltipArrowDirection.Up -> 0f
-                        TooltipArrowDirection.Down -> 180f
-                        TooltipArrowDirection.Left -> 90f
-                        TooltipArrowDirection.Right -> 270f
-                    }
-                    ArrowUp(Modifier.rotate(degrees), Color.Black.copy(0.8f))
-                }
-            ) {
-                BasicText("This is a tooltip")
-            }
-        }
-    ) {
-        UnstyledButton(onClick = {}) {
-            BasicText("Hover me")
-        }
-    }
-}
-```
-
-## Basic Example
-
-The `Tooltip` component has 2 main slots: its *panel* and its *anchor*.
-
-The *anchor* contains the element to which the tooltip is anchored. When this element has focus, is hovered or
-long-pressed (on touch) the tooltip will be displayed.
-
-The *panel* contains one of the overloads of `TooltipPanel` which renders the content of the tooltip according to the
-`Tooltip`'s internal state.
-
-Tooltips are placed in the same layout as the trigger. This is different
-to [how Tooltips work in Compose Foundation](#unstyled-tooltip-vs-compose-foundation-tooltips), in order to prevent any
-focus and pointer issues. Because of this, you need to use `Modifier.zIndex()` to your *panel* to place it above other
-elements in the same layout.
-
-```kotlin
-UnstyledTooltip(
-    placement = RelativeAlignment.TopCenter,
+PortalHost {
+  UnstyledTooltip(
     panel = {
-        UnstyledTooltipPanel(
-            modifier = Modifier.zIndex(15f),
-            enter = slideInVertically(tween(150), initialOffsetY = { (it * 0.25).toInt() }) +
-                    scaleIn(
-                        animationSpec = tween(150),
-                        transformOrigin = TransformOrigin(0.5f, 1f),
-                        initialScale = 0.65f
-                    ) + fadeIn(tween(150)),
-            exit = fadeOut(tween(250)),
-            arrow = { direction ->
-                val degrees = when (direction) {
-                    TooltipArrowDirection.Up -> 0f
-                    TooltipArrowDirection.Down -> 180f
-                    TooltipArrowDirection.Left -> 90f
-                    TooltipArrowDirection.Right -> 270f
-                }
-                ArrowUp(Modifier.rotate(degrees), Color.Black.copy(0.8f))
-            }
-        ) {
-            Box(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(100))
-                    .background(Color.Black.copy(0.8f))
-                    .padding(vertical = 8.dp, horizontal = 12.dp),
-            ) {
-                BasicText("Notifications", style = TextStyle(color = Color.White))
-            }
-        }
-    }
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-
-    UnstyledButton(
-        onClick = { },
-        contentPadding = PaddingValues(8.dp),
-        shape = CircleShape,
-        modifier = Modifier.focusRing(interactionSource, 1.dp, Color(0xFF3B82F6), CircleShape),
-        interactionSource = interactionSource
-    ) {
-        UnstyledIcon(Lucide.BellDot, contentDescription = null)
-    }
+      TooltipPanel {
+      }
+    },
+  ) {
+  }
 }
 ```
+
+## Concepts
+
+- `PortalHost` provides the destination where tooltip panels are rendered.
+- `UnstyledTooltip` marks the interactive area the user can hover, focus, or long-press to show the
+  tooltip.
+  - The `anchor` slot renders the content on which the tooltip will be anchored to. 
+  - The `panel` slot renders the floating content that is shown for the anchor.
+- `TooltipPanel` renders the floating tooltip content.
+
+## Usage Considerations
+
+`UnstyledTooltip` does not make the anchor focusable. Use focusable content in the anchor slot when
+the tooltip needs to show on keyboard focus.
+
+## Accessibility
+
+`TooltipPanel` automatically announces the tooltip content when the tooltip becomes visible.
 
 ## Code Examples
 
-### Styling the Tooltip
+### Positioning a tooltip
 
-The `TooltipPanel` composable contains styling properties such as *backgroundColor*, *contentColor*, *shape*  and
-*contentPadding* for easy styling.
-
-```kotlin
-UnstyledTooltip(
-    placement = RelativeAlignment.TopCenter,
-    panel = {
-        UnstyledTooltipPanel(
-            modifier = Modifier.zIndex(15f),
-            backgroundColor = Color(0xFF1E293B),
-            shape = RoundedCornerShape(8.dp),
-            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp)
-        ) {
-            BasicText("Styled tooltip")
-        }
-    }
-) {
-    UnstyledButton(onClick = {}) {
-        BasicText("Hover me")
-    }
-}
-```
-
-### Positioning the Tooltip
-
-Pass the relative alignment you want to the `Tooltip`'s *placement* property:
+Use the `side`, `alignment`, `sideOffset`, and `alignmentOffset` parameters to place the tooltip
+relative to the anchor:
 
 ```kotlin
 UnstyledTooltip(
-    placement = RelativeAlignment.TopEnd,
-    panel = {
-        TooltipPanel {
-            BasicText("This is a tooltip")
-        }
+  side = AnchorSide.Bottom,
+  alignment = AnchorAlignment.Center,
+  sideOffset = 8.dp,
+  panel = {
+    TooltipPanel {
+      BasicText("More information")
     }
+  },
 ) {
-    UnstyledButton(onClick = {}) {
-        BasicText("Hover me")
-    }
+  BasicText("Help")
 }
 ```
 
-### Tooltip with Arrow (Caret)
+### Delaying tooltip hover
 
-Use the `TooltipPanel` with the *arrow* parameter. The *arrow* lambda gives you the `TooltipArrowDirection` which the
-arrow needs to be pointing towards.
-
-We will always place the arrow between the `anchor` and the `panel` centering it to the respective direction.
-
-```kotlin
-@Composable
-fun ArrowUp(modifier: Modifier = Modifier, color: Color) {
-    Canvas(modifier = modifier.size(8.dp, 4.dp)) {
-        val path = Path().apply {
-            moveTo(size.width / 2f, 0f)
-            lineTo(0f, size.height)
-            lineTo(size.width, size.height)
-            close()
-        }
-        drawPath(path, color = color)
-    }
-}
-
-UnstyledTooltip(
-    placement = RelativeAlignment.BottomCenter,
-    panel = {
-        UnstyledTooltipPanel(
-            modifier = Modifier.zIndex(15f),
-            arrow = { direction ->
-                // Draw your arrow pointing towards the given direction
-                val degrees = when (direction) {
-                    TooltipArrowDirection.Up -> 0f
-                    TooltipArrowDirection.Down -> 180f
-                    TooltipArrowDirection.Left -> 90f
-                    TooltipArrowDirection.Right -> 270f
-                }
-                ArrowUp(Modifier.rotate(degrees), Color.Black)
-            }
-        ) {
-            BasicText("Tooltip with arrow")
-        }
-    }
-) {
-    UnstyledButton(onClick = {}) {
-        BasicText("Hover me")
-    }
-}
-```
-
-### Animating the Tooltip
-
-Pass the respective animation specs you want in the `TooltipPanel`'s *enter* and *exit* parameters:
+Use the `hoverDelayMillis` parameter to wait before showing the tooltip on hover:
 
 ```kotlin
 UnstyledTooltip(
-    placement = RelativeAlignment.TopCenter,
-    panel = {
-        UnstyledTooltipPanel(
-            modifier = Modifier.zIndex(15f),
-            enter = fadeIn(animationSpec = tween(300)),
-            exit = fadeOut(animationSpec = tween(300))
-        ) {
-            BasicText("This tooltip fades in and out")
-        }
+  hoverDelayMillis = 500,
+  panel = {
+    TooltipPanel {
+      BasicText("More information")
     }
+  },
 ) {
-    UnstyledButton(onClick = {}) {
-        BasicText("Hover me")
-    }
+  BasicText("Help")
 }
 ```
 
-## Unstyled Tooltip vs Compose Foundation Tooltips
+### Changing the long-press duration
 
-Tooltips in Compose Foundation are implemented using Popups. Popups do not allow pointer events behind them. This can
-cause weird glitches when the Tooltip is right above the trigger and mouse overed.
+Use the `longPressShowDurationMillis` parameter to change how long the tooltip stays visible after a
+long press:
 
-Unstyled Tooltips are placed in the same layout as its trigger, and do not use Popups. As a result, there are no
-weird focus or pointer issues.
+```kotlin
+UnstyledTooltip(
+  longPressShowDurationMillis = 3_000,
+  panel = {
+    TooltipPanel {
+      BasicText("More information")
+    }
+  },
+) {
+  BasicText("Help")
+}
+```
 
-## Keyboard Interactions
+### Animating a tooltip panel
 
-| Key                                    | Description                               |
-|----------------------------------------|-------------------------------------------|
-| <div class="keyboard-key">Escape</div> | Dismisses the tooltip when it is visible. |
+Use the `enter` and `exit` parameters on `TooltipPanel` to animate the tooltip panel:
+
+```kotlin
+UnstyledTooltip(
+  panel = {
+    TooltipPanel(
+      enter = fadeIn(),
+      exit = fadeOut(),
+    ) {
+      BasicText("More information")
+    }
+  },
+) {
+  BasicText("Help")
+}
+```
 
 <ApiReference id="tooltip" />

--- a/docs/pages/tristatecheckbox.md
+++ b/docs/pages/tristatecheckbox.md
@@ -1,6 +1,6 @@
 ---
 title: TriStateCheckbox
-description: A foundational component for creating three-state checkboxes that can be checked, unchecked, or in an indeterminate state. Perfect for "select all" scenarios and hierarchical selections. Accessible out of the box and fully renderless, so that you can apply any styling you like.
+description: A three-state checkbox component for checked, unchecked, and indeterminate values.
 ---
 
 <UnstyledDemo id="tristatecheckbox" />
@@ -11,127 +11,70 @@ description: A foundational component for creating three-state checkboxes that c
 implementation("com.composables:composeunstyled-tri-state-checkbox")
 ```
 
-## Basic Example
-
-To create a tri-state checkbox use the `TriStateCheckbox` component. The checkbox supports three states: `On`, `Off`, and `Indeterminate`. You can cycle through states by clicking or pressing Enter/Space while focused.
-
-The `checkIcon` composable receives the current `ToggleableState` and should render the appropriate icon for each state.
+## Anatomy
 
 ```kotlin
-var triState by remember { mutableStateOf(ToggleableState.Off) }
-
 UnstyledTriStateCheckbox(
-    value = triState,
-    onClick = {
-        triState = when (triState) {
-            ToggleableState.Off -> ToggleableState.On
-            ToggleableState.On -> ToggleableState.Indeterminate
-            ToggleableState.Indeterminate -> ToggleableState.Off
-        }
-    },
-    shape = RoundedCornerShape(4.dp),
-    backgroundColor = Color.White,
-    borderWidth = 1.dp,
-    borderColor = Color.Black.copy(0.33f),
-    modifier = Modifier.size(24.dp)
-) { state ->
-    when (state) {
-        ToggleableState.On -> UnstyledIcon(Check, contentDescription = null)
-        ToggleableState.Indeterminate -> UnstyledIcon(Minus, contentDescription = null)
-        ToggleableState.Off -> Unit // No icon shown
-    }
+  value = value,
+  onClick = onClick,
+) {
+  StateIndicator {
+  }
 }
 ```
 
-## Styling
+## Concepts
 
-The TriStateCheckbox is fully renderless and handles all UX logic, accessibility and keyboard interactions for you, but does not display any information on the screen by default.
+- `UnstyledTriStateCheckbox` represents the tri-state checkbox interaction target.
+- `StateIndicator` renders content for the current `ToggleableState`.
 
-The `shape` of the checkbox is used to clip the checkbox and applies to both the background and border.
+## Accessibility
 
-The `borderColor` and `borderWidth` parameters place a border around the checkbox, taking the given shape into consideration.
-
-The `backgroundColor` sets the color of the checkbox's surface.
-
-The `checkIcon` composable is where you define what gets displayed for each state. It receives the current `ToggleableState` as a parameter.
+Use tri-state checkboxes for parent selection controls where only some child items are selected.
 
 ## Code Examples
 
-### Select All Pattern
+### Rendering each checkbox state
 
-A common use case for TriStateCheckbox is implementing "select all" functionality with a group of child checkboxes.
+Use the `StateIndicator` component to render content for each `ToggleableState`:
 
 ```kotlin
-val checkboxOptions = listOf("Option 1", "Option 2", "Option 3")
-var selected by remember { mutableStateOf(List(checkboxOptions.size) { false }) }
-
-val triState = when {
-    selected.all { it } -> ToggleableState.On
-    selected.none { it } -> ToggleableState.Off
-    else -> ToggleableState.Indeterminate
-}
-
-Column {
-    // Parent TriState checkbox - "Select All"
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        UnstyledTriStateCheckbox(
-            value = triState,
-            onClick = {
-                val newState = when (triState) {
-                    ToggleableState.Off -> true
-                    ToggleableState.Indeterminate -> true
-                    ToggleableState.On -> false
-                }
-                selected = List(checkboxOptions.size) { newState }
-            },
-            shape = RoundedCornerShape(4.dp),
-            backgroundColor = Color.White,
-            borderWidth = 1.dp,
-            borderColor = Color.Black.copy(0.33f),
-            modifier = Modifier.size(24.dp),
-            contentDescription = "Select all options"
-        ) { state ->
-            when (state) {
-                ToggleableState.On -> UnstyledIcon(Check, contentDescription = null)
-                ToggleableState.Indeterminate -> UnstyledIcon(Minus, contentDescription = null)
-                ToggleableState.Off -> Unit
-            }
-        }
-        Spacer(Modifier.width(12.dp))
-        BasicText("Select All")
+UnstyledTriStateCheckbox(
+  value = value,
+  onClick = { toggleParent() },
+) {
+  StateIndicator { state ->
+    when (state) {
+      ToggleableState.On -> BasicText("Selected")
+      ToggleableState.Off -> BasicText("Not selected")
+      ToggleableState.Indeterminate -> BasicText("Partially selected")
     }
-
-    // Child checkboxes
-    checkboxOptions.forEachIndexed { index, option ->
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            UnstyledCheckbox(
-                checked = selected[index],
-                onCheckedChange = { checked ->
-                    selected = selected.toMutableList().apply {
-                        this[index] = checked
-                    }
-                },
-                shape = RoundedCornerShape(4.dp),
-                backgroundColor = Color.White,
-                borderWidth = 1.dp,
-                borderColor = Color.Black.copy(0.33f),
-                modifier = Modifier.size(24.dp),
-                contentDescription = option
-            ) {
-                UnstyledIcon(Check, contentDescription = null)
-            }
-            Spacer(Modifier.width(12.dp))
-            BasicText(option)
-        }
-    }
+  }
 }
 ```
 
-## Keyboard Interactions
+### Building a select-all checkbox
 
-| Key                                   | Description                                                   |
-|---------------------------------------|---------------------------------------------------------------|
-| <div class="keyboard-key">Enter</div> | Triggers the onClick callback |
-| <div class="keyboard-key">Space</div> | Triggers the onClick callback |
+Use the `ToggleableState.Indeterminate` value when only some items are selected:
+
+```kotlin
+val selectedCount = selectedItems.count()
+val parentState = when (selectedCount) {
+  0 -> ToggleableState.Off
+  items.size -> ToggleableState.On
+  else -> ToggleableState.Indeterminate
+}
+
+UnstyledTriStateCheckbox(
+  value = parentState,
+  onClick = {
+    selectedItems = if (parentState == ToggleableState.On) emptySet() else items.toSet()
+  },
+) {
+  StateIndicator { state ->
+    BasicText(state.toString())
+  }
+}
+```
 
 <ApiReference id="tristatecheckbox" />


### PR DESCRIPTION
## Summary
- Refresh component docs to the new API documentation structure
- Add focused demos for checkbox and bottom sheet examples
- Tighten examples, concepts, accessibility notes, and API reference placement across component pages

## Verification
- ./gradlew jvmTest spotlessCheck