### PR TITLE
Remove stale docs demo references

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,13 +14,9 @@ val composeUnstyledDocsAssets = composeUnstyledDocsSource.dir("assets")
 
 val composeUnstyledDemoSources = mapOf(
   "bottom-sheet" to "BottomSheetDemo.kt",
-  "bottom-sheet-scrollable-content" to "BottomSheetScrollableContentDemo.kt",
   "modal-bottom-sheet" to "ModalBottomSheetDemo.kt",
-  "modal-bottom-sheet-scrollable-content" to "ModalBottomSheetScrollableContentDemo.kt",
   "button" to "ButtonDemo.kt",
   "checkbox" to "CheckboxDemo.kt",
-  "checkbox-custom-checked-indicator" to "CheckboxCustomCheckedIndicatorDemo.kt",
-  "checkbox-extended-indicator-bounds" to "CheckboxExtendedIndicatorBoundsDemo.kt",
   "tristatecheckbox" to "TriStateCheckboxDemo.kt",
   "dialog" to "DialogDemo.kt",
   "disclosure" to "DisclosureDemo.kt",

--- a/docs/pages/bottom-sheet.md
+++ b/docs/pages/bottom-sheet.md
@@ -156,8 +156,6 @@ LaunchedEffect(peekHeight.value) {
 
 Use a scrollable layout inside the `Sheet` component to make content scroll within the current detent height:
 
-<UnstyledDemo id="bottom-sheet-scrollable-content" />
-
 ### Working with the soft keyboard
 
 Use the `offsetForIme` parameter to automatically move the sheet above the soft keyboard:

--- a/docs/pages/checkbox.md
+++ b/docs/pages/checkbox.md
@@ -71,8 +71,6 @@ Use padding on the `CheckedIndicator` component to place the visible checkbox in
 interaction area. This is useful when the ripple or touch target should be larger than the visible
 checkbox:
 
-<UnstyledDemo id="checkbox-extended-indicator-bounds" />
-
 ### Animating the checked indicator
 
 Use the `enter` and `exit` parameters on `CheckedIndicator` to animate the checked content.
@@ -94,8 +92,6 @@ UnstyledCheckbox(
 ### Creating a custom checked indicator animation
 
 Use the `checked` state value to draw your own indicator instead of `CheckedIndicator`. This is useful when your design system needs a custom checkmark animation:
-
-<UnstyledDemo id="checkbox-custom-checked-indicator" />
 
 ### Labeling an icon-only checkbox
 

--- a/docs/pages/modal-bottom-sheet.md
+++ b/docs/pages/modal-bottom-sheet.md
@@ -166,8 +166,6 @@ LaunchedEffect(peekHeight) {
 
 Use a scrollable layout inside the `Sheet` component to make content scroll within the current detent height:
 
-<UnstyledDemo id="modal-bottom-sheet-scrollable-content" />
-
 ### Moving a modal bottom sheet above the soft keyboard
 
 Use the `offsetForIme` parameter on `ModalBottomSheetProperties` to automatically move the sheet above the soft keyboard:


### PR DESCRIPTION
## Summary
- remove docs bundle registrations for demos that no longer exist
- remove stale UnstyledDemo embeds from bottom sheet, modal bottom sheet, and checkbox docs

## Verification
- ./gradlew bundleComposeUnstyledDocs