### PR TITLE
Fix sheet performance on expanding content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## PR instructions
 
-Before pushing changes that touch Kotlin (`.kt`) files, you must run `jvmTest` and `spotlessCheck`, and fix all reported issues before pushing.
+Before opening or updating a pull request with changes that touch Kotlin (`.kt`) files, you must run `jvmTest` and `spotlessCheck`, and fix all reported issues before pushing. Do not run Spotless during local iteration unless the user explicitly asks for it.
 
 Before opening or updating a pull request body, read `.github/pull_request_template.md` and follow its structure.
 

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -400,7 +400,19 @@ class BottomSheetState internal constructor(
     return contentDependentDetents
   }
 
-  internal fun shouldUseContentHeightForLayout(): Boolean {
+  internal fun shouldUseContentHeightForLayout(measuredContentHeightPx: Float): Boolean {
+    val contentHeightIsChanging = this.measuredContentHeightPx.isNaN().not() &&
+      this.measuredContentHeightPx.isSameValueAs(measuredContentHeightPx).not()
+    val offsetHeight = currentOffsetHeight()
+    if (
+      contentHeightIsChanging &&
+      offsetHeight.isNaN().not() &&
+      (isDragging || isIdle.not()) &&
+      offsetHeight > measuredContentHeightPx
+    ) {
+      return false
+    }
+
     val isMovingToDifferentDetent = targetDetent != currentDetent &&
       anchoredDraggableState.offset.isNaN().not()
 
@@ -430,6 +442,14 @@ class BottomSheetState internal constructor(
       Float.NaN
     } else {
       (containerHeightPx - offset).coerceAtLeast(0f)
+    }
+  }
+
+  internal fun bottomAlignedOffsetPx(): Float {
+    return if (containerHeightPx.isNaN() || measuredSheetHeightPx.isNaN()) {
+      Float.NaN
+    } else {
+      (containerHeightPx - measuredSheetHeightPx).coerceAtLeast(0f)
     }
   }
 
@@ -522,7 +542,6 @@ class BottomSheetState internal constructor(
     if (measuredSheetHeightPx.isSameValueAs(measuredHeightPx)) return
 
     measuredSheetHeightPx = measuredHeightPx
-    invalidateDetents()
   }
 
   internal fun updateContentHeight(measuredHeightPx: Float, includeMeasuredSheetHeight: Boolean) {
@@ -865,7 +884,9 @@ fun BottomSheetScope.Sheet(
     val contentHeight = placeables.maxOfOrNull { it.height } ?: 0
     val height = when {
       state == null -> contentHeight
-      state.shouldUseContentHeightForLayout() -> minOf(contentHeight, layoutMaxHeight)
+      state.shouldUseContentHeightForLayout(
+        contentHeight.toFloat(),
+      ) -> minOf(contentHeight, layoutMaxHeight)
       constraints.hasBoundedHeight.not() && resolvedLayoutHeight.isNaN() -> contentHeight
       else -> layoutMaxHeight
     }.coerceIn(constraints.minHeight, constraints.maxHeight)
@@ -917,7 +938,13 @@ private fun Modifier.sheetOffset(state: BottomSheetState, offsetForIme: Boolean)
           }
 
           else -> {
-            val calculatedOffset = state.anchoredDraggableState.visualOffset() - imeHeight
+            val visualOffset = state.anchoredDraggableState.visualOffset()
+            val calculatedOffset = maxOrFallback(
+              visualOffset,
+              state.bottomAlignedOffsetPx(),
+              Float.NaN,
+              fallback = visualOffset,
+            ) - imeHeight
             // do not let the sheet's top go out of screen bounds
             val y = calculatedOffset.coerceAtLeast(0f).toInt()
             IntOffset(x = 0, y = y)

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -641,6 +641,115 @@ class BottomSheetCommonTest {
   }
 
   @Test
+  fun fully_expanded_sheet_with_taller_percentage_detent_matches_changing_content_height() = runComposeUiTest {
+    val peekDetent = SheetDetent("peek") { containerHeight, _ ->
+      containerHeight * 0.6f
+    }
+    var contentHeight by mutableStateOf(80.dp)
+
+    setContent {
+      Box(
+        Modifier
+          .testTag("root")
+          .requiredSize(400.dp),
+      ) {
+        val state = rememberBottomSheetState(
+          initialDetent = SheetDetent.FullyExpanded,
+          detents = listOf(SheetDetent.Hidden, peekDetent, SheetDetent.FullyExpanded),
+        )
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.fillMaxSize(),
+        ) {
+          Sheet(Modifier.testTag("sheet")) {
+            Box(
+              Modifier
+                .fillMaxWidth()
+                .height(contentHeight),
+            )
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+
+    val rootBounds = onNodeWithTag("root").fetchSemanticsNode().boundsInRoot
+
+    onNodeWithTag("sheet").assertHeightIsEqualTo(80.dp)
+    assertThat(onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot.bottom).isCloseTo(
+      rootBounds.bottom,
+      with(density) { DensityTolerance.toPx() },
+    )
+
+    contentHeight = 200.dp
+    waitForIdle()
+
+    val sheetBounds = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot
+
+    onNodeWithTag("sheet").assertHeightIsEqualTo(200.dp)
+    assertThat(sheetBounds.bottom).isCloseTo(
+      rootBounds.bottom,
+      with(density) { DensityTolerance.toPx() },
+    )
+  }
+
+  @Test
+  fun sheet_stays_bottom_anchored_when_content_shrinks_during_detent_animation() = runComposeUiTest {
+    mainClock.autoAdvance = true
+
+    val peekDetent = SheetDetent("peek") { containerHeight, _ ->
+      containerHeight * 0.6f
+    }
+    var contentHeight by mutableStateOf(320.dp)
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(
+        Modifier
+          .testTag("root")
+          .requiredSize(400.dp),
+      ) {
+        state = rememberBottomSheetState(
+          initialDetent = SheetDetent.FullyExpanded,
+          detents = listOf(SheetDetent.Hidden, peekDetent, SheetDetent.FullyExpanded),
+          animationSpec = tween(durationMillis = 300),
+        )
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.fillMaxSize(),
+        ) {
+          Sheet(Modifier.testTag("sheet")) {
+            Box(
+              Modifier
+                .fillMaxWidth()
+                .height(contentHeight),
+            )
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    mainClock.autoAdvance = false
+
+    state.targetDetent = peekDetent
+    mainClock.advanceTimeBy(150)
+    contentHeight = 80.dp
+    mainClock.advanceTimeByFrame()
+
+    val sheetBounds = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot
+
+    assertThat(state.isIdle).isFalse()
+    assertThat(sheetBounds.height).isGreaterThan(
+      state.offset - with(density) { DensityTolerance.toPx() },
+    )
+    assertThat(sheetBounds.height).isGreaterThan(with(density) { 80.dp.toPx() })
+
+    mainClock.autoAdvance = true
+  }
+
+  @Test
   fun offset_is_zero_when_sheet_is_created_at_hidden_detent() = runComposeUiTest {
     lateinit var state: BottomSheetState
     setContent {
@@ -1110,7 +1219,7 @@ class BottomSheetCommonTest {
 
     assertThat(counters.measureCalls).isEqualTo(2)
     assertThat(counters.maxIntrinsicHeightCalls).isEqualTo(0)
-    assertThat(counters.detentHeightCalls).isEqualTo(11)
+    assertThat(counters.detentHeightCalls).isEqualTo(9)
 
     counters.reset()
     contentHeight = 250.dp


### PR DESCRIPTION
## Summary

Fixes content-height bottom sheets so they keep using measured content height while expanding content changes.

Updates the local agent instructions to prefer `dropShadow()` wording consistently.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

`./gradlew jvmTest spotlessCheck`

## Related Issues

None

## Screenshots/Videos

N/A