### PR TITLE
Add platformIndication color API

### DIFF
--- a/composeunstyled-platformtheme/src/commonMain/kotlin/com/composeunstyled/platformtheme/PlatformTheme.kt
+++ b/composeunstyled-platformtheme/src/commonMain/kotlin/com/composeunstyled/platformtheme/PlatformTheme.kt
@@ -21,6 +21,7 @@
  */
 package com.composeunstyled.platformtheme
 
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Indication
@@ -29,6 +30,7 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -39,12 +41,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.composeunstyled.theme.ColoredIndication
 import com.composeunstyled.theme.ThemeBuilder
 import com.composeunstyled.theme.ThemeComposable
 import com.composeunstyled.theme.ThemeProperty
 import com.composeunstyled.theme.ThemeToken
 import com.composeunstyled.theme.buildTheme
-import com.composeunstyled.theme.rememberColoredIndication
 
 val indications = ThemeProperty<Indication>("platform_indications")
 val bright = ThemeToken<Indication>("bright")
@@ -88,34 +90,8 @@ fun buildPlatformTheme(
 ): ThemeComposable {
   return buildTheme {
     properties[indications] = mapOf(
-      bright to platformValue(
-        android = { rememberPlatformIndication(Color.White) },
-        iOS = { rememberIosIndication(Color.White) },
-        jvm = {
-          rememberColoredIndication(
-            color = Color.White,
-            pressedAlpha = 0.25f,
-            hoveredAlpha = 0f,
-            draggedAlpha = 0f,
-            focusedAlpha = 0f,
-          )
-        },
-        web = { rememberWebIndication(Color.White) },
-      ),
-      dimmed to platformValue(
-        android = { rememberPlatformIndication(Color.Black) },
-        iOS = { rememberIosIndication(Color.Black) },
-        jvm = {
-          rememberColoredIndication(
-            color = Color.Black,
-            pressedAlpha = 0.1f,
-            hoveredAlpha = 0f,
-            draggedAlpha = 0f,
-            focusedAlpha = 0f,
-          )
-        },
-        web = { rememberWebIndication(Color.Black) },
-      ),
+      bright to platformIndication(Color.White),
+      dimmed to platformIndication(Color.Black),
     )
     defaultIndication = properties[indications][bright]
 
@@ -226,9 +202,21 @@ fun buildPlatformTheme(
 }
 
 @Composable
+fun platformIndication(
+  color: Color,
+): Indication {
+  return platformValue(
+    android = { rememberPlatformIndication(color) },
+    iOS = { rememberIosIndication(color) },
+    jvm = { rememberJvmIndication(color) },
+    web = { rememberWebIndication(color) },
+  )
+}
+
+@Composable
 private fun rememberIosIndication(tint: Color): IndicationNodeFactory {
-  return rememberColoredIndication(
-    color = tint,
+  return rememberPlatformColoredIndication(
+    tint = tint,
     pressedAlpha = 0.25f,
     hoveredAlpha = 0f,
     draggedAlpha = 0f,
@@ -239,15 +227,58 @@ private fun rememberIosIndication(tint: Color): IndicationNodeFactory {
 }
 
 @Composable
-private fun rememberWebIndication(tint: Color): IndicationNodeFactory = rememberColoredIndication(
-  color = tint,
-  pressedAlpha = 0.08f,
-  hoveredAlpha = 0.06f,
-  draggedAlpha = 0f,
-  focusedAlpha = 0f,
-  showAnimationSpec = tween(100),
-  hideAnimationSpec = tween(100),
-)
+private fun rememberJvmIndication(tint: Color): IndicationNodeFactory {
+  return rememberPlatformColoredIndication(
+    tint = tint,
+    pressedAlpha = 0.1f,
+    hoveredAlpha = 0f,
+    draggedAlpha = 0f,
+    focusedAlpha = 0f,
+  )
+}
+
+@Composable
+private fun rememberWebIndication(tint: Color): IndicationNodeFactory {
+  return rememberPlatformColoredIndication(
+    tint = tint,
+    pressedAlpha = 0.08f,
+    hoveredAlpha = 0.06f,
+    draggedAlpha = 0f,
+    focusedAlpha = 0f,
+    showAnimationSpec = tween(100),
+    hideAnimationSpec = tween(100),
+  )
+}
+
+@Composable
+private fun rememberPlatformColoredIndication(
+  tint: Color,
+  draggedAlpha: Float,
+  focusedAlpha: Float,
+  hoveredAlpha: Float,
+  pressedAlpha: Float,
+  showAnimationSpec: AnimationSpec<Float> = snap(),
+  hideAnimationSpec: AnimationSpec<Float> = snap(),
+): IndicationNodeFactory {
+  return remember(
+    tint,
+    draggedAlpha,
+    focusedAlpha,
+    hoveredAlpha,
+    pressedAlpha,
+    showAnimationSpec,
+    hideAnimationSpec,
+  ) {
+    ColoredIndication(
+      hoveredColor = tint.copy(alpha = hoveredAlpha),
+      pressedColor = tint.copy(alpha = pressedAlpha),
+      focusedColor = tint.copy(alpha = focusedAlpha),
+      draggedColor = tint.copy(alpha = draggedAlpha),
+      animationSpecEnter = showAnimationSpec,
+      animationSpecExit = hideAnimationSpec,
+    )
+  }
+}
 
 private fun typeScale(scale: Int): TextUnit {
   return platformValue(

--- a/composeunstyled-platformtheme/src/commonMain/kotlin/com/composeunstyled/platformtheme/PlatformTheme.kt
+++ b/composeunstyled-platformtheme/src/commonMain/kotlin/com/composeunstyled/platformtheme/PlatformTheme.kt
@@ -47,6 +47,7 @@ import com.composeunstyled.theme.ThemeComposable
 import com.composeunstyled.theme.ThemeProperty
 import com.composeunstyled.theme.ThemeToken
 import com.composeunstyled.theme.buildTheme
+import com.composeunstyled.theme.rememberColoredIndication
 
 val indications = ThemeProperty<Indication>("platform_indications")
 val bright = ThemeToken<Indication>("bright")
@@ -90,8 +91,34 @@ fun buildPlatformTheme(
 ): ThemeComposable {
   return buildTheme {
     properties[indications] = mapOf(
-      bright to platformIndication(Color.White),
-      dimmed to platformIndication(Color.Black),
+      bright to platformValue(
+        android = { rememberPlatformIndication(Color.White) },
+        iOS = { rememberIosIndication(Color.White) },
+        jvm = {
+          rememberColoredIndication(
+            color = Color.White,
+            pressedAlpha = 0.25f,
+            hoveredAlpha = 0f,
+            draggedAlpha = 0f,
+            focusedAlpha = 0f,
+          )
+        },
+        web = { rememberWebIndication(Color.White) },
+      ),
+      dimmed to platformValue(
+        android = { rememberPlatformIndication(Color.Black) },
+        iOS = { rememberIosIndication(Color.Black) },
+        jvm = {
+          rememberColoredIndication(
+            color = Color.Black,
+            pressedAlpha = 0.1f,
+            hoveredAlpha = 0f,
+            draggedAlpha = 0f,
+            focusedAlpha = 0f,
+          )
+        },
+        web = { rememberWebIndication(Color.Black) },
+      ),
     )
     defaultIndication = properties[indications][bright]
 
@@ -207,16 +234,44 @@ fun platformIndication(
 ): Indication {
   return platformValue(
     android = { rememberPlatformIndication(color) },
-    iOS = { rememberIosIndication(color) },
-    jvm = { rememberJvmIndication(color) },
-    web = { rememberWebIndication(color) },
+    iOS = {
+      rememberPlatformColoredIndication(
+        tint = color,
+        pressedAlpha = 0.25f,
+        hoveredAlpha = 0f,
+        draggedAlpha = 0f,
+        focusedAlpha = 0f,
+        showAnimationSpec = snap(),
+        hideAnimationSpec = tween(300),
+      )
+    },
+    jvm = {
+      rememberPlatformColoredIndication(
+        tint = color,
+        pressedAlpha = 0.1f,
+        hoveredAlpha = 0f,
+        draggedAlpha = 0f,
+        focusedAlpha = 0f,
+      )
+    },
+    web = {
+      rememberPlatformColoredIndication(
+        tint = color,
+        pressedAlpha = 0.08f,
+        hoveredAlpha = 0.06f,
+        draggedAlpha = 0f,
+        focusedAlpha = 0f,
+        showAnimationSpec = tween(100),
+        hideAnimationSpec = tween(100),
+      )
+    },
   )
 }
 
 @Composable
 private fun rememberIosIndication(tint: Color): IndicationNodeFactory {
-  return rememberPlatformColoredIndication(
-    tint = tint,
+  return rememberColoredIndication(
+    color = tint,
     pressedAlpha = 0.25f,
     hoveredAlpha = 0f,
     draggedAlpha = 0f,
@@ -227,28 +282,15 @@ private fun rememberIosIndication(tint: Color): IndicationNodeFactory {
 }
 
 @Composable
-private fun rememberJvmIndication(tint: Color): IndicationNodeFactory {
-  return rememberPlatformColoredIndication(
-    tint = tint,
-    pressedAlpha = 0.1f,
-    hoveredAlpha = 0f,
-    draggedAlpha = 0f,
-    focusedAlpha = 0f,
-  )
-}
-
-@Composable
-private fun rememberWebIndication(tint: Color): IndicationNodeFactory {
-  return rememberPlatformColoredIndication(
-    tint = tint,
-    pressedAlpha = 0.08f,
-    hoveredAlpha = 0.06f,
-    draggedAlpha = 0f,
-    focusedAlpha = 0f,
-    showAnimationSpec = tween(100),
-    hideAnimationSpec = tween(100),
-  )
-}
+private fun rememberWebIndication(tint: Color): IndicationNodeFactory = rememberColoredIndication(
+  color = tint,
+  pressedAlpha = 0.08f,
+  hoveredAlpha = 0.06f,
+  draggedAlpha = 0f,
+  focusedAlpha = 0f,
+  showAnimationSpec = tween(100),
+  hideAnimationSpec = tween(100),
+)
 
 @Composable
 private fun rememberPlatformColoredIndication(
@@ -270,14 +312,18 @@ private fun rememberPlatformColoredIndication(
     hideAnimationSpec,
   ) {
     ColoredIndication(
-      hoveredColor = tint.copy(alpha = hoveredAlpha),
-      pressedColor = tint.copy(alpha = pressedAlpha),
-      focusedColor = tint.copy(alpha = focusedAlpha),
-      draggedColor = tint.copy(alpha = draggedAlpha),
+      hoveredColor = tint.withInteractionAlpha(hoveredAlpha),
+      pressedColor = tint.withInteractionAlpha(pressedAlpha),
+      focusedColor = tint.withInteractionAlpha(focusedAlpha),
+      draggedColor = tint.withInteractionAlpha(draggedAlpha),
       animationSpecEnter = showAnimationSpec,
       animationSpecExit = hideAnimationSpec,
     )
   }
+}
+
+private fun Color.withInteractionAlpha(alpha: Float): Color {
+  return copy(alpha = this.alpha * alpha)
 }
 
 private fun typeScale(scale: Int): TextUnit {

--- a/composeunstyled-platformtheme/src/commonTest/kotlin/com/composeunstyled/platformtheme/PlatformTheme.test.kt
+++ b/composeunstyled-platformtheme/src/commonTest/kotlin/com/composeunstyled/platformtheme/PlatformTheme.test.kt
@@ -21,9 +21,15 @@
  */
 package com.composeunstyled.platformtheme
 
+import androidx.compose.foundation.Indication
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertTextEquals
@@ -31,6 +37,9 @@ import androidx.compose.ui.test.assertWidthIsAtLeast
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import com.composeunstyled.theme.Theme
 import com.composeunstyled.theme.ThemeProperty
 import com.composeunstyled.theme.ThemeToken
@@ -86,5 +95,24 @@ class PlatformThemeTest {
     onNodeWithTag("interactive-box")
       .assertWidthIsAtLeast(customSize)
       .assertHeightIsAtLeast(customSize)
+  }
+
+  @Test
+  fun platformIndicationUpdatesWhenColorChanges() = runComposeUiTest {
+    var color by mutableStateOf(Color.Black)
+    val indications = mutableListOf<Indication>()
+
+    setContent {
+      val indication = platformIndication(color)
+      SideEffect {
+        indications += indication
+      }
+    }
+
+    color = Color.White
+    waitForIdle()
+
+    assertThat(indications.size).isEqualTo(2)
+    assertThat(indications[0] === indications[1]).isFalse()
   }
 }

--- a/docs/api-descriptions.json
+++ b/docs/api-descriptions.json
@@ -262,6 +262,16 @@
     "outline.offset": "Distance between composable and outline (defaults to `0.dp`)",
     "offset": "Distance between composable and outline (defaults to `0.dp`)"
   },
+  "platform-themes": {
+    "buildPlatformTheme.webFontOptions": "Options for loading platform fonts on web targets.",
+    "webFontOptions": "Options for loading platform fonts on web targets.",
+    "buildPlatformTheme.themeAction": "Theme builder block for overriding or adding theme values.",
+    "themeAction": "Theme builder block for overriding or adding theme values.",
+    "platformIndication.color": "Color to apply to the platform indication where the platform supports it.",
+    "color": "Color to apply to the platform indication where the platform supports it.",
+    "Modifier.interactiveSize.size": "Minimum interactive size to apply to the modifier.",
+    "size": "Minimum interactive size to apply to the modifier."
+  },
   "progressindicator": {
     "UnstyledProgress.progress": "(Optional) A float value between 0 and 1 representing the progress. Skipping this value treats the progress as indeterminate for accessibility purposes.",
     "progress": "(Optional) A float value between 0 and 1 representing the progress. Skipping this value treats the progress as indeterminate for accessibility purposes.",

--- a/docs/pages/platform-themes.md
+++ b/docs/pages/platform-themes.md
@@ -214,6 +214,21 @@ Platform Themes apply an `indication` to their children according to each platfo
 
 We provide two Theme tokens: `bright` and `dimmed`. The default indication is `bright`.
 
+Use `platformIndication` when a component should ask for platform-native interaction feedback directly:
+
+```kotlin
+import androidx.compose.ui.graphics.Color
+import com.composeunstyled.platformtheme.platformIndication
+```
+
+```kotlin
+val brightIndication = platformIndication(Color.White.copy(alpha = 0.18f))
+val dimmedIndication = platformIndication(Color.Black.copy(alpha = 0.08f))
+```
+
+Compose Unstyled applies the provided color to the platform indication where the platform supports
+it.
+
 <div class="grid grid-cols-2 gap-8 my-8 unstyled-platform-indications-grid">
   <div class="flex flex-col items-center gap-2 unstyled-platform-indication-item">
     <h4 class="text-center font-semibold unstyled-platform-indication-title">Android</h4>
@@ -290,3 +305,5 @@ AppTheme {
 ```
 
 <UnstyledDemo id="platform-theme" />
+
+<ApiReference id="platform-themes" />

--- a/scripts/generate-compose-unstyled-api.mjs
+++ b/scripts/generate-compose-unstyled-api.mjs
@@ -161,6 +161,13 @@ const apiReferences = {
       fn('resolveThemeTextAppearance'),
     ]),
   ],
+  'platform-themes': [
+    source('composeunstyled-platformtheme/src/commonMain/kotlin/com/composeunstyled/platformtheme/PlatformTheme.kt', [
+      fn('buildPlatformTheme'),
+      fn('platformIndication'),
+      fn('interactiveSize', 'Modifier.interactiveSize'),
+    ]),
+  ],
   buildModifier: [
     source('composeunstyled-build-modifier/src/commonMain/kotlin/com/composeunstyled/BuildModifier.kt', [fn('buildModifier')]),
   ],


### PR DESCRIPTION
## Summary
- Add public platformIndication(color: Color? = null) to the platform theme module
- Reuse the existing platform-specific indication behavior for theme tokens
- Document the API and include it in generated API references

Closes #351

## Tests
- ./gradlew :composeunstyled-platformtheme:jvmTest
- ./gradlew jvmTest spotlessCheck :composeunstyled-platformtheme:compileDebugKotlinAndroid
- node scripts/generate-compose-unstyled-api.mjs build/generated/compose-unstyled-docs-check/pages