### PR TITLE
Add manual visual regression workflow

### DIFF
--- a/.github/workflows/visual-regressions.yml
+++ b/.github/workflows/visual-regressions.yml
@@ -1,0 +1,97 @@
+name: Visual Regressions
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  screenshot-tests:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          token: ${{ github.token }}
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Screenshot Tests
+        run: ./gradlew --console=plain :visual-regressions:jvmScreenshotTest
+
+  report-failure:
+    needs: screenshot-tests
+    if: ${{ always() && needs.screenshot-tests.result == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open GitHub issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = 'Visual regressions are failing';
+            const labels = ['visual-regression-failure'];
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const results = {
+              'screenshot-tests': '${{ needs.screenshot-tests.result }}',
+            };
+
+            const body = [
+              'Visual regression checks failed.',
+              '',
+              `Workflow run: ${runUrl}`,
+              '',
+              'Job results:',
+              ...Object.entries(results).map(([job, result]) => `- \`${job}\`: ${result}`),
+              '',
+              'Please inspect the failed job logs and update or fix the visual regression baselines.',
+            ].join('\n');
+
+            const { data: existingIssues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: labels.join(','),
+              per_page: 10,
+            });
+            const existingIssue = existingIssues.find(issue => issue.title === title);
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existingIssue.number,
+                body,
+              });
+              return;
+            }
+
+            try {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: labels[0],
+                color: 'd73a4a',
+                description: 'Visual regression checks are failing.',
+              });
+            } catch (error) {
+              if (error.status !== 422) {
+                throw error;
+              }
+            }
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels,
+            });


### PR DESCRIPTION
## Summary
- add a manually triggered Visual Regressions workflow
- run :visual-regressions:jvmScreenshotTest on macOS
- open or update a GitHub issue when the visual regression job fails

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/visual-regressions.yml"); puts "YAML OK"'
- ./gradlew --console=plain :visual-regressions:jvmScreenshotTest

Note: actionlint is not installed locally in this environment.