### PR TITLE
Stop inheriting text selection theme defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `selectionColors` parameter to `UnstyledTextField` for styling text selection handles and
   background. (#374)
 
+### Changed
+
+- Themes now default text selection colors to `Color.Unspecified` instead of inheriting parent
+  selection styling.
+
 ## [2.2.0] - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Themes now default text selection colors to `Color.Unspecified` instead of inheriting parent
   selection styling.
+- Deprecated `minimumInteractiveComponentSize`, `ComponentInteractiveSize`, and
+  `defaultComponentInteractiveSize`. These APIs will be removed in 3.0. It is now up to you to
+  implement this behavior if it is a requirement for your design system.
 
 ## [2.2.0] - 2026-05-18
 

--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/MinimumComponentInteractiveSize.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/MinimumComponentInteractiveSize.kt
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-@file:Suppress("ktlint:standard:max-line-length")
+@file:Suppress("DEPRECATION", "ktlint:standard:max-line-length")
 
 package com.composeunstyled
 
@@ -34,6 +34,9 @@ import com.composeunstyled.theme.supportsTouch
 internal val LocalMinimumComponentInteractiveSize =
   compositionLocalOf { ComponentInteractiveSize(Dp.Unspecified) }
 
+@Deprecated(
+  message = "This will be removed in 3.0. It is now up to you to implement this behavior if it is a requirement for your design system.",
+)
 @Composable
 fun Modifier.minimumInteractiveComponentSize(): Modifier {
   val size = LocalMinimumComponentInteractiveSize.current

--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
@@ -94,7 +94,7 @@ fun buildTheme(themeAction: @Composable ThemeBuilder.() -> Unit = {}): ThemeComp
     val allProperties = builder.properties.entries
 
     val defaultIndication = builder.defaultIndication ?: NoIndication
-    val textSelectionColors = builder.defaultTextSelectionColors ?: LocalTextSelectionColors.current
+    val textSelectionColors = builder.defaultTextSelectionColors ?: UnspecifiedTextSelectionColors
 
     val minInteractiveSize = builder.defaultComponentInteractiveSize
 
@@ -129,6 +129,11 @@ internal val LocalTheme =
       "No theme was set. In order to use the Theme object you need to wrap your content with a theme @Composable returned by the buildTheme {} function.",
     )
   }
+
+private val UnspecifiedTextSelectionColors = TextSelectionColors(
+  handleColor = Color.Unspecified,
+  backgroundColor = Color.Unspecified,
+)
 
 @DslMarker
 annotation class ThemeBuilderMarker

--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-@file:Suppress("ktlint:standard:max-line-length")
+@file:Suppress("DEPRECATION", "ktlint:standard:max-line-length")
 
 package com.composeunstyled.theme
 
@@ -138,11 +138,17 @@ private val UnspecifiedTextSelectionColors = TextSelectionColors(
 @DslMarker
 annotation class ThemeBuilderMarker
 
+@Deprecated(
+  message = "This will be removed in 3.0. It is now up to you to implement this behavior if it is a requirement for your design system.",
+)
 data class ComponentInteractiveSize(
   val nonTouchInteractionSize: Dp = Dp.Unspecified,
   val touchInteractionSize: Dp = Dp.Unspecified,
 )
 
+@Deprecated(
+  message = "This will be removed in 3.0. It is now up to you to implement this behavior if it is a requirement for your design system.",
+)
 fun ComponentInteractiveSize(size: Dp): ComponentInteractiveSize {
   return ComponentInteractiveSize(size, size)
 }
@@ -156,6 +162,9 @@ class ThemeBuilder internal constructor() {
   var defaultContentColor: Color by mutableStateOf(Color.Unspecified)
   var defaultTextSelectionColors: TextSelectionColors? by mutableStateOf(null)
 
+  @Deprecated(
+    message = "This will be removed in 3.0. It is now up to you to implement this behavior if it is a requirement for your design system.",
+  )
   var defaultComponentInteractiveSize: ComponentInteractiveSize by mutableStateOf(
     ComponentInteractiveSize(Dp.Unspecified, Dp.Unspecified),
   )

--- a/composeunstyled-theming/src/commonTest/kotlin/Theme.test.kt
+++ b/composeunstyled-theming/src/commonTest/kotlin/Theme.test.kt
@@ -21,16 +21,23 @@
  */
 package com.composeunstyled
 
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import com.composeunstyled.theme.NoIndication
 import com.composeunstyled.theme.Theme
 import com.composeunstyled.theme.ThemeProperty
 import com.composeunstyled.theme.ThemeToken
@@ -106,6 +113,46 @@ class ThemeCommonTest {
     onNodeWithText("Hello").assertExists()
     waitForIdle()
     assertThat(themedContentRecompositions).isEqualTo(1)
+  }
+
+  @Test
+  fun themeDefaultsToNoIndicationWhenParentProvidesIndication() = runComposeUiTest {
+    val parentIndication = object : Indication {}
+    var currentIndication: Indication = parentIndication
+    val testTheme = buildTheme()
+
+    setContent {
+      CompositionLocalProvider(LocalIndication provides parentIndication) {
+        testTheme {
+          currentIndication = LocalIndication.current
+        }
+      }
+    }
+
+    waitForIdle()
+    assertThat(currentIndication).isEqualTo(NoIndication)
+  }
+
+  @Test
+  fun themeDefaultsToUnspecifiedTextSelectionColorsWhenParentProvidesColors() = runComposeUiTest {
+    val parentSelectionColors = TextSelectionColors(
+      handleColor = Color.Red,
+      backgroundColor = Color.Blue,
+    )
+    var currentSelectionColors = parentSelectionColors
+    val testTheme = buildTheme()
+
+    setContent {
+      CompositionLocalProvider(LocalTextSelectionColors provides parentSelectionColors) {
+        testTheme {
+          currentSelectionColors = LocalTextSelectionColors.current
+        }
+      }
+    }
+
+    waitForIdle()
+    assertThat(currentSelectionColors.handleColor).isEqualTo(Color.Unspecified)
+    assertThat(currentSelectionColors.backgroundColor).isEqualTo(Color.Unspecified)
   }
 
   val strings = ThemeProperty<String>("strings")


### PR DESCRIPTION
## Summary
- Default theme text selection colors to Color.Unspecified instead of inheriting parent LocalTextSelectionColors
- Keep default theme indication at the no-op indication when a parent provides LocalIndication
- Add common tests for both inherited-local defaults
- Add an Unreleased changelog note

## Tests
- ./gradlew :composeunstyled-theming:jvmTest
- ./gradlew jvmTest spotlessCheck