### PR TITLE
Default primitive indications to null

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Before pushing changes that touch Kotlin (`.kt`) files, you must run `jvmTest` a
 - Scoped composables must be extension functions on the scope, not members of the scope interface or class.
 - State object constructors should stay available to users so they can wrap primitive state in their own state objects. Keep implementation details hidden, but do not hide a state constructor only because `remember...State` exists.
 - Public `interactionSource` parameters should be nullable and default to `null`. Resolve a non-null interaction source internally only when the primitive needs one for behavior or slot state.
-- Public `indication` parameters should be nullable and default to `LocalIndication.current`: `indication: Indication? = LocalIndication.current`.
+- Public `indication` parameters should be nullable and default to `null`: `indication: Indication? = null`.
 
 ## Working in Unstyled
 

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -28,7 +28,6 @@ import androidx.compose.animation.core.DecayAnimationSpec
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.DraggableAnchors
@@ -844,7 +843,7 @@ private fun ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
 @Composable
 fun BottomSheetScope.DragIndication(
   modifier: Modifier = Modifier,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   interactionSource: MutableInteractionSource? = null,
 ) {
   val context = LocalBottomSheetContext.current

--- a/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
+++ b/composeunstyled-button/src/commonMain/kotlin/com/composeunstyled/Button.kt
@@ -24,7 +24,6 @@
 package com.composeunstyled
 
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -47,7 +46,7 @@ fun UnstyledButton(
   contentPadding: PaddingValues = NoPadding,
   modifier: Modifier = Modifier,
   role: Role = Role.Button,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   interactionSource: MutableInteractionSource? = null,
   contentAlignment: Alignment = Alignment.Center,
   content: @Composable () -> Unit,

--- a/composeunstyled-checkbox/src/commonMain/kotlin/com/composeunstyled/CheckBox.kt
+++ b/composeunstyled-checkbox/src/commonMain/kotlin/com/composeunstyled/CheckBox.kt
@@ -26,7 +26,6 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -45,7 +44,7 @@ fun UnstyledCheckbox(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   accessibilityLabel: String? = null,
   content: @Composable CheckboxScope.() -> Unit,
 ) {

--- a/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
+++ b/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
@@ -27,7 +27,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -78,7 +77,7 @@ fun DisclosureScope.DisclosureButton(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   contentPadding: PaddingValues = NoPadding,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   interactionSource: MutableInteractionSource? = null,
   contentAlignment: Alignment = Alignment.Center,
   content: @Composable () -> Unit,

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -28,7 +28,6 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -243,7 +242,7 @@ fun DropdownMenuPanelScope.MenuItem(
   enabled: Boolean = true,
   closeOnClick: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   content: @Composable () -> Unit,
 ) {
   val state = LocalDropdownMenuState.current

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -31,7 +31,6 @@ import androidx.compose.animation.core.DecayAnimationSpec
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -342,7 +341,7 @@ fun ModalBottomSheetScope.Sheet(
 @Composable
 fun ModalBottomSheetScope.DragIndication(
   modifier: Modifier = Modifier,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   interactionSource: MutableInteractionSource? = null,
 ) {
   bottomSheetScope.DragIndication(

--- a/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
+++ b/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
@@ -28,7 +28,6 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -127,7 +126,7 @@ fun <T> RadioGroupScope.RadioButton(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   content: @Composable RadioButtonScope.() -> Unit,
 ) {
   val state = LocalInnerRadioGroupState.current

--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -24,7 +24,6 @@
 package com.composeunstyled
 
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
@@ -256,7 +255,7 @@ fun <T> TabListScope<T>.Tab(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   activateOnFocus: Boolean = true,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   interactionSource: MutableInteractionSource? = null,
   content: @Composable TabScope.() -> Unit,
 ) {

--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -27,7 +27,6 @@ import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.selection.toggleable
@@ -65,7 +64,7 @@ fun UnstyledSwitch(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   content: @Composable SwitchScope.() -> Unit,
 ) {
   val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }

--- a/composeunstyled-tri-state-checkbox/src/commonMain/kotlin/com/composeunstyled/TriStateCheckBox.kt
+++ b/composeunstyled-tri-state-checkbox/src/commonMain/kotlin/com/composeunstyled/TriStateCheckBox.kt
@@ -22,7 +22,6 @@
 package com.composeunstyled
 
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -42,7 +41,7 @@ fun UnstyledTriStateCheckbox(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
-  indication: Indication? = LocalIndication.current,
+  indication: Indication? = null,
   accessibilityLabel: String? = null,
   content: @Composable TriStateCheckboxScope.() -> Unit,
 ) {


### PR DESCRIPTION
## Summary
- default public primitive indication parameters to null instead of LocalIndication.current
- update the repository API guidance for indication defaults
- add a button regression test proving the default does not instantiate LocalIndication

## Verification
- ./gradlew jvmTest spotlessCheck
- ./gradlew :demo:hotRunJvm