### PR TITLE
Migrate tests to AssertK assertions

### DIFF
--- a/composeunstyled-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-bottom-sheet/build.gradle.kts
@@ -85,6 +85,7 @@ kotlin {
     }
 
     androidInstrumentedTest.dependencies {
+      implementation(libs.assertk)
       implementation(libs.androidx.compose.test)
       implementation(libs.androidx.compose.test.manifest)
       implementation(libs.androidx.espresso)

--- a/composeunstyled-bottom-sheet/src/androidInstrumentedTest/kotlin/BottomSheet.androidTest.kt
+++ b/composeunstyled-bottom-sheet/src/androidInstrumentedTest/kotlin/BottomSheet.androidTest.kt
@@ -37,8 +37,9 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isFalse
 import kotlin.test.Test
-import kotlin.test.assertFalse
 
 class BottomSheetTest {
 
@@ -86,6 +87,6 @@ class BottomSheetTest {
       )
     }
 
-    assertFalse(sheetState.isIdle)
+    assertThat(sheetState.isIdle).isFalse()
   }
 }

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -68,17 +68,18 @@ import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import androidx.compose.ui.unit.dp
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isCloseTo
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 class BottomSheetCommonTest {
   private val DensityTolerance = 0.5.dp
@@ -159,7 +160,7 @@ class BottomSheetCommonTest {
 
   @Test
   fun throws_exception_when_creating_state_without_detents() {
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       runComposeUiTest {
         setContent {
           BottomSheetState(
@@ -175,12 +176,12 @@ class BottomSheetCommonTest {
           )
         }
       }
-    }
+    }.isInstanceOf<IllegalStateException>()
   }
 
   @Test
   fun throws_exception_when_initial_detent_not_in_detents_list() {
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       runComposeUiTest {
         val customDetent = SheetDetent("custom") { _, _ -> 0.dp }
         setContent {
@@ -197,12 +198,12 @@ class BottomSheetCommonTest {
           )
         }
       }
-    }
+    }.isInstanceOf<IllegalStateException>()
   }
 
   @Test
   fun throws_exception_when_creating_state_with_duplicate_detents() {
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       runComposeUiTest {
         setContent {
           BottomSheetState(
@@ -218,12 +219,12 @@ class BottomSheetCommonTest {
           )
         }
       }
-    }
+    }.isInstanceOf<IllegalStateException>()
   }
 
   @Test
   fun throws_exception_when_creating_state_with_rememberbottomsheetstate_without_detents() {
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       runComposeUiTest {
         setContent {
           rememberBottomSheetState(
@@ -232,12 +233,12 @@ class BottomSheetCommonTest {
           )
         }
       }
-    }
+    }.isInstanceOf<IllegalStateException>()
   }
 
   @Test
   fun throws_exception_when_creating_state_with_rememberbottomsheetstate_with_initial_detent_not_in_list() {
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       runComposeUiTest {
         setContent {
           rememberBottomSheetState(
@@ -246,7 +247,7 @@ class BottomSheetCommonTest {
           )
         }
       }
-    }
+    }.isInstanceOf<IllegalStateException>()
   }
 
   @Test
@@ -1393,7 +1394,7 @@ class BottomSheetCommonTest {
 
   @Test
   fun throws_exception_when_setting_detents_to_empty_list() {
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       runComposeUiTest {
         lateinit var state: BottomSheetState
 
@@ -1411,7 +1412,7 @@ class BottomSheetCommonTest {
 
         state.detents = emptyList()
       }
-    }
+    }.isInstanceOf<IllegalStateException>()
   }
 
   @Test

--- a/composeunstyled-checkbox/build.gradle.kts
+++ b/composeunstyled-checkbox/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(libs.assertk)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-checkbox/src/commonTest/kotlin/com/composeunstyled/CheckboxTest.kt
+++ b/composeunstyled-checkbox/src/commonTest/kotlin/com/composeunstyled/CheckboxTest.kt
@@ -40,8 +40,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class CheckboxTest {
   @Test
@@ -62,7 +63,7 @@ class CheckboxTest {
 
     onNodeWithTag("checkbox").performClick()
 
-    assertEquals(true, nextValue)
+    assertThat(nextValue).isEqualTo(true)
   }
 
   @Test
@@ -84,7 +85,7 @@ class CheckboxTest {
 
     onNodeWithTag("checkbox").performClick()
 
-    assertEquals(0, calls)
+    assertThat(calls).isEqualTo(0)
   }
 
   @Test

--- a/composeunstyled-disclosure/build.gradle.kts
+++ b/composeunstyled-disclosure/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(libs.assertk)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
+++ b/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
@@ -43,8 +43,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class DisclosureTest {
   @Test
@@ -64,7 +65,7 @@ class DisclosureTest {
 
     onNodeWithTag("button").performClick()
 
-    assertEquals(true, nextValue)
+    assertThat(nextValue).isEqualTo(true)
   }
 
   @Test

--- a/composeunstyled-dropdown-menu/build.gradle.kts
+++ b/composeunstyled-dropdown-menu/build.gradle.kts
@@ -89,6 +89,7 @@ kotlin {
     val commonTest by getting {
       dependencies {
         implementation(kotlin("test"))
+        implementation(libs.assertk)
 
         @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
         implementation(libs.compose.ui.test)

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -51,10 +51,11 @@ import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class DropdownMenuPanelTest {
   @Test
@@ -100,7 +101,7 @@ class DropdownMenuPanelTest {
     }
     waitUntil { panelPositions.isNotEmpty() }
 
-    assertEquals(expectedPanelX, panelPositions.first())
+    assertThat(panelPositions.first()).isEqualTo(expectedPanelX)
   }
 
   @Test
@@ -143,8 +144,8 @@ class DropdownMenuPanelTest {
 
     onNodeWithTag("item").performClick()
 
-    assertTrue(clicked)
-    assertFalse(expanded)
+    assertThat(clicked).isTrue()
+    assertThat(expanded).isFalse()
   }
 
   @Test
@@ -175,8 +176,8 @@ class DropdownMenuPanelTest {
 
     onNodeWithTag("item").performClick()
 
-    assertTrue(clicked)
-    assertTrue(expanded)
+    assertThat(clicked).isTrue()
+    assertThat(expanded).isTrue()
   }
 
   @Test
@@ -206,8 +207,8 @@ class DropdownMenuPanelTest {
 
     onNodeWithTag("item").performClick()
 
-    assertTrue(clicked)
-    assertFalse(expanded)
+    assertThat(clicked).isTrue()
+    assertThat(expanded).isFalse()
   }
 
   @Test
@@ -242,7 +243,7 @@ class DropdownMenuPanelTest {
       pressKey(Key.Enter)
     }
 
-    assertTrue(expanded)
+    assertThat(expanded).isTrue()
     onNodeWithTag("first").assertExists()
   }
 
@@ -278,7 +279,7 @@ class DropdownMenuPanelTest {
       pressKey(Key.DirectionUp)
     }
 
-    assertTrue(expanded)
+    assertThat(expanded).isTrue()
     onNodeWithTag("last").assertExists()
   }
 

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPositionProviderTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPositionProviderTest.kt
@@ -28,8 +28,9 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class DropdownMenuPositionProviderTest {
   private val anchorBounds = IntRect(left = 100, top = 50, right = 180, bottom = 90)
@@ -48,7 +49,7 @@ class DropdownMenuPositionProviderTest {
       popupContentSize = popupContentSize,
     )
 
-    assertEquals(IntOffset(x = 112, y = 98), position)
+    assertThat(position).isEqualTo(IntOffset(x = 112, y = 98))
   }
 
   @Test
@@ -63,7 +64,7 @@ class DropdownMenuPositionProviderTest {
       popupContentSize = popupContentSize,
     )
 
-    assertEquals(IntOffset(x = 108, y = 98), position)
+    assertThat(position).isEqualTo(IntOffset(x = 108, y = 98))
   }
 
   @Test
@@ -79,7 +80,7 @@ class DropdownMenuPositionProviderTest {
       popupContentSize = popupContentSize,
     )
 
-    assertEquals(IntOffset(x = 112, y = 2), position)
+    assertThat(position).isEqualTo(IntOffset(x = 112, y = 2))
   }
 
   @Test
@@ -107,8 +108,8 @@ class DropdownMenuPositionProviderTest {
       popupContentSize = popupContentSize,
     )
 
-    assertEquals(IntOffset(x = 32, y = 62), startPosition)
-    assertEquals(IntOffset(x = 188, y = 62), endPosition)
+    assertThat(startPosition).isEqualTo(IntOffset(x = 32, y = 62))
+    assertThat(endPosition).isEqualTo(IntOffset(x = 188, y = 62))
   }
 
   @Test
@@ -122,7 +123,7 @@ class DropdownMenuPositionProviderTest {
       popupContentSize = popupContentSize,
     )
 
-    assertEquals(IntOffset(x = 110, y = 90), position)
+    assertThat(position).isEqualTo(IntOffset(x = 110, y = 90))
   }
 
   @Test
@@ -138,7 +139,7 @@ class DropdownMenuPositionProviderTest {
       popupContentSize = popupContentSize,
     )
 
-    assertEquals(IntOffset(x = 0, y = 0), position)
+    assertThat(position).isEqualTo(IntOffset(x = 0, y = 0))
   }
 
   private fun positionProvider(

--- a/composeunstyled-internal-anchored/build.gradle.kts
+++ b/composeunstyled-internal-anchored/build.gradle.kts
@@ -87,6 +87,7 @@ kotlin {
     val commonTest by getting {
       dependencies {
         implementation(kotlin("test"))
+        implementation(libs.assertk)
       }
     }
 

--- a/composeunstyled-internal-anchored/src/commonTest/kotlin/com/composeunstyled/AnchoredPositionTest.kt
+++ b/composeunstyled-internal-anchored/src/commonTest/kotlin/com/composeunstyled/AnchoredPositionTest.kt
@@ -28,8 +28,9 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class AnchoredPositionTest {
   private val anchorBounds = IntRect(left = 100, top = 50, right = 180, bottom = 90)
@@ -43,7 +44,7 @@ class AnchoredPositionTest {
       alignmentOffset = 12.dp,
     )
 
-    assertEquals(IntOffset(x = 112, y = 98), position)
+    assertThat(position).isEqualTo(IntOffset(x = 112, y = 98))
   }
 
   @Test
@@ -54,7 +55,7 @@ class AnchoredPositionTest {
       layoutDirection = LayoutDirection.Rtl,
     )
 
-    assertEquals(IntOffset(x = 108, y = 98), position)
+    assertThat(position).isEqualTo(IntOffset(x = 108, y = 98))
   }
 
   @Test
@@ -65,7 +66,7 @@ class AnchoredPositionTest {
       alignmentOffset = 12.dp,
     )
 
-    assertEquals(IntOffset(x = 112, y = 2), position)
+    assertThat(position).isEqualTo(IntOffset(x = 112, y = 2))
   }
 
   @Test
@@ -83,8 +84,8 @@ class AnchoredPositionTest {
       alignmentOffset = 12.dp,
     )
 
-    assertEquals(IntOffset(x = 32, y = 62), startPosition)
-    assertEquals(IntOffset(x = 188, y = 62), endPosition)
+    assertThat(startPosition).isEqualTo(IntOffset(x = 32, y = 62))
+    assertThat(endPosition).isEqualTo(IntOffset(x = 188, y = 62))
   }
 
   @Test
@@ -93,7 +94,7 @@ class AnchoredPositionTest {
       alignment = AnchorAlignment.Center,
     )
 
-    assertEquals(IntOffset(x = 110, y = 90), position)
+    assertThat(position).isEqualTo(IntOffset(x = 110, y = 90))
   }
 
   @Test
@@ -105,7 +106,7 @@ class AnchoredPositionTest {
       windowSize = IntSize(width = 120, height = 80),
     )
 
-    assertEquals(IntOffset(x = 0, y = 0), position)
+    assertThat(position).isEqualTo(IntOffset(x = 0, y = 0))
   }
 
   @Test
@@ -122,8 +123,8 @@ class AnchoredPositionTest {
       alignmentOffset = (-200).dp,
     )
 
-    assertEquals(IntOffset(x = 0, y = 0), position.position)
-    assertEquals(IntOffset(x = 100, y = 190), position.positionAdjustment)
+    assertThat(position.position).isEqualTo(IntOffset(x = 0, y = 0))
+    assertThat(position.positionAdjustment).isEqualTo(IntOffset(x = 100, y = 190))
   }
 
   @Test
@@ -133,7 +134,7 @@ class AnchoredPositionTest {
       contentSize = IntSize(width = 160, height = 120),
     )
 
-    assertEquals(IntOffset(x = 0, y = 0), position)
+    assertThat(position).isEqualTo(IntOffset(x = 0, y = 0))
   }
 
   private fun calculatePosition(

--- a/composeunstyled-modal-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-modal-bottom-sheet/build.gradle.kts
@@ -87,6 +87,7 @@ kotlin {
     }
 
     androidInstrumentedTest.dependencies {
+      implementation(libs.assertk)
       implementation(libs.androidx.compose.test)
       implementation(libs.androidx.compose.test.manifest)
       implementation(libs.androidx.espresso)

--- a/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
+++ b/composeunstyled-modal-bottom-sheet/src/androidInstrumentedTest/kotlin/ModalBottomSheet.androidTest.kt
@@ -32,8 +32,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import androidx.test.espresso.Espresso
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import kotlin.test.Test
 
 class ModalBottomSheet {
@@ -65,7 +66,7 @@ class ModalBottomSheet {
     onNodeWithTag("sheet").assertExists()
     Espresso.pressBack()
     onNodeWithTag("sheet").assertDoesNotExist()
-    assertTrue(dismissCalled)
+    assertThat(dismissCalled).isTrue()
   }
 
   @Test
@@ -90,6 +91,6 @@ class ModalBottomSheet {
     onNodeWithTag("sheet").assertExists()
     Espresso.pressBack()
     onNodeWithTag("sheet").assertExists()
-    assertFalse(dismissCalled)
+    assertThat(dismissCalled).isFalse()
   }
 }

--- a/composeunstyled-modal/build.gradle.kts
+++ b/composeunstyled-modal/build.gradle.kts
@@ -95,6 +95,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(libs.assertk)
       implementation(projects.composeunstyledTest)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)

--- a/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
+++ b/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
@@ -38,8 +38,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isTrue
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class ModalTest {
 
@@ -99,6 +100,6 @@ class ModalTest {
     waitUntil { attachedToWindow }
 
     onNodeWithTag("modal_content").assertExists()
-    assertTrue(state.attachedToWindow)
+    assertThat(state.attachedToWindow).isTrue()
   }
 }

--- a/composeunstyled-modal/src/commonTest/kotlin/ModalRecompositionTest.kt
+++ b/composeunstyled-modal/src/commonTest/kotlin/ModalRecompositionTest.kt
@@ -28,9 +28,10 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import com.composeunstyled.test.runComposeRecompositionTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class ModalRecompositionTest {
 
@@ -52,6 +53,6 @@ class ModalRecompositionTest {
     parentState++
     waitForIdle()
 
-    assertEquals(1, recompositionCount("modal-content"))
+    assertThat(recompositionCount("modal-content")).isEqualTo(1)
   }
 }

--- a/composeunstyled-progress/build.gradle.kts
+++ b/composeunstyled-progress/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(libs.assertk)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-progress/src/commonTest/kotlin/com/composeunstyled/ProgressIndicatorTest.kt
+++ b/composeunstyled-progress/src/commonTest/kotlin/com/composeunstyled/ProgressIndicatorTest.kt
@@ -36,8 +36,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class ProgressIndicatorTest {
 
@@ -100,7 +101,7 @@ class ProgressIndicatorTest {
 
     waitForIdle()
 
-    assertEquals(IntSize(width = 24, height = 8), indicatorSize)
+    assertThat(indicatorSize).isEqualTo(IntSize(width = 24, height = 8))
   }
 
   private fun hasProgressBarRangeInfo(rangeInfo: ProgressBarRangeInfo): SemanticsMatcher {

--- a/composeunstyled-radio-group/build.gradle.kts
+++ b/composeunstyled-radio-group/build.gradle.kts
@@ -90,6 +90,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(libs.assertk)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupTest.kt
+++ b/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupTest.kt
@@ -38,8 +38,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalTestApi::class)
 class RadioGroupTest {
@@ -63,7 +64,7 @@ class RadioGroupTest {
 
     onNodeWithTag("radio").performClick()
 
-    assertEquals("option", selectedValue)
+    assertThat(selectedValue).isEqualTo("option")
   }
 
   @Test
@@ -85,7 +86,7 @@ class RadioGroupTest {
 
     onNodeWithTag("radio").performClick()
 
-    assertEquals(1, selectedValue)
+    assertThat(selectedValue).isEqualTo(1)
   }
 
   @Test
@@ -108,7 +109,7 @@ class RadioGroupTest {
 
     onNodeWithTag("radio").performClick()
 
-    assertEquals(null, selectedValue)
+    assertThat(selectedValue).isEqualTo(null)
   }
 
   @Test

--- a/composeunstyled-slider/src/commonTest/kotlin/Slider.test.kt
+++ b/composeunstyled-slider/src/commonTest/kotlin/Slider.test.kt
@@ -44,10 +44,10 @@ import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.isCloseTo
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertContentEquals
 
 class SliderTest {
 
@@ -82,10 +82,9 @@ class SliderTest {
 
     assertThat(capturedTrackState.value).isEqualTo(0.6f)
     assertThat(capturedTrackState.fraction).isCloseTo(0.6f, 0.001f)
-    assertContentEquals(
-      floatArrayOf(0f, 0.2f, 0.4f, 0.6f, 0.8f, 1f),
-      capturedTrackState.tickFractions,
-    )
+    assertThat(
+      capturedTrackState.tickFractions.asList(),
+    ).containsExactly(0f, 0.2f, 0.4f, 0.6f, 0.8f, 1f)
     assertThat(capturedThumbState.value).isEqualTo(capturedTrackState.value)
   }
 

--- a/composeunstyled-stack/src/commonTest/kotlin/Stack.test.kt
+++ b/composeunstyled-stack/src/commonTest/kotlin/Stack.test.kt
@@ -34,8 +34,10 @@ import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isTrue
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class StackTest {
 
@@ -60,10 +62,7 @@ class StackTest {
     val item2Bounds = onNodeWithTag("item2").getBoundsInRoot()
 
     // Items should be placed horizontally (item2's left edge should be at or after item1's right edge)
-    assertTrue(
-      item2Bounds.left >= item1Bounds.right,
-      "Items should be placed horizontally, but item2 (left=${item2Bounds.left}) is not to the right of item1 (right=${item1Bounds.right})",
-    )
+    assertThat(item2Bounds.left).isGreaterThanOrEqualTo(item1Bounds.right)
   }
 
   @Test
@@ -87,10 +86,7 @@ class StackTest {
     val item2Bounds = onNodeWithTag("item2").getBoundsInRoot()
 
     // Items should be placed vertically (item2's top edge should be at or below item1's bottom edge)
-    assertTrue(
-      item2Bounds.top >= item1Bounds.bottom,
-      "Items should be placed vertically, but item2 (top=${item2Bounds.top}) is not below item1 (bottom=${item1Bounds.bottom})",
-    )
+    assertThat(item2Bounds.top).isGreaterThanOrEqualTo(item1Bounds.bottom)
   }
 
   @Test
@@ -115,7 +111,7 @@ class StackTest {
     // Initial horizontal placement
     val horizontalItem1Bounds = onNodeWithTag("item1").getBoundsInRoot()
     val horizontalItem2Bounds = onNodeWithTag("item2").getBoundsInRoot()
-    assertTrue(horizontalItem2Bounds.left >= horizontalItem1Bounds.right)
+    assertThat(horizontalItem2Bounds.left >= horizontalItem1Bounds.right).isTrue()
 
     // Change to vertical
     orientation = StackOrientation.Vertical
@@ -123,6 +119,6 @@ class StackTest {
     // Verify vertical placement
     val verticalItem1Bounds = onNodeWithTag("item1").getBoundsInRoot()
     val verticalItem2Bounds = onNodeWithTag("item2").getBoundsInRoot()
-    assertTrue(verticalItem2Bounds.top >= verticalItem1Bounds.bottom)
+    assertThat(verticalItem2Bounds.top >= verticalItem1Bounds.bottom).isTrue()
   }
 }

--- a/composeunstyled-toggle-switch/build.gradle.kts
+++ b/composeunstyled-toggle-switch/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(libs.assertk)
       implementation(projects.composeunstyledTest)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)

--- a/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchRecompositionTest.kt
+++ b/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchRecompositionTest.kt
@@ -34,9 +34,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import com.composeunstyled.test.runComposeRecompositionTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class ToggleSwitchRecompositionTest {
   @Test
@@ -67,7 +68,7 @@ class ToggleSwitchRecompositionTest {
     checked = true
     waitForIdle()
 
-    assertEquals(1, recompositionCount("thumb-content"))
+    assertThat(recompositionCount("thumb-content")).isEqualTo(1)
   }
 
   @Test
@@ -108,6 +109,6 @@ class ToggleSwitchRecompositionTest {
     switchWidth = 68
     waitForIdle()
 
-    assertEquals(0, recompositionCount("thumb-content"))
+    assertThat(recompositionCount("thumb-content")).isEqualTo(0)
   }
 }

--- a/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
+++ b/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
@@ -47,8 +47,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class ToggleSwitchTest {
   @Test
@@ -67,7 +68,7 @@ class ToggleSwitchTest {
 
     onNodeWithTag("switch").performClick()
 
-    assertEquals(true, nextValue)
+    assertThat(nextValue).isEqualTo(true)
   }
 
   @Test
@@ -87,7 +88,7 @@ class ToggleSwitchTest {
 
     onNodeWithTag("switch").performClick()
 
-    assertEquals(0, calls)
+    assertThat(calls).isEqualTo(0)
   }
 
   @Test
@@ -204,7 +205,7 @@ class ToggleSwitchTest {
 
     mainClock.advanceTimeByFrame()
 
-    assertEquals(listOf(34), thumbPositions.distinct())
+    assertThat(thumbPositions.distinct()).isEqualTo(listOf(34))
     onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(34.dp)
   }
 

--- a/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
@@ -31,9 +31,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isNotEqualTo
 import kotlin.test.Test
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 class FloatingContentTest {
 
@@ -121,11 +122,7 @@ class FloatingContentTest {
     bottomStartY = onNodeWithText("Floating").fetchSemanticsNode().positionInRoot.y
 
     // The Y positions should be different when placement changes
-    assertNotEquals(
-      topStartY,
-      bottomStartY,
-      "Floating content position should change when placement changes",
-    )
+    assertThat(bottomStartY).isNotEqualTo(topStartY)
   }
 
   @Test
@@ -156,10 +153,7 @@ class FloatingContentTest {
 
     // With TopStart placement at the top of the window,
     // floating content should be clamped to not go negative
-    assertTrue(
-      floatingY >= 0f,
-      "Floating content should be clamped to window bounds (floatingY=$floatingY should be >= 0)",
-    )
+    assertThat(floatingY).isGreaterThanOrEqualTo(0f)
   }
 
   @Test
@@ -194,13 +188,7 @@ class FloatingContentTest {
 
     // When content is larger than window, it should be clamped to 0
     // to maximize the visible portion at the top-left
-    assertTrue(
-      floatingX >= 0f,
-      "Large floating content should be clamped to x >= 0 (got x=$floatingX)",
-    )
-    assertTrue(
-      floatingY >= 0f,
-      "Large floating content should be clamped to y >= 0 (got y=$floatingY)",
-    )
+    assertThat(floatingX).isGreaterThanOrEqualTo(0f)
+    assertThat(floatingY).isGreaterThanOrEqualTo(0f)
   }
 }

--- a/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/Tooltip.test.kt
@@ -37,8 +37,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class TooltipCommonTest {
 
@@ -135,8 +136,8 @@ class TooltipCommonTest {
     waitForIdle()
 
     onNodeWithText("Tooltip content").assertIsDisplayed()
-    assertEquals(AnchorSide.Bottom, placement?.side)
-    assertEquals(AnchorAlignment.End, placement?.alignment)
+    assertThat(placement?.side).isEqualTo(AnchorSide.Bottom)
+    assertThat(placement?.alignment).isEqualTo(AnchorAlignment.End)
   }
 
   @Test

--- a/composeunstyled-tri-state-checkbox/build.gradle.kts
+++ b/composeunstyled-tri-state-checkbox/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
 
     commonTest.dependencies {
       implementation(kotlin("test"))
+      implementation(libs.assertk)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-tri-state-checkbox/src/commonTest/kotlin/com/composeunstyled/TriStateCheckboxTest.kt
+++ b/composeunstyled-tri-state-checkbox/src/commonTest/kotlin/com/composeunstyled/TriStateCheckboxTest.kt
@@ -35,8 +35,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalTestApi::class)
 class TriStateCheckboxTest {
@@ -58,7 +59,7 @@ class TriStateCheckboxTest {
 
     onNodeWithTag("checkbox").performClick()
 
-    assertEquals(1, clicks)
+    assertThat(clicks).isEqualTo(1)
   }
 
   @Test
@@ -79,7 +80,7 @@ class TriStateCheckboxTest {
 
     onNodeWithTag("checkbox").performClick()
 
-    assertEquals(0, clicks)
+    assertThat(clicks).isEqualTo(0)
   }
 
   @Test

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -156,6 +156,7 @@ kotlin {
       kotlin.srcDir(jvmScreenshotSharedDir)
       dependencies {
         implementation(kotlin("test"))
+        implementation(libs.assertk)
         implementation(libs.compose.ui.test.junit4)
       }
     }
@@ -164,6 +165,7 @@ kotlin {
       kotlin.srcDir(jvmScreenshotSharedDir)
       dependencies {
         implementation(kotlin("test"))
+        implementation(libs.assertk)
         implementation(libs.compose.ui.test.junit4)
       }
     }

--- a/demo/src/jvmScreenshotShared/kotlin/com/composeunstyled/demo/DemoScreenshots.kt
+++ b/demo/src/jvmScreenshotShared/kotlin/com/composeunstyled/demo/DemoScreenshots.kt
@@ -32,12 +32,13 @@ import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import assertk.fail
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
-import kotlin.test.fail
 
 data class DemoScreenshot(
   val name: String,
@@ -84,19 +85,14 @@ fun assertDemoScreenshotMatches(screenshot: DemoScreenshot) = runComposeUiTest {
     ?.use(ImageIO::read)
     ?: fail("Missing expected screenshot. Run `./gradlew :demo:takeScreenshots`.")
 
-  assertEquals(expected.width, actual.width, "Screenshot width changed.")
-  assertEquals(expected.height, actual.height, "Screenshot height changed.")
+  assertThat(actual.width).isEqualTo(expected.width)
+  assertThat(actual.height).isEqualTo(expected.height)
 
   val diff = diff(expected, actual)
   if (diff.changedPixels > 0) {
     ImageIO.write(diff.image, "png", File(reportDir, "${screenshot.name}.diff.png"))
   }
-  assertTrue(
-    actual = diff.changedPixels == 0,
-    message = "Screenshot changed by ${diff.changedPixels} pixels. " +
-      "See ${reportDir.path}/${screenshot.name}.actual.png and " +
-      "${reportDir.path}/${screenshot.name}.diff.png.",
-  )
+  assertThat(diff.changedPixels == 0).isTrue()
 }
 
 @OptIn(ExperimentalTestApi::class)


### PR DESCRIPTION
## Summary
- Replace kotlin.test and JUnit assertion helpers in tests with AssertK assertions
- Add AssertK dependencies to the affected test source sets
- Keep Compose UI test assertions unchanged

## Verification
- ./gradlew jvmTest
- ./gradlew spotlessCheck
- ./gradlew :composeunstyled-bottom-sheet:compileDebugAndroidTestKotlinAndroid :composeunstyled-modal-bottom-sheet:compileDebugAndroidTestKotlinAndroid