### PR TITLE
Fix dropdown menu keyboard focus behavior

### DIFF
--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -29,26 +29,31 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -56,7 +61,11 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.ParentDataModifier
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -64,6 +73,8 @@ import androidx.compose.ui.unit.dp
 internal class DropdownMenuState(
   val onExpandedChange: (Boolean) -> Unit,
   val transitionState: MutableTransitionState<Boolean>,
+  val initialFocusDirection: FocusDirection? = null,
+  val onExitMenu: (FocusDirection) -> Unit = {},
 )
 
 interface DropdownMenuScope
@@ -71,7 +82,8 @@ interface DropdownMenuScope
 private object DropdownMenuScopeInstance : DropdownMenuScope
 
 class DropdownMenuPanelScope internal constructor() {
-  internal val itemFocusRequesters = mutableStateListOf<FocusRequester>()
+  internal var itemFocusTargets: List<DropdownMenuItemFocusTarget> = emptyList()
+  internal var firstItemFocusTarget by mutableStateOf<DropdownMenuItemFocusTarget?>(null)
 }
 
 internal val LocalDropdownMenuState = staticCompositionLocalOf<DropdownMenuState> {
@@ -80,6 +92,11 @@ internal val LocalDropdownMenuState = staticCompositionLocalOf<DropdownMenuState
     transitionState = MutableTransitionState(false),
   )
 }
+
+internal class DropdownMenuItemFocusTarget(
+  val focusRequester: FocusRequester,
+  var focused: Boolean = false,
+)
 
 @Composable
 fun UnstyledDropdownMenu(
@@ -94,11 +111,37 @@ fun UnstyledDropdownMenu(
   anchor: @Composable () -> Unit,
 ) {
   val modalState = rememberModalState(initiallyVisible = expanded)
+  val focusManager = LocalFocusManager.current
+  val anchorPreviousExitFocusRequester = remember { FocusRequester() }
+  val anchorNextExitFocusRequester = remember { FocusRequester() }
+  var initialFocusDirection by remember { mutableStateOf<FocusDirection?>(null) }
+  var pendingExitFocusDirection by remember { mutableStateOf<FocusDirection?>(null) }
   SideEffect { modalState.transitionState.targetState = expanded }
-  val state = remember(onExpandedChange, modalState.transitionState) {
+  LaunchedEffect(expanded) {
+    if (expanded.not()) {
+      initialFocusDirection = null
+    }
+  }
+  LaunchedEffect(expanded, pendingExitFocusDirection) {
+    val direction = pendingExitFocusDirection
+    if (expanded.not() && direction != null) {
+      when (direction) {
+        FocusDirection.Previous -> anchorPreviousExitFocusRequester.requestFocus()
+        else -> anchorNextExitFocusRequester.requestFocus()
+      }
+      focusManager.moveFocus(direction)
+      pendingExitFocusDirection = null
+    }
+  }
+  val state = remember(onExpandedChange, modalState.transitionState, initialFocusDirection) {
     DropdownMenuState(
       onExpandedChange = onExpandedChange,
       transitionState = modalState.transitionState,
+      initialFocusDirection = initialFocusDirection,
+      onExitMenu = { direction ->
+        pendingExitFocusDirection = direction
+        onExpandedChange(false)
+      },
     )
   }
 
@@ -108,14 +151,30 @@ fun UnstyledDropdownMenu(
         return@onPreviewKeyEvent false
       }
       when (event.key) {
-        Key.DirectionDown, Key.Enter, Key.Spacebar -> {
-          onExpandedChange(true)
+        Key.DirectionDown -> {
+          initialFocusDirection = FocusDirection.Next
+          if (expanded.not()) {
+            onExpandedChange(true)
+          }
           true
         }
 
         Key.DirectionUp -> {
-          onExpandedChange(true)
+          initialFocusDirection = FocusDirection.Previous
+          if (expanded.not()) {
+            onExpandedChange(true)
+          }
           true
+        }
+
+        Key.Enter, Key.Spacebar -> {
+          if (expanded) {
+            false
+          } else {
+            initialFocusDirection = FocusDirection.Next
+            onExpandedChange(true)
+            true
+          }
         }
 
         else -> false
@@ -123,7 +182,6 @@ fun UnstyledDropdownMenu(
     },
   ) {
     AnchoredFloatingContent(
-      anchor = anchor,
       layer = { content ->
         Modal(state = modalState) {
           if (expanded) {
@@ -150,6 +208,25 @@ fun UnstyledDropdownMenu(
       alignment = alignment,
       sideOffset = sideOffset,
       alignmentOffset = alignmentOffset,
+      anchor = {
+        Box {
+          // Hidden focus sentinels let Tab/Shift+Tab close the menu and continue traversal
+          // from the anchor's position without requiring the caller's anchor to expose a modifier.
+          Box(
+            Modifier
+              .size(0.dp)
+              .focusRequester(anchorPreviousExitFocusRequester)
+              .focusable(enabled = pendingExitFocusDirection == FocusDirection.Previous),
+          )
+          anchor()
+          Box(
+            Modifier
+              .size(0.dp)
+              .focusRequester(anchorNextExitFocusRequester)
+              .focusable(enabled = pendingExitFocusDirection == FocusDirection.Next),
+          )
+        }
+      },
     )
   }
 }
@@ -162,59 +239,93 @@ fun DropdownMenuScope.DropdownMenuPanel(
   content: @Composable DropdownMenuPanelScope.() -> Unit,
 ) {
   val state = LocalDropdownMenuState.current
+  val modalState = LocalModalState.current
   val menuFocusRequester = remember { FocusRequester() }
   val currentFocusManager = LocalFocusManager.current
   val scope = remember { DropdownMenuPanelScope() }
+  var placed by remember { mutableStateOf(false) }
+
+  LaunchedEffect(
+    modalState,
+    placed,
+    state.initialFocusDirection,
+    state.transitionState.targetState,
+  ) {
+    if (placed && state.initialFocusDirection == null && state.transitionState.targetState) {
+      modalState.awaitAttachedToWindow()
+      menuFocusRequester.requestFocus()
+    }
+  }
 
   AnimatedVisibility(
     visibleState = state.transitionState,
     enter = enter,
     exit = exit,
-    modifier = Modifier.onKeyEvent { event ->
-      when (event.key) {
-        Key.DirectionDown -> {
-          if (event.isKeyDown) {
-            currentFocusManager.moveFocus(FocusDirection.Next)
-          }
+    modifier = Modifier
+      .onPreviewKeyEvent { event ->
+        if (event.isKeyDown && event.key == Key.Tab) {
+          state.onExitMenu(
+            if (event.isShiftPressed) {
+              FocusDirection.Previous
+            } else {
+              FocusDirection.Next
+            },
+          )
           true
+        } else {
+          false
         }
-
-        Key.DirectionUp -> {
-          if (event.isKeyDown) {
-            currentFocusManager.moveFocus(FocusDirection.Previous)
-          }
-          true
-        }
-
-        Key.Home -> {
-          if (event.isKeyDown) {
-            scope.itemFocusRequesters.firstOrNull()?.requestFocus()
-          }
-          true
-        }
-
-        Key.MoveEnd -> {
-          if (event.isKeyDown) {
-            scope.itemFocusRequesters.lastOrNull()?.requestFocus()
-          }
-          true
-        }
-
-        else -> false
       }
-    },
+      .onKeyEvent { event ->
+        when (event.key) {
+          Key.DirectionDown -> {
+            if (event.isKeyDown) {
+              if (scope.hasFocusedItem()) {
+                currentFocusManager.moveFocus(FocusDirection.Next)
+              } else {
+                scope.itemFocusTargets.firstOrNull()?.focusRequester?.requestFocus()
+              }
+            }
+            true
+          }
+
+          Key.DirectionUp -> {
+            if (event.isKeyDown) {
+              if (scope.hasFocusedItem()) {
+                currentFocusManager.moveFocus(FocusDirection.Previous)
+              } else {
+                scope.itemFocusTargets.lastOrNull()?.focusRequester?.requestFocus()
+              }
+            }
+            true
+          }
+
+          Key.Home -> {
+            if (event.isKeyDown) {
+              scope.itemFocusTargets.firstOrNull()?.focusRequester?.requestFocus()
+            }
+            true
+          }
+
+          Key.MoveEnd -> {
+            if (event.isKeyDown) {
+              scope.itemFocusTargets.lastOrNull()?.focusRequester?.requestFocus()
+            }
+            true
+          }
+
+          else -> false
+        }
+      },
   ) {
-    Box(
+    DropdownMenuPanelLayout(
+      scope = scope,
       modifier = modifier
         .modalFragment()
-        .focusRequester(menuFocusRequester),
+        .onPlaced { placed = true }
+        .focusRequester(menuFocusRequester)
+        .focusable(),
     ) {
-      // Request focus when the menu becomes visible
-      if (state.transitionState.currentState) {
-        LaunchedEffect(Unit) {
-          menuFocusRequester.requestFocus()
-        }
-      }
       scope.content()
     }
   }
@@ -231,18 +342,38 @@ fun DropdownMenuPanelScope.MenuItem(
   content: @Composable () -> Unit,
 ) {
   val state = LocalDropdownMenuState.current
+  val modalState = LocalModalState.current
   val focusRequester = remember { FocusRequester() }
+  val focusTarget = remember(focusRequester) {
+    DropdownMenuItemFocusTarget(focusRequester = focusRequester)
+  }
+  var placed by remember { mutableStateOf(false) }
+  val isFirstItem = firstItemFocusTarget == focusTarget
+  val shouldRequestInitialFocus = when (state.initialFocusDirection) {
+    FocusDirection.Next -> isFirstItem
+    FocusDirection.Previous -> itemFocusTargets.lastOrNull() == focusTarget
+    else -> false
+  }
 
-  DisposableEffect(focusRequester) {
-    itemFocusRequesters.add(focusRequester)
-    onDispose {
-      itemFocusRequesters.remove(focusRequester)
+  LaunchedEffect(
+    modalState,
+    focusRequester,
+    shouldRequestInitialFocus,
+    placed,
+    state.transitionState.targetState,
+  ) {
+    if (shouldRequestInitialFocus && placed && state.transitionState.targetState) {
+      modalState.awaitAttachedToWindow()
+      focusRequester.requestFocus()
     }
   }
 
   Box(
     modifier = modifier then buildModifier {
+      add(DropdownMenuItemParentDataModifier(focusTarget))
+      add(Modifier.onPlaced { placed = true })
       add(Modifier.focusRequester(focusRequester))
+      add(Modifier.onFocusChanged { focusTarget.focused = it.hasFocus })
       add(
         Modifier.clickable(
           onClick = {
@@ -267,3 +398,63 @@ fun DropdownMenuPanelScope.MenuItem(
 
 private val KeyEvent.isKeyDown: Boolean
   get() = type == KeyEventType.KeyDown
+
+@Composable
+private fun DropdownMenuPanelLayout(
+  scope: DropdownMenuPanelScope,
+  modifier: Modifier,
+  content: @Composable () -> Unit,
+) {
+  Layout(
+    modifier = modifier,
+    content = content,
+  ) { measurables, constraints ->
+    val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+    val placeables = measurables.map { it.measure(looseConstraints) }
+    val width = placeables
+      .maxOfOrNull { it.width }
+      ?.coerceIn(constraints.minWidth, constraints.maxWidth)
+      ?: constraints.minWidth
+    val contentHeight = placeables.sumOf { it.height }
+    val height = contentHeight.coerceIn(constraints.minHeight, constraints.maxHeight)
+    val orderedFocusTargets = measurables.mapNotNull {
+      (it.parentData as? DropdownMenuItemParentData)?.focusTarget
+    }
+
+    scope.updateItemFocusTargets(orderedFocusTargets)
+
+    layout(width, height) {
+      var y = 0
+      placeables.forEach { placeable ->
+        placeable.placeRelative(x = 0, y = y)
+        y += placeable.height
+      }
+    }
+  }
+}
+
+private fun DropdownMenuPanelScope.updateItemFocusTargets(
+  orderedFocusTargets: List<DropdownMenuItemFocusTarget>,
+) {
+  if (itemFocusTargets == orderedFocusTargets) {
+    return
+  }
+  itemFocusTargets = orderedFocusTargets
+  firstItemFocusTarget = orderedFocusTargets.firstOrNull()
+}
+
+private fun DropdownMenuPanelScope.hasFocusedItem(): Boolean {
+  return itemFocusTargets.any { it.focused }
+}
+
+private data class DropdownMenuItemParentData(
+  val focusTarget: DropdownMenuItemFocusTarget,
+)
+
+private data class DropdownMenuItemParentDataModifier(
+  val focusTarget: DropdownMenuItemFocusTarget,
+) : ParentDataModifier {
+  override fun Density.modifyParentData(parentData: Any?): Any {
+    return DropdownMenuItemParentData(focusTarget)
+  }
+}

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -24,7 +24,11 @@ package com.composeunstyled
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -42,7 +46,9 @@ import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.KeyInjectionScope
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -284,6 +290,362 @@ class DropdownMenuPanelTest {
   }
 
   @Test
+  fun openingMenuRequestsFocusBeforeEnterTransitionCompletes() = runComposeUiTest {
+    mainClock.autoAdvance = false
+
+    var expanded by mutableStateOf(false)
+
+    setContent {
+      UseKeyboardInputMode()
+      UnstyledDropdownMenu(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        panel = {
+          DropdownMenuPanel(
+            enter = fadeIn(animationSpec = tween(durationMillis = 1_000)),
+          ) {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+          }
+        },
+        anchor = {
+          BasicText("Anchor", Modifier.testTag("anchor").focusable())
+        },
+      )
+    }
+
+    onNodeWithTag("anchor").requestFocus()
+    onNodeWithTag("anchor").performKeyInput {
+      pressKey(Key.Enter)
+    }
+    mainClock.advanceTimeBy(100)
+
+    assertThat(expanded).isTrue()
+    onNodeWithTag("first").assertIsFocused()
+
+    mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun clickingAnchorOpensMenuWithoutFocusingFirstItem() = runComposeUiTest {
+    var expanded by mutableStateOf(false)
+    var firstItemClicked = false
+
+    setContent {
+      UnstyledDropdownMenu(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        panel = {
+          DropdownMenuPanel(modifier = Modifier.testTag("panel")) {
+            MenuItem(onClick = { firstItemClicked = true }, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        },
+        anchor = {
+          BasicText(
+            text = "Anchor",
+            modifier = Modifier
+              .testTag("anchor")
+              .focusable()
+              .clickable { expanded = true },
+          )
+        },
+      )
+    }
+
+    onNodeWithTag("anchor").performClick()
+    waitForIdle()
+
+    assertThat(expanded).isTrue()
+    onNodeWithTag("panel").assertIsFocused()
+    onNodeWithTag("first").assertIsNotFocused()
+
+    onNodeWithTag("panel").performKeyInput {
+      pressKey(Key.Spacebar)
+    }
+    waitForIdle()
+
+    assertThat(firstItemClicked).isFalse()
+    onNodeWithTag("first").assertIsNotFocused()
+  }
+
+  @Test
+  fun downArrowAfterClickingAnchorFocusesFirstItem() = runComposeUiTest {
+    var expanded by mutableStateOf(false)
+
+    setContent {
+      UnstyledDropdownMenu(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        panel = {
+          DropdownMenuPanel(modifier = Modifier.testTag("panel")) {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        },
+        anchor = {
+          BasicText(
+            text = "Anchor",
+            modifier = Modifier
+              .testTag("anchor")
+              .focusable()
+              .clickable { expanded = true },
+          )
+        },
+      )
+    }
+
+    onNodeWithTag("anchor").performClick()
+    waitForIdle()
+    onNodeWithTag("panel").assertIsFocused()
+    onNodeWithTag("first").assertIsNotFocused()
+    onNodeWithTag("panel").performKeyInput {
+      pressKey(Key.DirectionDown)
+    }
+    waitForIdle()
+
+    onNodeWithTag("first").assertIsFocused()
+  }
+
+  @Test
+  fun upArrowAfterClickingAnchorFocusesLastItem() = runComposeUiTest {
+    var expanded by mutableStateOf(false)
+
+    setContent {
+      UnstyledDropdownMenu(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        panel = {
+          DropdownMenuPanel(modifier = Modifier.testTag("panel")) {
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        },
+        anchor = {
+          BasicText(
+            text = "Anchor",
+            modifier = Modifier
+              .testTag("anchor")
+              .focusable()
+              .clickable { expanded = true },
+          )
+        },
+      )
+    }
+
+    onNodeWithTag("anchor").performClick()
+    waitForIdle()
+    onNodeWithTag("panel").assertIsFocused()
+    onNodeWithTag("first").assertIsNotFocused()
+    onNodeWithTag("panel").performKeyInput {
+      pressKey(Key.DirectionUp)
+    }
+    waitForIdle()
+
+    onNodeWithTag("last").assertIsFocused()
+  }
+
+  @Test
+  fun spaceKeyActivatesFocusedMenuItemAfterClickingAnchorAndArrowNavigation() = runComposeUiTest {
+    var expanded by mutableStateOf(false)
+    var firstItemClicked = false
+
+    setContent {
+      UnstyledDropdownMenu(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        panel = {
+          DropdownMenuPanel(modifier = Modifier.testTag("panel")) {
+            MenuItem(onClick = { firstItemClicked = true }, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+          }
+        },
+        anchor = {
+          BasicText(
+            text = "Anchor",
+            modifier = Modifier
+              .testTag("anchor")
+              .focusable()
+              .clickable { expanded = true },
+          )
+        },
+      )
+    }
+
+    onNodeWithTag("anchor").performClick()
+    waitForIdle()
+    onNodeWithTag("panel").performKeyInput {
+      pressKey(Key.DirectionDown)
+    }
+    waitForIdle()
+    onNodeWithTag("first").assertIsFocused()
+
+    onNodeWithTag("first").performKeyInput {
+      pressKey(Key.Spacebar)
+    }
+    waitForIdle()
+
+    assertThat(firstItemClicked).isTrue()
+  }
+
+  @Test
+  fun tabKeyClosesMenuAndMovesFocusToNextFocusableAfterAnchor() = runComposeUiTest {
+    var expanded by mutableStateOf(true)
+
+    setContent {
+      UseKeyboardInputMode()
+      Column {
+        BasicText("Before", Modifier.testTag("before").focusable())
+        UnstyledDropdownMenu(
+          expanded = expanded,
+          onExpandedChange = { expanded = it },
+          panel = {
+            DropdownMenuPanel {
+              MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+                BasicText("First")
+              }
+              MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+                BasicText("Last")
+              }
+            }
+          },
+          anchor = {
+            BasicText("Anchor", Modifier.testTag("anchor").focusable())
+          },
+        )
+        BasicText("After", Modifier.testTag("after").focusable())
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("first").requestFocus()
+    waitForIdle()
+    onNodeWithTag("first").assertIsFocused()
+
+    onNodeWithTag("first").performKeyInput {
+      pressKey(Key.Tab)
+    }
+    waitForIdle()
+
+    assertThat(expanded).isFalse()
+    onNodeWithTag("after").assertIsFocused()
+  }
+
+  @Test
+  fun shiftTabKeyClosesMenuAndMovesFocusToPreviousFocusableBeforeAnchor() = runComposeUiTest {
+    var expanded by mutableStateOf(true)
+
+    setContent {
+      UseKeyboardInputMode()
+      Column {
+        BasicText("Before", Modifier.testTag("before").focusable())
+        UnstyledDropdownMenu(
+          expanded = expanded,
+          onExpandedChange = { expanded = it },
+          panel = {
+            DropdownMenuPanel {
+              MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+                BasicText("First")
+              }
+              MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+                BasicText("Last")
+              }
+            }
+          },
+          anchor = {
+            BasicText("Anchor", Modifier.testTag("anchor").focusable())
+          },
+        )
+        BasicText("After", Modifier.testTag("after").focusable())
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("first").requestFocus()
+    waitForIdle()
+    onNodeWithTag("first").assertIsFocused()
+
+    onNodeWithTag("first").performKeyInput {
+      shiftTab()
+    }
+    waitForIdle()
+
+    assertThat(expanded).isFalse()
+    onNodeWithTag("before").assertIsFocused()
+  }
+
+  @Test
+  fun panelPlacesDirectChildrenVertically() = runComposeUiTest {
+    val itemHeight = 24.dp
+    var firstItemY = 0
+    var secondItemY = 0
+    var expectedSecondItemY = 0
+
+    setContent {
+      val density = LocalDensity.current
+      SideEffect {
+        expectedSecondItemY = with(density) {
+          itemHeight.roundToPx()
+        }
+      }
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            MenuItem(
+              onClick = {},
+              modifier = Modifier
+                .testTag("first")
+                .size(itemHeight)
+                .onPlaced { firstItemY = it.positionInWindow().y.toInt() },
+            ) {
+              BasicText("First")
+            }
+            BasicText(
+              text = "Separator",
+              modifier = Modifier.size(itemHeight),
+            )
+            MenuItem(
+              onClick = {},
+              modifier = Modifier
+                .testTag("second")
+                .size(itemHeight)
+                .onPlaced { secondItemY = it.positionInWindow().y.toInt() },
+            ) {
+              BasicText("Second")
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+
+    assertThat(secondItemY - firstItemY).isEqualTo(expectedSecondItemY * 2)
+  }
+
+  @Test
   fun homeKeyMovesFocusToFirstMenuItem() = runComposeUiTest {
     setContent {
       UseKeyboardInputMode()
@@ -358,6 +720,110 @@ class DropdownMenuPanelTest {
 
     onNodeWithTag("last").assertIsFocused()
   }
+
+  @Test
+  fun homeAndEndKeysSkipDirectChildrenThatAreNotMenuItems() = runComposeUiTest {
+    setContent {
+      UseKeyboardInputMode()
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            BasicText("Before")
+            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              BasicText("First")
+            }
+            BasicText("Separator")
+            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              BasicText("Last")
+            }
+            BasicText("After")
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("first").requestFocus()
+    waitForIdle()
+
+    onNodeWithTag("first").performKeyInput {
+      pressKey(Key.MoveEnd)
+    }
+
+    onNodeWithTag("last").assertIsFocused()
+
+    onNodeWithTag("last").performKeyInput {
+      pressKey(Key.Home)
+    }
+
+    onNodeWithTag("first").assertIsFocused()
+  }
+
+  @Test
+  fun homeAndEndKeysUseCurrentMenuItemOrderAfterReordering() = runComposeUiTest {
+    var reversed by mutableStateOf(false)
+
+    setContent {
+      UseKeyboardInputMode()
+      with(FakeDropdownMenuScope) {
+        CompositionLocalProvider(
+          LocalDropdownMenuState provides DropdownMenuState(
+            onExpandedChange = {},
+            transitionState = MutableTransitionState(true),
+          ),
+        ) {
+          DropdownMenuPanel {
+            if (reversed) {
+              ReorderableMenuItem(tag = "last", text = "Last")
+              ReorderableMenuItem(tag = "middle", text = "Middle")
+              ReorderableMenuItem(tag = "first", text = "First")
+            } else {
+              ReorderableMenuItem(tag = "first", text = "First")
+              ReorderableMenuItem(tag = "middle", text = "Middle")
+              ReorderableMenuItem(tag = "last", text = "Last")
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("middle").requestFocus()
+    waitForIdle()
+
+    onNodeWithTag("middle").performKeyInput {
+      pressKey(Key.Home)
+    }
+
+    onNodeWithTag("first").assertIsFocused()
+
+    runOnIdle {
+      reversed = true
+    }
+    waitForIdle()
+    onNodeWithTag("middle").requestFocus()
+    waitForIdle()
+
+    onNodeWithTag("middle").performKeyInput {
+      pressKey(Key.Home)
+    }
+
+    onNodeWithTag("last").assertIsFocused()
+
+    onNodeWithTag("middle").requestFocus()
+    waitForIdle()
+
+    onNodeWithTag("middle").performKeyInput {
+      pressKey(Key.MoveEnd)
+    }
+
+    onNodeWithTag("first").assertIsFocused()
+  }
 }
 
 @Composable
@@ -367,6 +833,19 @@ private fun UseKeyboardInputMode() {
   LaunchedEffect(inputModeManager) {
     inputModeManager.requestInputMode(InputMode.Keyboard)
   }
+}
+
+@Composable
+private fun DropdownMenuPanelScope.ReorderableMenuItem(tag: String, text: String) {
+  MenuItem(onClick = {}, modifier = Modifier.testTag(tag)) {
+    BasicText(text)
+  }
+}
+
+private fun KeyInjectionScope.shiftTab() {
+  keyDown(Key.ShiftLeft)
+  pressKey(Key.Tab)
+  keyUp(Key.ShiftLeft)
 }
 
 private object FakeDropdownMenuScope : DropdownMenuScope

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -109,47 +108,44 @@ fun DropdownMenuDemo() {
         ) +
           fadeOut(tween(durationMillis = 75)),
       ) {
-        Column {
-          options.forEachIndexed { index, option ->
-            if (index == 1 || index == options.lastIndex) {
-              UnstyledHorizontalSeparator(color = Color(0xFFBDBDBD))
-            }
-            MenuItem(
-              onClick = {},
-              enabled = option.enabled,
+        options.forEachIndexed { index, option ->
+          if (index == 1 || index == options.lastIndex) {
+            UnstyledHorizontalSeparator(color = Color(0xFFBDBDBD))
+          }
+          MenuItem(
+            onClick = {},
+            enabled = option.enabled,
+            modifier = Modifier
+              .padding(4.dp)
+              .sizeIn(minWidth = 40.dp, minHeight = 40.dp)
+              .clip(RoundedCornerShape(8.dp))
+              .fillMaxWidth(),
+          ) {
+            Row(
               modifier = Modifier
-                .padding(4.dp)
-                .sizeIn(minWidth = 40.dp, minHeight = 40.dp)
-                .clip(RoundedCornerShape(8.dp))
-                .fillMaxWidth(),
-              indication = LocalIndication.current,
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+              horizontalArrangement = Arrangement.Start,
+              verticalAlignment = Alignment.CenterVertically,
             ) {
-              Row(
-                modifier = Modifier
-                  .fillMaxWidth()
-                  .padding(horizontal = 8.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.Start,
-                verticalAlignment = Alignment.CenterVertically,
-              ) {
-                val contentColor = (
-                  if (option.dangerous) {
-                    Color(0xFFDC2626)
-                  } else {
-                    LocalContentColor.current
-                  }
-                  ).copy(alpha = if (option.enabled) 1f else 0.5f)
+              val contentColor = (
+                if (option.dangerous) {
+                  Color(0xFFDC2626)
+                } else {
+                  LocalContentColor.current
+                }
+                ).copy(alpha = if (option.enabled) 1f else 0.5f)
 
-                UnstyledIcon(
-                  imageVector = option.icon,
-                  contentDescription = null,
-                  tint = contentColor,
-                )
-                Spacer(Modifier.width(12.dp))
-                BasicText(
-                  text = option.text,
-                  style = TextStyle(color = contentColor),
-                )
-              }
+              UnstyledIcon(
+                imageVector = option.icon,
+                contentDescription = null,
+                tint = contentColor,
+              )
+              Spacer(Modifier.width(12.dp))
+              BasicText(
+                text = option.text,
+                style = TextStyle(color = contentColor),
+              )
             }
           }
         }

--- a/docs/pages/dropdown-menu.md
+++ b/docs/pages/dropdown-menu.md
@@ -40,8 +40,8 @@ UnstyledDropdownMenu(
 - `UnstyledDropdownMenu` marks the anchor area and renders the floating menu when expanded.
   - The `anchor` slot renders the content the menu is positioned against.
   - The `panel` slot renders the floating menu content.
-- `DropdownMenuPanel` renders the menu surface.
-- `MenuItem` renders an item inside `DropdownMenuPanel`.
+- `DropdownMenuPanel` renders the menu surface and arranges direct children vertically.
+- `MenuItem` renders a focusable item inside `DropdownMenuPanel`. Use direct `MenuItem` children for managed keyboard navigation. Custom nested layouts can be rendered inside the panel, but nested items are not part of the panel-managed menu order.
 
 ## Accessibility
 


### PR DESCRIPTION
## Summary

- Request dropdown item focus as soon as the opened panel has been attached and placed, instead of waiting for the enter transition to complete.
- Make `DropdownMenuPanel` own direct-child vertical layout so menu item order comes from layout parent data rather than Compose call/effect ordering.
- Keep pointer-opened menus keyboard-operable by focusing the menu surface first, then moving to the first or last item on `ArrowDown`/`ArrowUp`.
- Keep keyboard-opened menus moving focus into the menu immediately: `Enter`/`Space`/`ArrowDown` focus the first item, and `ArrowUp` focuses the last item.
- Make `Tab` and `Shift+Tab` close the open menu and continue focus traversal after/before the anchor, matching APG menu-button behavior.
- Document that managed keyboard navigation is guaranteed for direct `MenuItem` children, while custom nested layouts may render inside the panel without panel-managed ordering.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed
- `./gradlew :composeunstyled-dropdown-menu:jvmTest`
- `./gradlew jvmTest spotlessCheck`
- `./gradlew :demo:hotReloadJvmMain`

## Related Issues

None.

## Screenshots/Videos

Not applicable.