### PR TITLE
Fix outline offset geometry

### DIFF
--- a/composeunstyled-outline/build.gradle.kts
+++ b/composeunstyled-outline/build.gradle.kts
@@ -87,6 +87,11 @@ kotlin {
         implementation(libs.compose.foundation)
       }
     }
+
+    commonTest.dependencies {
+      implementation(kotlin("test"))
+      implementation(libs.assertk)
+    }
   }
 }
 

--- a/composeunstyled-outline/src/commonMain/kotlin/com/composeunstyled/Outline.kt
+++ b/composeunstyled-outline/src/commonMain/kotlin/com/composeunstyled/Outline.kt
@@ -49,81 +49,97 @@ fun Modifier.outline(
       }
 
       is Outline.Rectangle -> {
-        val inset = -offset.toPx()
+        val geometry = calculateOutlineRectGeometry(
+          rect = Rect(0f, 0f, size.width, size.height),
+          strokeWidth = strokeWidth,
+          offset = offset.toPx(),
+        )
 
         val path = Path().apply {
-          addRect(
-            Rect(
-              left = inset - strokeWidth,
-              top = inset - strokeWidth,
-              right = size.width - inset + strokeWidth,
-              bottom = size.height - inset + strokeWidth,
-            ),
-          )
+          addRect(geometry.outer)
           fillType = PathFillType.EvenOdd
-          addRect(
-            Rect(
-              left = inset,
-              top = inset,
-              right = size.width - inset,
-              bottom = size.height - inset,
-            ),
-          )
+          addRect(geometry.inner)
         }
 
         drawPath(path, color)
       }
 
       is Outline.Rounded -> {
-        val inset = -offset.toPx()
-        val roundRect = outline.roundRect
-
-        val topLeftRadius = roundRect.topLeftCornerRadius.x
-        val topRightRadius = roundRect.topRightCornerRadius.x
-        val bottomRightRadius = roundRect.bottomRightCornerRadius.x
-        val bottomLeftRadius = roundRect.bottomLeftCornerRadius.y
-
-        val topLeftOutlineRadius = topLeftRadius + strokeWidth
-        val topRightOutlineRadius = topRightRadius + strokeWidth
-        val bottomRightOutlineRadius = bottomRightRadius + strokeWidth
-        val bottomLeftOutlineRadius = bottomLeftRadius + strokeWidth
+        val geometry = calculateOutlineRoundRectGeometry(
+          roundRect = outline.roundRect,
+          strokeWidth = strokeWidth,
+          offset = offset.toPx(),
+        )
 
         val path = Path().apply {
-          addRoundRect(
-            RoundRect(
-              left = inset - strokeWidth,
-              top = inset - strokeWidth,
-              right = size.width - inset + strokeWidth,
-              bottom = size.height - inset + strokeWidth,
-              topLeftCornerRadius = CornerRadius(topLeftOutlineRadius, topLeftOutlineRadius),
-              topRightCornerRadius = CornerRadius(topRightOutlineRadius, topRightOutlineRadius),
-              bottomRightCornerRadius = CornerRadius(
-                bottomRightOutlineRadius,
-                bottomRightOutlineRadius,
-              ),
-              bottomLeftCornerRadius = CornerRadius(
-                bottomLeftOutlineRadius,
-                bottomLeftOutlineRadius,
-              ),
-            ),
-          )
+          addRoundRect(geometry.outer)
           fillType = PathFillType.EvenOdd
-          addRoundRect(
-            RoundRect(
-              left = inset,
-              top = inset,
-              right = size.width - inset,
-              bottom = size.height - inset,
-              topLeftCornerRadius = CornerRadius(topLeftRadius, topLeftRadius),
-              topRightCornerRadius = CornerRadius(topRightRadius, topRightRadius),
-              bottomRightCornerRadius = CornerRadius(bottomRightRadius, bottomRightRadius),
-              bottomLeftCornerRadius = CornerRadius(bottomLeftRadius, bottomLeftRadius),
-            ),
-          )
+          addRoundRect(geometry.inner)
         }
 
         drawPath(path, color)
       }
     }
   }
+}
+
+internal data class OutlineRectGeometry(
+  val inner: Rect,
+  val outer: Rect,
+)
+
+internal data class OutlineRoundRectGeometry(
+  val inner: RoundRect,
+  val outer: RoundRect,
+)
+
+internal fun calculateOutlineRectGeometry(
+  rect: Rect,
+  strokeWidth: Float,
+  offset: Float,
+): OutlineRectGeometry {
+  return OutlineRectGeometry(
+    inner = rect.inflate(offset),
+    outer = rect.inflate(offset + strokeWidth),
+  )
+}
+
+internal fun calculateOutlineRoundRectGeometry(
+  roundRect: RoundRect,
+  strokeWidth: Float,
+  offset: Float,
+): OutlineRoundRectGeometry {
+  return OutlineRoundRectGeometry(
+    inner = roundRect.inflate(offset),
+    outer = roundRect.inflate(offset + strokeWidth),
+  )
+}
+
+private fun Rect.inflate(amount: Float): Rect {
+  return Rect(
+    left = left - amount,
+    top = top - amount,
+    right = right + amount,
+    bottom = bottom + amount,
+  )
+}
+
+private fun RoundRect.inflate(amount: Float): RoundRect {
+  return RoundRect(
+    left = left - amount,
+    top = top - amount,
+    right = right + amount,
+    bottom = bottom + amount,
+    topLeftCornerRadius = topLeftCornerRadius.inflate(amount),
+    topRightCornerRadius = topRightCornerRadius.inflate(amount),
+    bottomRightCornerRadius = bottomRightCornerRadius.inflate(amount),
+    bottomLeftCornerRadius = bottomLeftCornerRadius.inflate(amount),
+  )
+}
+
+private fun CornerRadius.inflate(amount: Float): CornerRadius {
+  return CornerRadius(
+    x = (x + amount).coerceAtLeast(0f),
+    y = (y + amount).coerceAtLeast(0f),
+  )
 }

--- a/composeunstyled-outline/src/commonTest/kotlin/com/composeunstyled/OutlineTest.kt
+++ b/composeunstyled-outline/src/commonTest/kotlin/com/composeunstyled/OutlineTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class OutlineTest {
+  @Test
+  fun rectangleOffsetExpandsInnerAndOuterBounds() {
+    val geometry = calculateOutlineRectGeometry(
+      rect = Rect(left = 0f, top = 0f, right = 100f, bottom = 40f),
+      strokeWidth = 2f,
+      offset = 4f,
+    )
+
+    assertThat(geometry.inner).isEqualTo(Rect(left = -4f, top = -4f, right = 104f, bottom = 44f))
+    assertThat(geometry.outer).isEqualTo(Rect(left = -6f, top = -6f, right = 106f, bottom = 46f))
+  }
+
+  @Test
+  fun roundedOffsetExpandsCornerRadii() {
+    val geometry = calculateOutlineRoundRectGeometry(
+      roundRect = RoundRect(
+        left = 0f,
+        top = 0f,
+        right = 100f,
+        bottom = 40f,
+        cornerRadius = CornerRadius(8f, 8f),
+      ),
+      strokeWidth = 2f,
+      offset = 4f,
+    )
+
+    assertThat(geometry.inner.topLeftCornerRadius).isEqualTo(CornerRadius(12f, 12f))
+    assertThat(geometry.outer.topLeftCornerRadius).isEqualTo(CornerRadius(14f, 14f))
+  }
+
+  @Test
+  fun roundedOffsetPreservesAsymmetricCornerRadii() {
+    val geometry = calculateOutlineRoundRectGeometry(
+      roundRect = RoundRect(
+        left = 0f,
+        top = 0f,
+        right = 100f,
+        bottom = 40f,
+        topLeftCornerRadius = CornerRadius(8f, 4f),
+        topRightCornerRadius = CornerRadius(10f, 6f),
+        bottomRightCornerRadius = CornerRadius(12f, 8f),
+        bottomLeftCornerRadius = CornerRadius(14f, 10f),
+      ),
+      strokeWidth = 2f,
+      offset = 4f,
+    )
+
+    assertThat(geometry.inner.topLeftCornerRadius).isEqualTo(CornerRadius(12f, 8f))
+    assertThat(geometry.outer.topLeftCornerRadius).isEqualTo(CornerRadius(14f, 10f))
+    assertThat(geometry.inner.bottomRightCornerRadius).isEqualTo(CornerRadius(16f, 12f))
+    assertThat(geometry.outer.bottomRightCornerRadius).isEqualTo(CornerRadius(18f, 14f))
+  }
+}


### PR DESCRIPTION
## Summary

Fixes outline offset geometry for rounded shapes. The offset now expands both the outline bounds and the corner radii before applying the stroke width, so focus rings keep the expected shape when drawn outside a component.

Also adds common tests for rectangle and rounded outline geometry, including asymmetric corner radii.

## Test Plan

Captured the bug first: `roundedOffsetExpandsCornerRadii` failed before the fix because an 8px radius with 4px offset still rendered the inner/outer radii as 8px/10px instead of 12px/14px.

- [x] Tests added/updated
- [ ] Manual testing performed

Commands run:

- `./gradlew :composeunstyled-outline:jvmTest`
- `./gradlew :composeunstyled-outline:spotlessCheck`

## Related Issues

None.

## Screenshots/Videos

Not applicable. This is covered by the outline geometry regression tests.