### PR TITLE
Fix dropdown menu initial placement

### DIFF
--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -108,16 +109,13 @@ fun UnstyledDropdownMenu(
     sideOffset = sideOffset,
     alignmentOffset = alignmentOffset,
   )
-  val transitionState = remember { MutableTransitionState(false) }
+  val transitionState = remember { MutableTransitionState(expanded) }
+  SideEffect { transitionState.targetState = expanded }
   val state = remember(onExpandedChange, transitionState) {
     DropdownMenuState(
       onExpandedChange = onExpandedChange,
       transitionState = transitionState,
     )
-  }
-
-  LaunchedEffect(expanded) {
-    transitionState.targetState = expanded
   }
 
   Box(

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -21,8 +21,11 @@
  */
 package com.composeunstyled
 
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -33,6 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsFocused
@@ -43,11 +48,51 @@ import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DropdownMenuPanelTest {
+  @Test
+  fun expandedMenuPlacesPanelAtAnchorPositionOnFirstFrame() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val panelPositions = mutableListOf<Int>()
+
+    setContent {
+      UnstyledDropdownMenu(
+        expanded = true,
+        onExpandedChange = {},
+        alignment = AnchorAlignment.End,
+        panel = {
+          DropdownMenuPanel(
+            enter = EnterTransition.None,
+            exit = ExitTransition.None,
+          ) {
+            BasicText(
+              text = "Menu content",
+              modifier = Modifier
+                .size(width = 60.dp, height = 40.dp)
+                .onPlaced { coordinates ->
+                  panelPositions += coordinates.positionInWindow().x.toInt()
+                },
+            )
+          }
+        },
+        anchor = {
+          BasicText(
+            text = "Anchor",
+            modifier = Modifier.size(width = 80.dp, height = 40.dp),
+          )
+        },
+      )
+    }
+    mainClock.advanceTimeByFrame()
+
+    assertEquals(listOf(20), panelPositions)
+  }
+
   @Test
   fun panelWithoutMenuStateIsHidden() = runComposeUiTest {
     setContent {


### PR DESCRIPTION
## Summary
- initialize dropdown transition state from the current expanded value
- update the transition target in a side effect so the popup measures visible content before placement
- add a regression test for first-frame end-aligned placement

Fixes #308

## Testing
- ./gradlew :composeunstyled-dropdown-menu:jvmTest spotlessCheck