### PR TITLE
Add modal recomposition performance test

### DIFF
--- a/composeunstyled-modal/build.gradle.kts
+++ b/composeunstyled-modal/build.gradle.kts
@@ -95,6 +95,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(projects.composeunstyledTest)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-modal/src/commonTest/kotlin/ModalRecompositionTest.kt
+++ b/composeunstyled-modal/src/commonTest/kotlin/ModalRecompositionTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.composeunstyled.test.runComposeRecompositionTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ModalRecompositionTest {
+
+  @Test
+  fun parentRecompositionRecomposesVisibleModalContentOnce() = runComposeRecompositionTest {
+    var parentState by mutableIntStateOf(0)
+
+    setContent {
+      parentState
+      Modal(state = rememberModalState(initiallyVisible = true)) {
+        RecompositionCount("modal-content")
+        Box(Modifier.size(40.dp))
+      }
+    }
+
+    waitUntil { recompositionCount("modal-content") > 0 }
+    resetRecompositionCounts("modal-content")
+
+    parentState++
+    waitForIdle()
+
+    assertEquals(1, recompositionCount("modal-content"))
+  }
+}


### PR DESCRIPTION
## Summary
- Add a modal recomposition test that records the current visible modal content recomposition count when parent state changes
- Add the composeunstyled-test dependency to the modal module tests

## Tests
- ./gradlew --console=plain :composeunstyled-modal:jvmTest
- ./gradlew --console=plain jvmTest spotlessCheck