### PR TITLE
Reduce bottom sheet layout invalidation churn

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -277,7 +277,7 @@ class BottomSheetState internal constructor(
   internal var contentHeightPx: Float by mutableStateOf(Float.NaN)
   internal var containerHeightPx: Float by mutableStateOf(Float.NaN)
   private var contentDependentDetents by mutableStateOf(false)
-  internal var measuredSheetHeightPx: Float by mutableStateOf(Float.NaN)
+  private var measuredSheetHeightPx: Float by mutableStateOf(Float.NaN)
   internal var maxDetentHeightPx: Float by mutableStateOf(Float.NaN)
   internal var isDragging: Boolean by mutableStateOf(false)
 
@@ -434,11 +434,15 @@ class BottomSheetState internal constructor(
     invalidateDetents()
   }
 
-  internal fun updateContentHeight(measuredHeightPx: Float) {
-    val resolvedMeasuredHeightPx = maxOf(
-      measuredHeightPx,
-      measuredSheetHeightPx.takeUnless { it.isNaN() } ?: 0f,
-    )
+  internal fun updateContentHeight(measuredHeightPx: Float, includeMeasuredSheetHeight: Boolean) {
+    val shouldIncludeMeasuredSheetHeight = includeMeasuredSheetHeight ||
+      measuredSheetHeightPx < containerHeightPx
+    val measuredSheetHeight = if (shouldIncludeMeasuredSheetHeight) {
+      measuredSheetHeightPx.takeUnless { it.isNaN() } ?: 0f
+    } else {
+      0f
+    }
+    val resolvedMeasuredHeightPx = maxOf(measuredHeightPx, measuredSheetHeight)
     if (contentHeightPx.isSameValueAs(resolvedMeasuredHeightPx)) return
 
     contentHeightPx = resolvedMeasuredHeightPx
@@ -777,7 +781,10 @@ fun BottomSheetScope.Sheet(
           previousHeight > contentHeight
       }
       ?: contentHeight.toFloat()
-    state?.updateContentHeight(max(measuredContentHeight, height.toFloat()))
+    state?.updateContentHeight(
+      measuredHeightPx = max(measuredContentHeight, height.toFloat()),
+      includeMeasuredSheetHeight = contentHeight == contentMaxHeight,
+    )
 
     layout(width, height) {
       placeables.forEach { placeable ->

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -39,7 +39,6 @@ import androidx.compose.foundation.gestures.snapTo
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.ime
@@ -277,6 +276,7 @@ class BottomSheetState internal constructor(
   internal var closestDetentToTopPx: Float by mutableStateOf(Float.NaN)
   internal var contentHeightPx: Float by mutableStateOf(Float.NaN)
   internal var containerHeightPx: Float by mutableStateOf(Float.NaN)
+  private var contentDependentDetents by mutableStateOf(false)
   internal var measuredSheetHeightPx: Float by mutableStateOf(Float.NaN)
   internal var maxDetentHeightPx: Float by mutableStateOf(Float.NaN)
   internal var isDragging: Boolean by mutableStateOf(false)
@@ -348,12 +348,12 @@ class BottomSheetState internal constructor(
       val targetHeight = anchoredHeightFor(targetDetent)
       val offsetHeight = currentOffsetHeight()
 
-      when {
-        currentHeight.isNaN() && targetHeight.isNaN() && offsetHeight.isNaN() -> maxDetentHeightPx
-        else -> listOf(currentHeight, targetHeight, offsetHeight)
-          .filterNot { it.isNaN() }
-          .maxOrNull() ?: maxDetentHeightPx
-      }
+      maxOrFallback(
+        currentHeight,
+        targetHeight,
+        offsetHeight,
+        fallback = maxDetentHeightPx,
+      )
     }
   }
 
@@ -364,18 +364,16 @@ class BottomSheetState internal constructor(
     val targetHeight = detentHeightPx(targetDetent, measuredContentHeightPx)
     val offsetHeight = currentOffsetHeight().coerceAtMost(measuredContentHeightPx.coerceAtLeast(0f))
 
-    return listOf(currentHeight, targetHeight, offsetHeight)
-      .filterNot { it.isNaN() }
-      .maxOrNull() ?: Float.NaN
+    return maxOrFallback(
+      currentHeight,
+      targetHeight,
+      offsetHeight,
+      fallback = Float.NaN,
+    )
   }
 
   internal fun hasContentDependentDetents(): Boolean {
-    if (containerHeightPx.isNaN()) return false
-
-    return innerDetents.any { detent ->
-      rawDetentHeightPx(detent, sheetHeightPx = 0f) !=
-        rawDetentHeightPx(detent, sheetHeightPx = containerHeightPx)
-    }
+    return contentDependentDetents
   }
 
   private fun anchoredHeightFor(detent: SheetDetent): Float {
@@ -415,11 +413,18 @@ class BottomSheetState internal constructor(
     }
   }
 
+  internal fun updateContainerHeight(measuredHeightPx: Float) {
+    if (containerHeightPx.isSameValueAs(measuredHeightPx)) return
+
+    containerHeightPx = measuredHeightPx
+    invalidateDetents()
+  }
+
   internal fun updateMeasuredSheetHeight(measuredHeightPx: Float) {
-    if (measuredSheetHeightPx != measuredHeightPx) {
-      measuredSheetHeightPx = measuredHeightPx
-      invalidateDetents()
-    }
+    if (measuredSheetHeightPx.isSameValueAs(measuredHeightPx)) return
+
+    measuredSheetHeightPx = measuredHeightPx
+    invalidateDetents()
   }
 
   internal fun updateContentHeight(measuredHeightPx: Float) {
@@ -427,10 +432,10 @@ class BottomSheetState internal constructor(
       measuredHeightPx,
       measuredSheetHeightPx.takeUnless { it.isNaN() } ?: 0f,
     )
-    if (contentHeightPx != resolvedMeasuredHeightPx) {
-      contentHeightPx = resolvedMeasuredHeightPx
-      invalidateDetents()
-    }
+    if (contentHeightPx.isSameValueAs(resolvedMeasuredHeightPx)) return
+
+    contentHeightPx = resolvedMeasuredHeightPx
+    invalidateDetents()
   }
 
   suspend fun animateTo(value: SheetDetent, animationSpec: AnimationSpec<Float>? = null) {
@@ -471,6 +476,10 @@ class BottomSheetState internal constructor(
     val density = density()
     val containerHeight = with(density) { containerHeightPx.toDp() }
     val sheetHeight = with(density) { contentHeightPx.toDp() }
+    val hasMeasuredContainer = containerHeightPx.isNaN().not()
+    var nextClosestDetentToTopPx = Float.NaN
+    var nextMaxDetentHeightPx = Float.NaN
+    var nextContentDependentDetents = false
 
     // We are about to update detents, and we need to figure out the new target for the sheet
     // If anchors haven't been initialized yet (offset is NaN), always use currentDetent to establish the starting position
@@ -496,9 +505,6 @@ class BottomSheetState internal constructor(
 
     val anchors = DraggableAnchors {
       with(density) {
-        closestDetentToTopPx = Float.NaN
-        maxDetentHeightPx = Float.NaN
-
         innerDetents.forEach { detent ->
           val maxDetentHeight = minOf(containerHeight, sheetHeight)
           val contentHeight =
@@ -508,11 +514,16 @@ class BottomSheetState internal constructor(
           val offsetDp = containerHeight - contentHeight
           val offset = offsetDp.toPx()
           val detentHeightPx = contentHeight.toPx()
-          if (closestDetentToTopPx.isNaN() || closestDetentToTopPx > offset) {
-            closestDetentToTopPx = offset
+          if (nextClosestDetentToTopPx.isNaN() || nextClosestDetentToTopPx > offset) {
+            nextClosestDetentToTopPx = offset
           }
-          if (maxDetentHeightPx.isNaN() || maxDetentHeightPx < detentHeightPx) {
-            maxDetentHeightPx = detentHeightPx
+          if (nextMaxDetentHeightPx.isNaN() || nextMaxDetentHeightPx < detentHeightPx) {
+            nextMaxDetentHeightPx = detentHeightPx
+          }
+          if (hasMeasuredContainer && nextContentDependentDetents.not()) {
+            val heightAtEmptySheet = rawDetentHeightPx(detent, sheetHeightPx = 0f)
+            val heightAtFullSheet = rawDetentHeightPx(detent, sheetHeightPx = containerHeightPx)
+            nextContentDependentDetents = heightAtEmptySheet != heightAtFullSheet
           }
           detent at offset
         }
@@ -533,8 +544,35 @@ class BottomSheetState internal constructor(
       }
     }
 
+    if (closestDetentToTopPx.isSameValueAs(nextClosestDetentToTopPx).not()) {
+      closestDetentToTopPx = nextClosestDetentToTopPx
+    }
+    if (maxDetentHeightPx.isSameValueAs(nextMaxDetentHeightPx).not()) {
+      maxDetentHeightPx = nextMaxDetentHeightPx
+    }
+    if (contentDependentDetents != nextContentDependentDetents) {
+      contentDependentDetents = nextContentDependentDetents
+    }
+
     anchoredDraggableState.updateAnchors(anchors, newTarget = overridden)
   }
+}
+
+private fun maxOrFallback(
+  first: Float,
+  second: Float,
+  third: Float,
+  fallback: Float,
+): Float {
+  var result = Float.NaN
+  if (first.isNaN().not()) result = first
+  if (second.isNaN().not() && (result.isNaN() || second > result)) result = second
+  if (third.isNaN().not() && (result.isNaN() || third > result)) result = third
+  return if (result.isNaN()) fallback else result
+}
+
+private fun Float.isSameValueAs(other: Float): Boolean {
+  return this == other || (isNaN() && other.isNaN())
 }
 
 private fun DraggableAnchors<SheetDetent>.closestDetent(
@@ -608,10 +646,9 @@ fun UnstyledBottomSheet(
       }
     }
   }
-  BoxWithConstraints(
+  Box(
     modifier = modifier.onSizeChanged { measuredSize ->
-      state.containerHeightPx = measuredSize.height.toFloat()
-      state.invalidateDetents()
+      state.updateContainerHeight(measuredSize.height.toFloat())
     },
   ) {
     CompositionLocalProvider(LocalBottomSheetContext provides context) {

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -372,6 +372,13 @@ class BottomSheetState internal constructor(
     )
   }
 
+  internal fun estimatedContentHeightPx(fallbackHeightPx: Float): Float {
+    return when {
+      contentHeightPx.isNaN().not() -> contentHeightPx
+      else -> fallbackHeightPx
+    }
+  }
+
   internal fun hasContentDependentDetents(): Boolean {
     return contentDependentDetents
   }
@@ -716,20 +723,18 @@ fun BottomSheetScope.Sheet(
       constraints.minHeight,
       constraints.maxHeight,
     )
-    var hasUnsupportedIntrinsicHeight = false
-    val intrinsicContentHeight = measurables.maxOfOrNull { measurable ->
-      try {
-        measurable.maxIntrinsicHeight(constraints.maxWidth)
-      } catch (_: IllegalStateException) {
-        hasUnsupportedIntrinsicHeight = true
-        constrainedFallbackContentHeight
-      }
-    }
-    val estimatedContentHeight = if (intrinsicContentHeight == 0) {
-      constrainedFallbackContentHeight
-    } else {
-      intrinsicContentHeight ?: constrainedFallbackContentHeight
-    }
+    val contentMeasurementHeight = when {
+      state != null && state.containerHeightPx.isNaN().not() -> state.containerHeightPx.roundToInt()
+      else -> constraints.maxHeight
+    }.coerceIn(
+      constraints.minHeight,
+      constraints.maxHeight,
+    )
+    val estimatedContentHeight = state
+      ?.estimatedContentHeightPx(constrainedFallbackContentHeight.toFloat())
+      ?.roundToInt()
+      ?.coerceIn(constraints.minHeight, constraints.maxHeight)
+      ?: constrainedFallbackContentHeight
 
     val resolvedLayoutHeight = state?.layoutHeightPxFor(estimatedContentHeight.toFloat())
       ?: estimatedContentHeight.toFloat()
@@ -743,8 +748,10 @@ fun BottomSheetScope.Sheet(
       else -> resolvedLayoutHeight.roundToInt()
     }.coerceIn(constraints.minHeight, constraints.maxHeight)
     val contentMaxHeight = when {
-      waitingForHiddenAnchors -> layoutMaxHeight
-      state?.hasContentDependentDetents() == true -> constrainedFallbackContentHeight
+      state == null -> contentMeasurementHeight
+      state.contentHeightPx.isNaN() -> contentMeasurementHeight
+      state.hasContentDependentDetents() -> contentMeasurementHeight
+      waitingForHiddenAnchors -> contentMeasurementHeight
       else -> layoutMaxHeight
     }
     val contentConstraints = constraints.copy(maxHeight = contentMaxHeight)
@@ -763,14 +770,14 @@ fun BottomSheetScope.Sheet(
       layoutMaxHeight,
     ).coerceIn(constraints.minHeight, constraints.maxHeight)
 
-    val measuredContentHeight = when {
-      waitingForHiddenAnchors -> estimatedContentHeight
-      contentHeight == constrainedFallbackContentHeight &&
-        constrainedFallbackContentHeight < fallbackContentHeight -> fallbackContentHeight
-      hasUnsupportedIntrinsicHeight -> contentHeight
-      else -> max(estimatedContentHeight, contentHeight)
-    }
-    state?.updateContentHeight(max(measuredContentHeight, height).toFloat())
+    val measuredContentHeight = state?.contentHeightPx
+      ?.takeIf { previousHeight ->
+        contentHeight == contentMaxHeight &&
+          contentMaxHeight < contentMeasurementHeight &&
+          previousHeight > contentHeight
+      }
+      ?: contentHeight.toFloat()
+    state?.updateContentHeight(max(measuredContentHeight, height.toFloat()))
 
     layout(width, height) {
       placeables.forEach { placeable ->

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -808,6 +808,10 @@ class BottomSheetCommonTest {
         maxIntrinsicHeightCalls = 0
         detentHeightCalls = 0
       }
+
+      fun snapshot(): String {
+        return "measure=$measureCalls intrinsic=$maxIntrinsicHeightCalls detent=$detentHeightCalls"
+      }
     }
 
     val counters = Counters()
@@ -864,17 +868,67 @@ class BottomSheetCommonTest {
 
     waitForIdle()
 
-    assertThat(counters.measureCalls).isEqualTo(2)
-    assertThat(counters.maxIntrinsicHeightCalls).isEqualTo(2)
-    assertThat(counters.detentHeightCalls).isEqualTo(9)
+    assertThat(counters.snapshot()).isEqualTo("measure=2 intrinsic=0 detent=7")
 
     counters.reset()
     contentHeight = 250.dp
     waitForIdle()
 
-    assertThat(counters.measureCalls).isEqualTo(2)
-    assertThat(counters.maxIntrinsicHeightCalls).isEqualTo(2)
-    assertThat(counters.detentHeightCalls).isEqualTo(13)
+    assertThat(counters.snapshot()).isEqualTo("measure=1 intrinsic=0 detent=0")
+  }
+
+  @Test
+  fun sheet_does_not_query_content_intrinsic_height() = runComposeUiTest {
+    val contentDetent = SheetDetent("content") { _, sheetHeight ->
+      sheetHeight
+    }
+
+    setContent {
+      Box(Modifier.requiredSize(400.dp)) {
+        val state = rememberBottomSheetState(
+          initialDetent = contentDetent,
+          detents = listOf(contentDetent),
+        )
+
+        UnstyledBottomSheet(
+          state,
+          Modifier.testTag("sheet"),
+        ) {
+          Sheet {
+            Layout(
+              modifier = Modifier.testTag("sheet_contents"),
+              content = {},
+              measurePolicy = object : MeasurePolicy {
+                override fun MeasureScope.measure(
+                  measurables: List<Measurable>,
+                  constraints: Constraints,
+                ): MeasureResult {
+                  return layout(
+                    width = 1.coerceIn(constraints.minWidth, constraints.maxWidth),
+                    height = 200.dp.roundToPx().coerceIn(
+                      constraints.minHeight,
+                      constraints.maxHeight,
+                    ),
+                  ) {
+                  }
+                }
+
+                override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+                  measurables: List<IntrinsicMeasurable>,
+                  width: Int,
+                ): Int {
+                  error("BottomSheet should not query max intrinsic height.")
+                }
+              },
+            )
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+
+    onNodeWithTag("sheet").assertHeightIsEqualTo(200.dp)
   }
 
   @Test

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
@@ -44,6 +45,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.IntrinsicMeasurable
@@ -797,6 +799,58 @@ class BottomSheetCommonTest {
   }
 
   @Test
+  fun fixed_height_sheet_inside_fill_parent_layout_uses_its_content_height() = runComposeUiTest {
+    val peekDetent = SheetDetent("peek") { containerHeight, _ ->
+      containerHeight * 0.6f
+    }
+    var containerSize by mutableStateOf(1_000.dp)
+
+    setContent {
+      Box(
+        Modifier
+          .requiredSize(containerSize)
+          .testTag("root"),
+      ) {
+        val state = rememberBottomSheetState(
+          initialDetent = peekDetent,
+          detents = listOf(peekDetent, SheetDetent.FullyExpanded),
+        )
+
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.fillMaxSize(),
+        ) {
+          Box(Modifier.fillMaxSize(), contentAlignment = Alignment.TopCenter) {
+            Sheet(
+              modifier = Modifier
+                .widthIn(max = 640.dp)
+                .fillMaxWidth()
+                .testTag("panel"),
+            ) {
+              Box(
+                Modifier
+                  .fillMaxWidth()
+                  .height(600.dp),
+              )
+            }
+          }
+        }
+      }
+    }
+
+    waitUntilExactlyOneExists(hasTestTag("panel"))
+
+    containerSize = 1_200.dp
+    waitForIdle()
+
+    val rootBounds = onNodeWithTag("root").fetchSemanticsNode().boundsInRoot
+    val panelBounds = onNodeWithTag("panel").fetchSemanticsNode().boundsInRoot
+
+    assertThat(panelBounds.height).isEqualTo(with(density) { 600.dp.toPx() })
+    assertThat(panelBounds.bottom).isEqualTo(rootBounds.bottom)
+  }
+
+  @Test
   fun sheet_measurement_counter_baseline() = runComposeUiTest {
     class Counters {
       var measureCalls = 0
@@ -807,10 +861,6 @@ class BottomSheetCommonTest {
         measureCalls = 0
         maxIntrinsicHeightCalls = 0
         detentHeightCalls = 0
-      }
-
-      fun snapshot(): String {
-        return "measure=$measureCalls intrinsic=$maxIntrinsicHeightCalls detent=$detentHeightCalls"
       }
     }
 
@@ -868,13 +918,17 @@ class BottomSheetCommonTest {
 
     waitForIdle()
 
-    assertThat(counters.snapshot()).isEqualTo("measure=2 intrinsic=0 detent=7")
+    assertThat(counters.measureCalls).isEqualTo(2)
+    assertThat(counters.maxIntrinsicHeightCalls).isEqualTo(0)
+    assertThat(counters.detentHeightCalls).isEqualTo(7)
 
     counters.reset()
     contentHeight = 250.dp
     waitForIdle()
 
-    assertThat(counters.snapshot()).isEqualTo("measure=1 intrinsic=0 detent=0")
+    assertThat(counters.measureCalls).isEqualTo(1)
+    assertThat(counters.maxIntrinsicHeightCalls).isEqualTo(0)
+    assertThat(counters.detentHeightCalls).isEqualTo(0)
   }
 
   @Test

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -46,6 +46,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.SemanticsMatcher
@@ -67,6 +74,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.test.waitUntilExactlyOneExists
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import assertk.assertFailure
 import assertk.assertThat
@@ -786,6 +794,87 @@ class BottomSheetCommonTest {
       with(density) { DensityTolerance.toPx() },
     )
     onNodeWithTag("sheet").assertHeightIsEqualTo(200.dp)
+  }
+
+  @Test
+  fun sheet_measurement_counter_baseline() = runComposeUiTest {
+    class Counters {
+      var measureCalls = 0
+      var maxIntrinsicHeightCalls = 0
+      var detentHeightCalls = 0
+
+      fun reset() {
+        measureCalls = 0
+        maxIntrinsicHeightCalls = 0
+        detentHeightCalls = 0
+      }
+    }
+
+    val counters = Counters()
+    var contentHeight by mutableStateOf(200.dp)
+    val contentDetent = SheetDetent("content") { _, sheetHeight ->
+      counters.detentHeightCalls++
+      sheetHeight
+    }
+
+    setContent {
+      Box(Modifier.requiredSize(400.dp)) {
+        val state = rememberBottomSheetState(
+          initialDetent = contentDetent,
+          detents = listOf(contentDetent),
+        )
+
+        UnstyledBottomSheet(
+          state,
+          Modifier.testTag("sheet"),
+        ) {
+          Sheet {
+            Layout(
+              modifier = Modifier.testTag("sheet_contents"),
+              content = {},
+              measurePolicy = object : MeasurePolicy {
+                override fun MeasureScope.measure(
+                  measurables: List<Measurable>,
+                  constraints: Constraints,
+                ): MeasureResult {
+                  counters.measureCalls++
+                  return layout(
+                    width = 1.coerceIn(constraints.minWidth, constraints.maxWidth),
+                    height = contentHeight.roundToPx().coerceIn(
+                      constraints.minHeight,
+                      constraints.maxHeight,
+                    ),
+                  ) {
+                  }
+                }
+
+                override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+                  measurables: List<IntrinsicMeasurable>,
+                  width: Int,
+                ): Int {
+                  counters.maxIntrinsicHeightCalls++
+                  return contentHeight.roundToPx()
+                }
+              },
+            )
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+
+    assertThat(counters.measureCalls).isEqualTo(2)
+    assertThat(counters.maxIntrinsicHeightCalls).isEqualTo(2)
+    assertThat(counters.detentHeightCalls).isEqualTo(9)
+
+    counters.reset()
+    contentHeight = 250.dp
+    waitForIdle()
+
+    assertThat(counters.measureCalls).isEqualTo(2)
+    assertThat(counters.maxIntrinsicHeightCalls).isEqualTo(2)
+    assertThat(counters.detentHeightCalls).isEqualTo(13)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add a committed bottom sheet measurement counter baseline before changing the implementation
- avoid repeated bottom sheet anchor invalidation when the container height is unchanged
- cache content-dependent-detent detection during anchor recalculation instead of recomputing it from measure
- replace small list allocations in height selection with scalar helpers and batch anchor metadata state writes
- remove the intrinsic-height measurement pass from `Sheet` and use one child measure per layout pass
- keep fixed-height sheets inside fill-parent wrappers sized from their own content after window resize

## Measured counter change
- initial content-sized sheet: `measure=2 intrinsic=2 detent=9` -> `measure=2 intrinsic=0 detent=7`
- after content grows: `measure=2 intrinsic=2 detent=13` -> `measure=1 intrinsic=0 detent=0`

## Tests
- ./gradlew jvmTest
- ./gradlew spotlessCheck
- ./gradlew :visual-regressions:jvmScreenshotTest
- ./gradlew :composeunstyled-bottom-sheet:connectedDebugAndroidTest