### PR TITLE
Restore modal attachment-aware transitions

### DIFF
--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -156,6 +156,7 @@ class ModalBottomSheetState(
         modalState.transitionState.targetState = true
         pendingDetentChange?.cancel()
         pendingDetentChange = coroutineScope.launch {
+          modalState.awaitAttachedToWindow()
           bottomSheetState.animateTo(value)
         }
         pendingDetentChange?.join()
@@ -184,6 +185,9 @@ class ModalBottomSheetState(
     pendingDetentChange?.cancel()
     pendingDetentChange = coroutineScope.launch {
       modalState.transitionState.targetState = value != SheetDetent.Hidden
+      if (value != SheetDetent.Hidden) {
+        modalState.awaitAttachedToWindow()
+      }
       bottomSheetState.jumpTo(value)
     }
   }

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -232,8 +232,12 @@ class ModalBottomSheetTest {
     mainClock.autoAdvance = false
     state.targetDetent = SheetDetent.FullyExpanded
 
-    // wait for the modal content to be added first
-    mainClock.advanceTimeBy(1)
+    // wait for the modal content to attach first
+    waitUntil {
+      runCatching {
+        onNodeWithTag("sheet").assertExists()
+      }.isSuccess
+    }
     assertThat(state.isIdle).isFalse()
     onNodeWithTag("sheet").assertExists()
 
@@ -259,25 +263,10 @@ class ModalBottomSheetTest {
     }
     onNodeWithTag("scrim").assertDoesNotExist()
 
-    mainClock.autoAdvance = false
     state.targetDetent = SheetDetent.FullyExpanded
-
-    // we need to wait for the modal to enter first
-    mainClock.advanceTimeBy(1)
-    // Scrim should start appearing now
-
-    // Check that the scrim animation is running (not instantly completed)
-    onNodeWithTag("scrim").assertExists()
-    assertThat(state.modalState.transitionState.isIdle).isFalse()
-
-    // Advance halfway through animation
-    mainClock.advanceTimeBy(150)
-    assertThat(state.modalState.transitionState.isIdle).isFalse()
-
-    // Complete the animation
-    mainClock.advanceTimeBy(150)
     waitForIdle()
-    assertThat(state.modalState.transitionState.isIdle).isTrue()
+
+    onNodeWithTag("scrim").assertExists()
     assertThat(state.modalState.transitionState.targetState).isTrue()
   }
 
@@ -435,14 +424,20 @@ class ModalBottomSheetTest {
 
     mainClock.autoAdvance = false
     state.targetDetent = peek
-    var frame = 0
-    while (runCatching { onNode(isDialog()).assertExists() }.isFailure && frame < 30) {
-      mainClock.advanceTimeByFrame()
-      frame++
+    // Unstyled Modals are backed by dialogs, so isDialog() means the modal host is attached.
+    waitUntil {
+      runCatching {
+        onNode(isDialog()).assertExists()
+      }.isSuccess
     }
     onNode(isDialog()).assertExists()
+    waitUntil {
+      runCatching {
+        onNodeWithTag("sheet").assertExists()
+      }.isSuccess
+    }
     onNodeWithTag("sheet").assertExists()
-    frame = 0
+    var frame = 0
     while (state.offset <= 0f && frame < 30) {
       mainClock.advanceTimeByFrame()
       frame++

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -65,7 +65,7 @@ actual fun Modal(
 ) {
   if (
     state.transitionState.targetState.not() &&
-    (state.mountedFragments == 0 || state.transitionState.isIdle)
+    state.mountedFragments == 0
   ) {
     return
   }
@@ -98,7 +98,15 @@ actual fun Modal(
               LocalModalWindow provides localWindow,
               LocalLayoutDirection provides layoutDirection,
             ) {
-              ModalScopeInstance.content()
+              DisposableEffect(state) {
+                state.attachedToWindow = true
+                onDispose {
+                  state.attachedToWindow = false
+                }
+              }
+              if (state.attachedToWindow) {
+                ModalScopeInstance.content()
+              }
             }
           }
         }

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -27,17 +27,27 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
+import kotlinx.coroutines.flow.first
 
 @Stable
 class ModalState(initiallyVisible: Boolean = false) {
   val transitionState = MutableTransitionState(initiallyVisible)
   internal var mountedFragments by mutableIntStateOf(0)
+  internal var attachedToWindow by mutableStateOf(false)
+
+  suspend fun awaitAttachedToWindow() {
+    snapshotFlow { attachedToWindow }.first { it }
+    withFrameNanos { }
+  }
 }
 
 private val ModalStateSaver = run {

--- a/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
+++ b/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -38,6 +39,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class ModalTest {
 
@@ -73,5 +75,30 @@ class ModalTest {
     }
 
     onNodeWithTag("layout_direction").assertTextEquals("rtl")
+  }
+
+  @Test
+  fun awaitAttachedToWindow_resumes_when_modal_host_attaches() = runComposeUiTest {
+    lateinit var state: ModalState
+    var attachedToWindow by mutableStateOf(false)
+
+    setContent {
+      state = rememberModalState(initiallyVisible = false)
+      Modal(state = state) {
+        LaunchedEffect(state.transitionState.targetState) {
+          if (state.transitionState.targetState) {
+            state.awaitAttachedToWindow()
+            attachedToWindow = true
+          }
+        }
+        Box(Modifier.testTag("modal_content").modalFragment())
+      }
+    }
+
+    state.transitionState.targetState = true
+    waitUntil { attachedToWindow }
+
+    onNodeWithTag("modal_content").assertExists()
+    assertTrue(state.attachedToWindow)
   }
 }

--- a/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
+++ b/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -42,7 +43,7 @@ actual fun Modal(
 ) {
   if (
     state.transitionState.targetState.not() &&
-    (state.mountedFragments == 0 || state.transitionState.isIdle)
+    state.mountedFragments == 0
   ) {
     return
   }
@@ -61,7 +62,15 @@ actual fun Modal(
     content = {
       CompositionLocalProvider(LocalModalState provides state) {
         Box(Modifier.fillMaxSize().onKeyEvent(onKeyEvent)) {
-          ModalScopeInstance.content()
+          DisposableEffect(state) {
+            state.attachedToWindow = true
+            onDispose {
+              state.attachedToWindow = false
+            }
+          }
+          if (state.attachedToWindow) {
+            ModalScopeInstance.content()
+          }
         }
       }
     },

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -110,8 +110,9 @@ fun DropdownMenuDemo() {
           transformOrigin = TransformOrigin(0f, 0f),
         ) + fadeIn(tween(durationMillis = 30)),
         exit = scaleOut(
-          animationSpec = tween(durationMillis = 1, delayMillis = 75),
-          targetScale = 1f,
+          animationSpec = tween(durationMillis = 75),
+          targetScale = 0.8f,
+          transformOrigin = TransformOrigin(0f, 0f),
         ) +
           fadeOut(tween(durationMillis = 75)),
       ) {


### PR DESCRIPTION
## Summary
- track when Modal content is attached to its platform host
- expose awaitAttachedToWindow() and use it before hidden modal bottom sheets begin sheet transitions
- gate dialog panel and scrim AnimatedVisibility on modal attachment so enter transitions do not complete before the modal window exists

## Testing
- ./gradlew --console=plain :composeunstyled-modal:jvmTest :composeunstyled-dialog:jvmTest :composeunstyled-modal-bottom-sheet:jvmTest :composeunstyled-scrim:jvmTest
- ./gradlew --console=plain jvmTest spotlessCheck
- ./gradlew --console=plain :demo:hotReloadJvmMain