### PR TITLE
Fix bottom sheets detaching while content shrinks

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -279,6 +279,7 @@ class BottomSheetState internal constructor(
   private var sheetHeightDependentDetents: Set<SheetDetent> by mutableStateOf(emptySet())
   private var sheetHeightDependencyContainerHeightPx = Float.NaN
   private var sheetHeightDependencyDetents: List<SheetDetent> = emptyList()
+  private var measuredContentHeightPx = Float.NaN
   private var measuredSheetHeightPx: Float by mutableStateOf(Float.NaN)
   internal var maxDetentHeightPx: Float by mutableStateOf(Float.NaN)
   internal var isDragging: Boolean by mutableStateOf(false)
@@ -525,8 +526,11 @@ class BottomSheetState internal constructor(
   }
 
   internal fun updateContentHeight(measuredHeightPx: Float, includeMeasuredSheetHeight: Boolean) {
+    val measuredContentHeightShrank = measuredContentHeightPx.isNaN().not() &&
+      measuredHeightPx < measuredContentHeightPx
+    measuredContentHeightPx = measuredHeightPx
     val shouldIncludeMeasuredSheetHeight = includeMeasuredSheetHeight ||
-      measuredSheetHeightPx < containerHeightPx
+      (measuredContentHeightShrank.not() && measuredSheetHeightPx < containerHeightPx)
     val measuredSheetHeight = if (shouldIncludeMeasuredSheetHeight) {
       measuredSheetHeightPx.takeUnless { it.isNaN() } ?: 0f
     } else {


### PR DESCRIPTION
## Summary

Fixes bottom sheets briefly detaching from the bottom edge when fully expanded content shrinks.

The sheet now distinguishes a genuine content-height shrink from stable outer sheet height such as padding, so stale measured sheet height is not reused for content-dependent anchors during shrink frames.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

- `./gradlew jvmTest spotlessCheck`
- Installed and ran the Android demo with `./gradlew :demo:installDebug`
- Captured modal bottom sheet shrink frames with `adb exec-out screencap`; before fix the detected sheet-bottom gap reached 6px, after fix it stayed at the normal 3px baseline.

## Related Issues

Fixes #387

## Screenshots/Videos

N/A
