### PR TITLE
Move 2.2.0 notes under release heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-05-18
+
 ### Added
 
 - Added focus-visible support to `focusRing`, including `FocusVisibilityProvider`,


### PR DESCRIPTION
## Summary
- move the 2.2.0 changelog notes from Unreleased into the dated 2.2.0 heading required by the release workflow

## Verification
- git diff --check