### PR TITLE
Fix content-height sheet hidden transitions

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -404,7 +404,11 @@ class BottomSheetState internal constructor(
       anchoredDraggableState.offset.isNaN().not()
 
     return if (isMovingToDifferentDetent) {
-      currentDetent.dependsOnSheetHeight() && targetDetent.dependsOnSheetHeight()
+      (
+        currentDetent.dependsOnSheetHeight() &&
+          (targetDetent.dependsOnSheetHeight() || targetDetent == SheetDetent.Hidden)
+        ) ||
+        (targetDetent.dependsOnSheetHeight() && currentDetent == SheetDetent.Hidden)
     } else {
       currentDetent.dependsOnSheetHeight()
     }

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -704,6 +704,58 @@ class BottomSheetCommonTest {
   }
 
   @Test
+  fun sheet_content_keeps_its_height_while_animating_from_hidden_to_content_height_detent() =
+    runComposeUiTest {
+      lateinit var state: BottomSheetState
+
+      setContent {
+        Box(Modifier.requiredSize(400.dp)) {
+          state = rememberBottomSheetState(
+            initialDetent = SheetDetent.Hidden,
+            detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
+            animationSpec = tween(durationMillis = 300),
+          )
+
+          UnstyledBottomSheet(
+            state,
+            Modifier.fillMaxSize().testTag("sheet"),
+          ) {
+            Box(
+              modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+              contentAlignment = Alignment.TopCenter,
+            ) {
+              Sheet(
+                Modifier
+                  .widthIn(max = 320.dp)
+                  .fillMaxWidth()
+                  .testTag("panel"),
+              ) {
+                Box(
+                  Modifier
+                    .testTag("sheet_contents")
+                    .fillMaxWidth()
+                    .height(80.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+
+      waitForIdle()
+      mainClock.autoAdvance = false
+
+      state.targetDetent = SheetDetent.FullyExpanded
+      mainClock.advanceTimeBy(150)
+
+      onNodeWithTag("panel").assertHeightIsEqualTo(80.dp)
+
+      mainClock.autoAdvance = true
+    }
+
+  @Test
   fun sheet_stops_at_detent_fixed_height_when_target_detent_set_to_detent_with_fixed_height_from_hidden() = runComposeUiTest {
     val customDetent = SheetDetent("fixed") { _, _ -> 40.dp }
 
@@ -1302,6 +1354,76 @@ class BottomSheetCommonTest {
     onNodeWithTag("panel").assertHeightIsEqualTo(400.dp)
 
     onNodeWithTag("sheet").performTouchInput {
+      up()
+    }
+    mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun sheet_content_keeps_its_height_when_drag_reverses_after_moving_toward_hidden() = runComposeUiTest {
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(400.dp)) {
+        state = rememberBottomSheetState(
+          initialDetent = SheetDetent.FullyExpanded,
+          detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
+        )
+
+        UnstyledBottomSheet(
+          state,
+          Modifier.fillMaxSize().testTag("sheet"),
+        ) {
+          Box(
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(16.dp),
+            contentAlignment = Alignment.TopCenter,
+          ) {
+            Sheet(
+              Modifier
+                .widthIn(max = 320.dp)
+                .fillMaxWidth()
+                .testTag("panel"),
+            ) {
+              Box(
+                Modifier
+                  .testTag("sheet_contents")
+                  .fillMaxWidth()
+                  .height(80.dp),
+              )
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("panel").assertHeightIsEqualTo(80.dp)
+    val restingTop = onNodeWithTag("panel").fetchSemanticsNode().boundsInRoot.top
+    val restingOffset = state.offset
+
+    mainClock.autoAdvance = false
+    val dragDistance = with(density) { 220.dp.toPx() }
+    val tolerance = with(density) { DensityTolerance.toPx() }
+
+    onNodeWithTag("panel").performTouchInput {
+      down(center)
+      moveTo(center.copy(y = center.y + dragDistance))
+      moveTo(center.copy(y = center.y - dragDistance))
+    }
+    mainClock.advanceTimeByFrame()
+
+    onNodeWithTag("panel").assertHeightIsEqualTo(80.dp)
+    val reversedDragTop = onNodeWithTag("panel").fetchSemanticsNode().boundsInRoot.top
+    assertThat(reversedDragTop >= restingTop - tolerance).isTrue()
+    assertThat(state.offset <= restingOffset + tolerance).isTrue()
+    assertThat(state.contentHeightPx).isCloseTo(
+      restingOffset,
+      tolerance,
+    )
+
+    onNodeWithTag("panel").performTouchInput {
       up()
     }
     mainClock.autoAdvance = true


### PR DESCRIPTION
## Summary

Fixes content-height bottom sheet detents growing to the container height while moving to or from the hidden detent.

The sheet layout now stays content-sized for hidden/content-height transitions in both directions, while keeping container-based detents able to expand beyond short content.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed

Validated with:

- `./gradlew --quiet :composeunstyled-bottom-sheet:jvmTest --tests BottomSheetCommonTest.sheet_content_keeps_its_height_while_animating_from_hidden_to_content_height_detent --tests BottomSheetCommonTest.sheet_content_keeps_its_height_when_drag_reverses_after_moving_toward_hidden --tests BottomSheetCommonTest.percentage_detent_uses_container_height_when_content_is_shorter_than_detent --tests BottomSheetCommonTest.percentage_detent_without_hidden_uses_container_height_when_content_is_shorter_than_detent --tests BottomSheetCommonTest.short_content_percentage_detent_can_expand_to_full_and_rest`
- `./gradlew :demo:hotReloadJvmMain`
- `./gradlew --console=plain :composeunstyled-bottom-sheet:jvmTest spotlessCheck`
- Manual demo verification of startup animation and reversed drag behavior

## Related Issues

None.

## Screenshots/Videos

Visual regressions will be run through the manual CI workflow on this PR branch.
