### PR TITLE
Add TextField selection color styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a `selectionColors` parameter to `UnstyledTextField` for styling text selection handles and
+  background. (#374)
+
 ## [2.2.0] - 2026-05-18
 
 ### Added

--- a/composeunstyled-text-field/src/commonMain/kotlin/com/composeunstyled/TextField.kt
+++ b/composeunstyled-text-field/src/commonMain/kotlin/com/composeunstyled/TextField.kt
@@ -32,7 +32,10 @@ import androidx.compose.foundation.text.input.KeyboardActionHandler
 import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -99,6 +102,10 @@ fun UnstyledTextField(
   accessibilityLabel: String? = null,
   readOnly: Boolean = false,
   cursorBrush: Brush = SolidColor(Color.Unspecified),
+  selectionColors: TextSelectionColors = TextSelectionColors(
+    handleColor = Color.Unspecified,
+    backgroundColor = Color.Unspecified,
+  ),
   textStyle: TextStyle = TextStyle.Default,
   textAlign: TextAlign = TextAlign.Unspecified,
   lineHeight: TextUnit = TextUnit.Unspecified,
@@ -135,32 +142,34 @@ fun UnstyledTextField(
   )
   scope.textAlignment = newTextStyle.textAlign
 
-  key(lineLimits) {
-    BasicTextField(
-      scrollState = scrollState,
-      state = state,
-      interactionSource = interactionSource,
-      textStyle = newTextStyle,
-      enabled = enabled,
-      readOnly = readOnly,
-      outputTransformation = outputTransformation,
-      inputTransformation = inputTransformation,
-      modifier = modifier then buildModifier {
-        add(Modifier.semantics(mergeDescendants = true) {})
-        if (accessibilityLabel != null) {
-          add(Modifier.semantics { contentDescription = accessibilityLabel })
-        }
-      },
-      cursorBrush = cursorBrush,
-      lineLimits = lineLimits,
-      onTextLayout = onTextLayout,
-      keyboardOptions = keyboardOptions,
-      onKeyboardAction = onKeyboardAction,
-      decorator = { innerTextField ->
-        scope.innerTextField = innerTextField
-        scope.content()
-      },
-    )
+  CompositionLocalProvider(LocalTextSelectionColors provides selectionColors) {
+    key(lineLimits) {
+      BasicTextField(
+        scrollState = scrollState,
+        state = state,
+        interactionSource = interactionSource,
+        textStyle = newTextStyle,
+        enabled = enabled,
+        readOnly = readOnly,
+        outputTransformation = outputTransformation,
+        inputTransformation = inputTransformation,
+        modifier = modifier then buildModifier {
+          add(Modifier.semantics(mergeDescendants = true) {})
+          if (accessibilityLabel != null) {
+            add(Modifier.semantics { contentDescription = accessibilityLabel })
+          }
+        },
+        cursorBrush = cursorBrush,
+        lineLimits = lineLimits,
+        onTextLayout = onTextLayout,
+        keyboardOptions = keyboardOptions,
+        onKeyboardAction = onKeyboardAction,
+        decorator = { innerTextField ->
+          scope.innerTextField = innerTextField
+          scope.content()
+        },
+      )
+    }
   }
 }
 

--- a/composeunstyled-text-field/src/commonTest/kotlin/TextField.test.kt
+++ b/composeunstyled-text-field/src/commonTest/kotlin/TextField.test.kt
@@ -33,11 +33,15 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
@@ -177,6 +181,60 @@ class TextFieldTest {
     }
 
     onNodeWithText("secret", useUnmergedTree = true).assertTextEquals("secret")
+  }
+
+  @Test
+  fun providesSelectionColorsToTextInputContent() = runComposeUiTest {
+    val selectionColors = TextSelectionColors(
+      handleColor = Color.Red,
+      backgroundColor = Color.Blue,
+    )
+    var providedSelectionColors: TextSelectionColors? = null
+
+    setContent {
+      UnstyledTextField(
+        state = rememberTextFieldState(),
+        selectionColors = selectionColors,
+      ) {
+        providedSelectionColors = LocalTextSelectionColors.current
+        TextInput()
+      }
+    }
+
+    waitForIdle()
+
+    assertThat(providedSelectionColors).isEqualTo(selectionColors)
+  }
+
+  @Test
+  fun usesUnspecifiedSelectionColorsByDefault() = runComposeUiTest {
+    val parentSelectionColors = TextSelectionColors(
+      handleColor = Color.Red,
+      backgroundColor = Color.Blue,
+    )
+    var providedSelectionColors: TextSelectionColors? = null
+
+    setContent {
+      CompositionLocalProvider(
+        LocalTextSelectionColors provides parentSelectionColors,
+      ) {
+        UnstyledTextField(
+          state = rememberTextFieldState(),
+        ) {
+          providedSelectionColors = LocalTextSelectionColors.current
+          TextInput()
+        }
+      }
+    }
+
+    waitForIdle()
+
+    assertThat(providedSelectionColors).isEqualTo(
+      TextSelectionColors(
+        handleColor = Color.Unspecified,
+        backgroundColor = Color.Unspecified,
+      ),
+    )
   }
 
   @Test

--- a/docs/api-descriptions.json
+++ b/docs/api-descriptions.json
@@ -433,6 +433,8 @@
     "editable": "Whether the text field is editable.",
     "TextField.cursorBrush": "The brush to use for the cursor.",
     "cursorBrush": "The brush to use for the cursor.",
+    "TextField.selectionColors": "Colors to use for text selection handles and background. Defaults to unspecified colors.",
+    "selectionColors": "Colors to use for text selection handles and background. Defaults to unspecified colors.",
     "TextField.textStyle": "Style to apply to the text.",
     "textStyle": "Style to apply to the text.",
     "TextField.textAlign": "Alignment of the text.",

--- a/docs/pages/textfield.md
+++ b/docs/pages/textfield.md
@@ -10,7 +10,7 @@ description: A text field component with placeholders, transformations, and text
 - State-based text input
 - Placeholder slot
 - Input and output transformations
-- Text style parameters
+- Text and selection style parameters
 
 ## Installation
 
@@ -88,6 +88,23 @@ UnstyledTextField(
   state = state,
   fontWeight = FontWeight.Medium,
   textColor = Color.Black,
+) {
+  TextInput()
+}
+```
+
+### Styling selected text
+
+By default, selection colors are unspecified. Use the `selectionColors` parameter to set the
+selection handle and background colors:
+
+```kotlin
+UnstyledTextField(
+  state = state,
+  selectionColors = TextSelectionColors(
+    handleColor = Color.Black,
+    backgroundColor = Color.Black.copy(alpha = 0.4f),
+  ),
 ) {
   TextInput()
 }


### PR DESCRIPTION
## Summary
- Add `selectionColors` to `UnstyledTextField` and provide it through `LocalTextSelectionColors` around the text field
- Keep the default fully unstyled by using unspecified selection handle/background colors instead of inheriting `LocalTextSelectionColors.current`
- Cover both explicit selection colors and the unspecified default behavior in `commonTest`
- Document the new styling hook and changelog entry

Addresses #374

## Verification
- `./gradlew :composeunstyled-text-field:jvmTest`
- `./gradlew jvmTest spotlessCheck`
- `./gradlew generateComposeUnstyledApiReference`
- `./gradlew :demo:hotRunJvm` launched successfully for a smoke run