### PR TITLE
Fix bottom sheet fling

### DIFF
--- a/composeunstyled-bottom-sheet/src/androidInstrumentedTest/kotlin/BottomSheet.androidTest.kt
+++ b/composeunstyled-bottom-sheet/src/androidInstrumentedTest/kotlin/BottomSheet.androidTest.kt
@@ -24,24 +24,32 @@
 package com.composeunstyled
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.test.swipeWithVelocity
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThanOrEqualTo
 import kotlin.test.Test
 
 class BottomSheetTest {
+
+  private val BoundsTolerance = 1.dp
 
   @Test
   fun isidle_is_false_when_dragging_sheet_with_scrollable_content() = runComposeUiTest {
@@ -88,5 +96,61 @@ class BottomSheetTest {
     }
 
     assertThat(sheetState.isIdle).isFalse()
+  }
+
+  @Test
+  fun sheet_stays_within_bounds_when_flinging_to_fullyexpanded() = runComposeUiTest {
+    lateinit var state: BottomSheetState
+    val peek = SheetDetent("peek") { _, _ -> 240.dp }
+    val contentHeight = 560.dp
+
+    setContent {
+      Box(Modifier.fillMaxSize()) {
+        state = rememberBottomSheetState(
+          initialDetent = peek,
+          detents = listOf(SheetDetent.Hidden, peek, SheetDetent.FullyExpanded),
+        )
+
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .testTag("sheet"),
+        ) {
+          Box(
+            Modifier
+              .fillMaxWidth()
+              .height(contentHeight),
+          )
+        }
+      }
+    }
+
+    val expandedTop = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot.bottom -
+      with(density) { contentHeight.toPx() }
+    mainClock.autoAdvance = false
+
+    try {
+      onNodeWithTag("sheet").performTouchInput {
+        swipeWithVelocity(
+          start = Offset(centerX, centerY),
+          end = Offset(centerX, top),
+          endVelocity = 4_000f,
+          durationMillis = 50,
+        )
+      }
+
+      repeat(10) {
+        mainClock.advanceTimeByFrame()
+
+        val sheetBounds = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot
+        assertThat(sheetBounds.top).isGreaterThanOrEqualTo(
+          expandedTop - with(density) { BoundsTolerance.toPx() },
+        )
+      }
+    } finally {
+      mainClock.autoAdvance = true
+    }
   }
 }

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -345,12 +345,10 @@ class BottomSheetState internal constructor(
       Float.NaN
     } else {
       val currentHeight = anchoredHeightFor(currentDetent)
-      val targetHeight = anchoredHeightFor(targetDetent)
       val offsetHeight = currentOffsetHeight()
 
       maxOrFallback(
         currentHeight,
-        targetHeight,
         offsetHeight,
         fallback = maxDetentHeightPx,
       )
@@ -361,12 +359,10 @@ class BottomSheetState internal constructor(
     if (containerHeightPx.isNaN() || measuredContentHeightPx.isNaN()) return Float.NaN
 
     val currentHeight = detentHeightPx(currentDetent, measuredContentHeightPx)
-    val targetHeight = detentHeightPx(targetDetent, measuredContentHeightPx)
     val offsetHeight = currentOffsetHeight().coerceAtMost(measuredContentHeightPx.coerceAtLeast(0f))
 
     return maxOrFallback(
       currentHeight,
-      targetHeight,
       offsetHeight,
       fallback = Float.NaN,
     )
@@ -572,13 +568,11 @@ class BottomSheetState internal constructor(
 private fun maxOrFallback(
   first: Float,
   second: Float,
-  third: Float,
   fallback: Float,
 ): Float {
   var result = Float.NaN
   if (first.isNaN().not()) result = first
   if (second.isNaN().not() && (result.isNaN() || second > result)) result = second
-  if (third.isNaN().not() && (result.isNaN() || third > result)) result = third
   return if (result.isNaN()) fallback else result
 }
 
@@ -821,7 +815,7 @@ private fun Modifier.sheetOffset(state: BottomSheetState, offsetForIme: Boolean)
           }
 
           else -> {
-            val calculatedOffset = state.anchoredDraggableState.requireOffset() - imeHeight
+            val calculatedOffset = state.anchoredDraggableState.visualOffset() - imeHeight
             // do not let the sheet's top go out of screen bounds
             val y = calculatedOffset.coerceAtLeast(0f).toInt()
             IntOffset(x = 0, y = y)
@@ -833,6 +827,14 @@ private fun Modifier.sheetOffset(state: BottomSheetState, offsetForIme: Boolean)
       add(Modifier.consumeWindowInsets(ime))
     }
   }
+}
+
+private fun AnchoredDraggableState<SheetDetent>.visualOffset(): Float {
+  val offset = requireOffset()
+  val minPosition = anchors.minPosition()
+  val maxPosition = anchors.maxPosition()
+  if (minPosition.isNaN() || maxPosition.isNaN()) return offset
+  return offset.coerceIn(minPosition, maxPosition)
 }
 
 private fun ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(


### PR DESCRIPTION
## Summary
- update the changelog for the 2.2.0 release
- document release retry monitoring
- keep bottom sheets within bounds during fast flings
- add an Android regression test for modal bottom sheet fling bounds

## Verification
- ./gradlew :composeunstyled-bottom-sheet:jvmTest :composeunstyled-modal-bottom-sheet:jvmTest
- ./gradlew spotlessCheck
- installed and launched :demo on Pixel 2 (HT79S1A05765)

Note: the Android connected regression test could not complete earlier because ADB lost the emulator/device before test execution.