### PR TITLE
Allow overriding the publish version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,12 @@ val composeUnstyledDocsSource = layout.projectDirectory.dir("docs")
 val generatedComposeUnstyledDocsPages = layout.buildDirectory.dir("generated/compose-unstyled-docs/pages")
 val generatedComposeUnstyledDemoSources = layout.buildDirectory.dir("generated/compose-unstyled-docs/demo-sources")
 val composeUnstyledDocsAssets = composeUnstyledDocsSource.dir("assets")
+val composeUnstyledPublishVersion = providers
+  .gradleProperty("publishVersion")
+  .orElse(libs.versions.unstyled)
+  .get()
+
+extra["publishVersion"] = composeUnstyledPublishVersion
 
 val composeUnstyledDemoSources = mapOf(
   "bottom-sheet" to "BottomSheetDemo.kt",

--- a/composeunstyled-anchored-api/build.gradle.kts
+++ b/composeunstyled-anchored-api/build.gradle.kts
@@ -34,7 +34,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-bottom-sheet/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-build-modifier/build.gradle.kts
+++ b/composeunstyled-build-modifier/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-button/build.gradle.kts
+++ b/composeunstyled-button/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-button"

--- a/composeunstyled-checkbox/build.gradle.kts
+++ b/composeunstyled-checkbox/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-checkbox"

--- a/composeunstyled-colored-indication/build.gradle.kts
+++ b/composeunstyled-colored-indication/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-dialog/build.gradle.kts
+++ b/composeunstyled-dialog/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-disclosure/build.gradle.kts
+++ b/composeunstyled-disclosure/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-disclosure"

--- a/composeunstyled-dropdown-menu/build.gradle.kts
+++ b/composeunstyled-dropdown-menu/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-escape-handler/build.gradle.kts
+++ b/composeunstyled-escape-handler/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-focus-ring/build.gradle.kts
+++ b/composeunstyled-focus-ring/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-focus-ring"

--- a/composeunstyled-icon/build.gradle.kts
+++ b/composeunstyled-icon/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-icon"

--- a/composeunstyled-internal-anchored/build.gradle.kts
+++ b/composeunstyled-internal-anchored/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-modal-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-modal-bottom-sheet/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-modal/build.gradle.kts
+++ b/composeunstyled-modal/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-outline/build.gradle.kts
+++ b/composeunstyled-outline/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-outline"

--- a/composeunstyled-platformtheme/build.gradle.kts
+++ b/composeunstyled-platformtheme/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-portal/build.gradle.kts
+++ b/composeunstyled-portal/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-portal"

--- a/composeunstyled-primitives/build.gradle.kts
+++ b/composeunstyled-primitives/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-progress/build.gradle.kts
+++ b/composeunstyled-progress/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-progress"

--- a/composeunstyled-radio-group/build.gradle.kts
+++ b/composeunstyled-radio-group/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-radio-group"

--- a/composeunstyled-scrollbars/build.gradle.kts
+++ b/composeunstyled-scrollbars/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-separators/build.gradle.kts
+++ b/composeunstyled-separators/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-separators"

--- a/composeunstyled-slider/build.gradle.kts
+++ b/composeunstyled-slider/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-slider"

--- a/composeunstyled-stack/build.gradle.kts
+++ b/composeunstyled-stack/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-stack"

--- a/composeunstyled-tab-group/build.gradle.kts
+++ b/composeunstyled-tab-group/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-tab-group"

--- a/composeunstyled-text-field/build.gradle.kts
+++ b/composeunstyled-text-field/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-text-field"

--- a/composeunstyled-theming/build.gradle.kts
+++ b/composeunstyled-theming/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-toggle-switch/build.gradle.kts
+++ b/composeunstyled-toggle-switch/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-toggle-switch"

--- a/composeunstyled-tooltip/build.gradle.kts
+++ b/composeunstyled-tooltip/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled-tri-state-checkbox/build.gradle.kts
+++ b/composeunstyled-tri-state-checkbox/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 val pomArtifactId = "composeunstyled-tri-state-checkbox"

--- a/composeunstyled-window-container-size/build.gradle.kts
+++ b/composeunstyled-window-container-size/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 

--- a/composeunstyled/build.gradle.kts
+++ b/composeunstyled/build.gradle.kts
@@ -34,7 +34,7 @@ plugins {
 }
 
 val publishGroupId = "com.composables"
-val publishVersion = libs.versions.unstyled.get()
+val publishVersion = rootProject.extra["publishVersion"] as String
 val githubUrl = "github.com/composablehorizons/compose-unstyled"
 val projectUrl = "https://composeunstyled.com"
 


### PR DESCRIPTION
## Summary

Adds a root-level `publishVersion` Gradle property override for published artifacts. Normal releases keep using `libs.versions.unstyled`, while local publishing can now pass a version such as `-PpublishVersion=2.5.0-snapshot` and have all published modules use the same value.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

Commands run:

```sh
./gradlew spotlessCheck
./gradlew publishToMavenLocal -PpublishVersion=2.5.0-snapshot
```

## Related Issues

None.

## Screenshots/Videos

Not applicable.