### PR TITLE
Dismiss dropdown menus from Android back

### DIFF
--- a/composeunstyled-dropdown-menu/build.gradle.kts
+++ b/composeunstyled-dropdown-menu/build.gradle.kts
@@ -82,6 +82,7 @@ kotlin {
         api(projects.composeunstyledAnchoredApi)
         implementation(projects.composeunstyledInternalAnchored)
         implementation(projects.composeunstyledBuildModifier)
+        implementation(projects.composeunstyledEscapeHandler)
         implementation(projects.composeunstyledModal)
       }
     }

--- a/composeunstyled-dropdown-menu/src/androidInstrumentedTest/kotlin/DropdownMenu.androidTest.kt
+++ b/composeunstyled-dropdown-menu/src/androidInstrumentedTest/kotlin/DropdownMenu.androidTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.test.espresso.Espresso
+import assertk.assertThat
+import assertk.assertions.isFalse
+import kotlin.test.Test
+
+class DropdownMenuAndroidTest {
+  @Test
+  fun backPressClosesMenu() = runComposeUiTest {
+    var expanded by mutableStateOf(true)
+
+    setContent {
+      UnstyledDropdownMenu(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        panel = {
+          DropdownMenuPanel {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("item")) {
+              BasicText("Item")
+            }
+          }
+        },
+        anchor = {
+          BasicText("Anchor")
+        },
+      )
+    }
+
+    onNodeWithTag("item").assertExists()
+    Espresso.pressBack()
+
+    assertThat(expanded).isFalse()
+    onNodeWithTag("item").assertDoesNotExist()
+  }
+}

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -125,20 +125,12 @@ fun UnstyledDropdownMenu(
     AnchoredFloatingContent(
       anchor = anchor,
       layer = { content ->
-        Modal(
-          state = modalState,
-          onKeyEvent = { event ->
-            if (
-              event.type == KeyEventType.KeyDown &&
-              (event.key == Key.Back || event.key == Key.Escape)
-            ) {
+        Modal(state = modalState) {
+          if (expanded) {
+            EscapeHandler {
               onExpandedChange(false)
-              true
-            } else {
-              false
             }
-          },
-        ) {
+          }
           content()
         }
       },
@@ -204,13 +196,6 @@ fun DropdownMenuScope.DropdownMenuPanel(
         Key.MoveEnd -> {
           if (event.isKeyDown) {
             scope.itemFocusRequesters.lastOrNull()?.requestFocus()
-          }
-          true
-        }
-
-        Key.Escape -> {
-          if (event.isKeyDown) {
-            state.onExpandedChange(false)
           }
           true
         }


### PR DESCRIPTION
## Summary
- use EscapeHandler for expanded dropdown dismissal instead of modal/panel Escape key handlers
- add the escape-handler dependency to the dropdown menu module
- add Android instrumentation coverage for system Back dismissal

## Tests
- ./gradlew :composeunstyled-dropdown-menu:jvmTest
- ./gradlew spotlessCheck
- ANDROID_SERIAL=HT79S1A05765 ./gradlew :composeunstyled-dropdown-menu:connectedAndroidTest
