### PR TITLE
Move modal docs to utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ Before pushing changes that touch Kotlin (`.kt`) files, you must run `jvmTest` a
 - When asked to run the demo app, use `./gradlew :<module>:hotRunJvm` instead.
 - When running any desktop JVM app, start it in a background terminal/process so the main terminal remains available.
 
+## Documentation
+
+- Keep the `Primitives` and `Utilities` entries in `docs/docs.yml` in alphabetical order.
+
 ## Working with Compose Foundation
 
 - Do not use experimental Compose Foundation APIs. They can be removed or changed in future Compose versions and cause consumers to crash.

--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -31,8 +31,6 @@ sections:
         slug: dropdown-menu
       - title: Icon
         slug: icon
-      - title: Modal
-        slug: modal
       - title: Progress Indicator
         slug: progressindicator
       - title: Radio Group
@@ -79,9 +77,11 @@ sections:
         slug: outline
   - title: Utilities
     pages:
-      - title: Window Container Size
-        slug: window-container-size
-      - title: Escape Handler
-        slug: escape-handler
       - title: buildModifier
         slug: buildModifier
+      - title: Escape Handler
+        slug: escape-handler
+      - title: Modal
+        slug: modal
+      - title: Window Container Size
+        slug: window-container-size

--- a/docs/docs.yml
+++ b/docs/docs.yml
@@ -83,5 +83,7 @@ sections:
         slug: escape-handler
       - title: Modal
         slug: modal
+      - title: Portal
+        slug: portal
       - title: Window Container Size
         slug: window-container-size

--- a/docs/pages/portal.md
+++ b/docs/pages/portal.md
@@ -19,10 +19,11 @@ PortalHost {
 }
 ```
 
-## General Usage
+## Concepts
 
 - `PortalHost` provides the destination where portal content is rendered.
 - `Portal` sends content to the nearest `PortalHost`, or renders nothing when no host is available.
+- Portal content is rendered after the host content, inside the same window.
 
 ## Code Examples
 


### PR DESCRIPTION
## Summary
- move the Modal docs entry from Primitives to Utilities
- keep Primitives and Utilities docs index entries alphabetized
- document that Primitives and Utilities ordering rule in AGENTS.md
- add Portal to Utilities and update its docs page structure

## Validation
- ruby docs.yml navigation and Primitives/Utilities ordering check
- ./gradlew bundleComposeUnstyledDocs *(fails: missing demo source `demo/src/commonMain/kotlin/BottomSheetScrollableContentDemo.kt`)*