### PR TITLE
Add TooltipHost for tooltip panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added recomposition test coverage for Bottom Sheet, Modal Bottom Sheet, and Toggle Switch.
 - Added screenshot test coverage for Bottom Sheet and Modal Bottom Sheet demos.
+- Added `TooltipHost` as the destination for tooltip panels.
 
 ### Changed
 
+- `composeunstyled-tooltip` no longer exposes the Portal API transitively. Use `TooltipHost` for
+  tooltips, or add `composeunstyled-portal` directly if you use `PortalHost` or `Portal`.
 - `UnstyledIcon` now defaults `contentDescription` to `null` for decorative icons.
 
 ### Fixed

--- a/composeunstyled-tooltip/build.gradle.kts
+++ b/composeunstyled-tooltip/build.gradle.kts
@@ -80,7 +80,7 @@ kotlin {
       dependencies {
         implementation(libs.compose.foundation)
         api(projects.composeunstyledAnchored)
-        api(projects.composeunstyledPortal)
+        implementation(projects.composeunstyledPortal)
         implementation(projects.composeunstyledBuildModifier)
         implementation(projects.composeunstyledEscapeHandler)
       }

--- a/composeunstyled-tooltip/src/androidInstrumentedTest/kotlin/Tooltip.androidTest.kt
+++ b/composeunstyled-tooltip/src/androidInstrumentedTest/kotlin/Tooltip.androidTest.kt
@@ -44,7 +44,7 @@ class TooltipTest {
 
   private fun ComposeUiTest.setPaddedContent(content: @Composable () -> Unit) {
     setContent {
-      PortalHost {
+      TooltipHost {
         Box(Modifier.padding(100.dp)) {
           content()
         }

--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
@@ -82,6 +82,17 @@ private enum class TooltipFocusTrigger {
 }
 
 @Composable
+fun TooltipHost(
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  PortalHost(
+    modifier = modifier,
+    content = content,
+  )
+}
+
+@Composable
 fun UnstyledTooltip(
   enabled: Boolean = true,
   panel: @Composable TooltipScope.() -> Unit,

--- a/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
@@ -70,7 +70,7 @@ class FloatingContentTest {
   }
 
   @Test
-  fun rendersNoFloatingContentWithoutPortalHost() = runComposeUiTest {
+  fun rendersNoFloatingContentWithoutTooltipHost() = runComposeUiTest {
     setContent {
       FloatingContent(
         floatingContent = {
@@ -95,7 +95,7 @@ class FloatingContentTest {
     var bottomStartY = 0f
 
     setContent {
-      PortalHost {
+      TooltipHost {
         FloatingContent(
           side = side,
           alignment = AnchorAlignment.Start,
@@ -132,7 +132,7 @@ class FloatingContentTest {
   fun floatingContentClampsToWindowBounds() = runComposeUiTest {
     // FloatingContent clamps to window bounds like a Popup
     setContent {
-      PortalHost {
+      TooltipHost {
         FloatingContent(
           side = AnchorSide.Top,
           alignment = AnchorAlignment.Start,
@@ -167,7 +167,7 @@ class FloatingContentTest {
     // When floating content is larger than the window,
     // it should be clamped to start at 0 to maximize visible area
     setContent {
-      PortalHost {
+      TooltipHost {
         FloatingContent(
           side = AnchorSide.Bottom,
           alignment = AnchorAlignment.Start,

--- a/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
@@ -44,7 +44,7 @@ class TooltipCommonTest {
 
   fun ComposeUiTest.setPaddedContent(content: @Composable () -> Unit) {
     setContent {
-      PortalHost {
+      TooltipHost {
         Box(Modifier.padding(100.dp)) {
           content()
         }

--- a/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
+++ b/composeunstyled-tooltip/src/jvmTest/kotlin/TooltipJvm.test.kt
@@ -53,7 +53,7 @@ class TooltipJvmTest {
 
   fun ComposeUiTest.setPaddedContent(content: @Composable () -> Unit) {
     setContent {
-      PortalHost {
+      TooltipHost {
         Box(Modifier.padding(100.dp)) {
           content()
         }
@@ -230,7 +230,7 @@ class TooltipJvmTest {
   @Test
   fun edgeCaseTooltipOnTopOnTarget() = runComposeUiTest {
     setContent {
-      PortalHost {
+      TooltipHost {
         UnstyledTooltip(
           panel = {
             TooltipPanel {

--- a/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3Catalogue.kt
+++ b/demo-material-impl/src/commonMain/kotlin/com/composeunstyled/demo/materialimpl/Material3Catalogue.kt
@@ -70,8 +70,8 @@ import com.composables.icons.materialsymbols.rounded.Help
 import com.composables.icons.materialsymbols.rounded.Info
 import com.composables.icons.materialsymbols.rounded.Settings
 import com.composables.icons.materialsymbols.rounded.Star
-import com.composeunstyled.PortalHost
 import com.composeunstyled.SheetDetent
+import com.composeunstyled.TooltipHost
 import com.composeunstyled.rememberModalBottomSheetState
 import androidx.compose.material3.AlertDialog as M3AlertDialog
 import androidx.compose.material3.Button as M3Button
@@ -112,7 +112,7 @@ import androidx.compose.material3.rememberModalBottomSheetState as rememberM3Mod
 @Composable
 fun Material3ImplementationDemo() {
   MaterialTheme {
-    PortalHost(Modifier.fillMaxSize()) {
+    TooltipHost(Modifier.fillMaxSize()) {
       val navController = rememberNavController()
       Surface(
         modifier = Modifier.fillMaxSize(),

--- a/demo/src/commonMain/kotlin/TooltipDemo.kt
+++ b/demo/src/commonMain/kotlin/TooltipDemo.kt
@@ -56,7 +56,7 @@ import com.composables.icons.lucide.BellDot
 import com.composables.icons.lucide.Lucide
 import com.composeunstyled.AnchorAlignment
 import com.composeunstyled.AnchorSide
-import com.composeunstyled.PortalHost
+import com.composeunstyled.TooltipHost
 import com.composeunstyled.TooltipPanel
 import com.composeunstyled.TooltipPlacement
 import com.composeunstyled.UnstyledButton
@@ -66,7 +66,7 @@ import com.composeunstyled.focusRing
 
 @Composable
 fun TooltipDemo() {
-  PortalHost(Modifier.fillMaxSize()) {
+  TooltipHost(Modifier.fillMaxSize()) {
     Box(
       modifier = Modifier.fillMaxSize(),
       contentAlignment = Alignment.Center,

--- a/docs/api-descriptions.json
+++ b/docs/api-descriptions.json
@@ -483,6 +483,8 @@
     "SwitchThumb.content": "Thumb content."
   },
   "tooltip": {
+    "TooltipHost.modifier": "Modifier to be applied to the tooltip host.",
+    "TooltipHost.content": "Content that can render tooltip panels into this host.",
     "Tooltip.enabled": "Whether the tooltip is enabled. When disabled, the tooltip will not show.",
     "enabled": "Whether the tooltip is enabled. When disabled, the tooltip will not show.",
     "Tooltip.panel": "A composable function that defines the tooltip content panel.",

--- a/docs/pages/tooltip.md
+++ b/docs/pages/tooltip.md
@@ -21,7 +21,7 @@ implementation("com.composables:composeunstyled-tooltip")
 ## Anatomy
 
 ```kotlin
-PortalHost {
+TooltipHost {
   UnstyledTooltip(
     panel = {
       TooltipPanel {
@@ -34,11 +34,11 @@ PortalHost {
 
 ## Concepts
 
-- `PortalHost` provides the destination where tooltip panels are rendered.
+- `TooltipHost` provides the destination where tooltip panels are rendered.
 - `UnstyledTooltip` marks the interactive area the user can hover, focus, or long-press to show the
   tooltip.
-  - The `anchor` slot renders the content on which the tooltip will be anchored to. 
-  - The `panel` slot renders the floating content that is shown for the anchor.
+- The `anchor` slot renders the content on which the tooltip will be anchored to.
+- The `panel` slot renders the floating content that is shown for the anchor.
 - `TooltipPanel` renders the floating tooltip content.
 
 ## Usage Considerations

--- a/playground-android/src/main/kotlin/com/composeunstyled/demo/android/DemoAndroidActivity.kt
+++ b/playground-android/src/main/kotlin/com/composeunstyled/demo/android/DemoAndroidActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.sp
 import com.composeunstyled.AnchorAlignment
 import com.composeunstyled.AnchorSide
 import com.composeunstyled.Text
+import com.composeunstyled.TooltipHost
 import com.composeunstyled.TooltipPanel
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledTooltip
@@ -54,7 +55,9 @@ class DemoAndroidActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
     setContent {
       AppTheme {
-        TooltipCrashRepro()
+        TooltipHost(Modifier.fillMaxSize()) {
+          TooltipCrashRepro()
+        }
       }
     }
   }

--- a/scripts/generate-compose-unstyled-api.mjs
+++ b/scripts/generate-compose-unstyled-api.mjs
@@ -139,6 +139,7 @@ const apiReferences = {
   ],
   tooltip: [
     source('composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt', [
+      fn('TooltipHost'),
       fn('UnstyledTooltip'),
       cls('TooltipPlacement'),
       fn('TooltipPanel', 'TooltipScope.TooltipPanel'),


### PR DESCRIPTION
## Summary
- add TooltipHost as the tooltip-owned public host abstraction
- implement TooltipHost as a thin wrapper around the existing PortalHost internals
- stop exposing composeunstyled-portal transitively from composeunstyled-tooltip; users should use TooltipHost or depend on composeunstyled-portal directly
- update tooltip tests, docs, and demos to use TooltipHost

## Tests
- ./gradlew jvmTest spotlessCheck :demo-material-impl:hotReloadJvmMain :composeunstyled-tooltip:connectedDebugAndroidTest