### PR TITLE
Scope bottom sheet dragging to sheet bounds

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -736,6 +736,8 @@ private fun DraggableAnchors<SheetDetent>.closestDetent(
 private class BottomSheetContext(
   internal val state: BottomSheetState? = null,
   enabled: Boolean = true,
+  internal val coroutineScope: CoroutineScope? = null,
+  internal val dragInteractionSource: MutableInteractionSource? = null,
 ) {
   internal var enabled by mutableStateOf(enabled)
 }
@@ -755,11 +757,18 @@ fun UnstyledBottomSheet(
   offsetForIme: Boolean = false,
   content: @Composable BottomSheetScope.() -> Unit,
 ) {
-  val context = remember(state) { BottomSheetContext(state = state, enabled = enabled) }
-  SideEffect { context.enabled = enabled }
-
   val coroutineScope = rememberCoroutineScope()
   val dragInteractionSource = remember { MutableInteractionSource() }
+  val context = remember(state, coroutineScope, dragInteractionSource) {
+    BottomSheetContext(
+      state = state,
+      enabled = enabled,
+      coroutineScope = coroutineScope,
+      dragInteractionSource = dragInteractionSource,
+    )
+  }
+  SideEffect { context.enabled = enabled }
+
   LaunchedEffect(dragInteractionSource) {
     dragInteractionSource.interactions.collect { interaction ->
       when (interaction) {
@@ -783,34 +792,7 @@ fun UnstyledBottomSheet(
               state.updateMeasuredSheetHeight(measuredSize.height.toFloat())
             }
           }
-          .sheetOffset(state = state, offsetForIme = offsetForIme)
-          .then(
-            buildModifier {
-              if (context.enabled && state.detents.size > 1) {
-                add(
-                  Modifier
-                    .anchoredDraggable(
-                      state = state.anchoredDraggableState,
-                      orientation = Orientation.Vertical,
-                      enabled = context.enabled,
-                      interactionSource = dragInteractionSource,
-                    )
-                    .nestedScroll(
-                      remember(state.anchoredDraggableState, Orientation.Vertical) {
-                        ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
-                          orientation = Orientation.Vertical,
-                          sheetState = state.anchoredDraggableState,
-                          onFling = {
-                            coroutineScope.launch { state.anchoredDraggableState.settle(it) }
-                          },
-                        )
-                      },
-                    ),
-                )
-              }
-            },
-          )
-          .pointerInput(Unit) { detectTapGestures { } },
+          .sheetOffset(state = state, offsetForIme = offsetForIme),
       ) {
         BottomSheetScopeInstance.content()
       }
@@ -825,9 +807,40 @@ fun BottomSheetScope.Sheet(
 ) {
   val context = LocalBottomSheetContext.current
   val state = context.state
+  val coroutineScope = context.coroutineScope
+  val dragInteractionSource = context.dragInteractionSource
 
   Layout(
-    modifier = modifier.clipToBounds(),
+    modifier = Modifier
+      .then(
+        buildModifier {
+          add(Modifier.pointerInput(Unit) { detectTapGestures { } })
+          if (state != null && coroutineScope != null && context.enabled && state.detents.size > 1) {
+            add(
+              Modifier
+                .anchoredDraggable(
+                  state = state.anchoredDraggableState,
+                  orientation = Orientation.Vertical,
+                  enabled = context.enabled,
+                  interactionSource = dragInteractionSource,
+                )
+                .nestedScroll(
+                  remember(state.anchoredDraggableState, Orientation.Vertical) {
+                    ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
+                      orientation = Orientation.Vertical,
+                      sheetState = state.anchoredDraggableState,
+                      onFling = {
+                        coroutineScope.launch { state.anchoredDraggableState.settle(it) }
+                      },
+                    )
+                  },
+                ),
+            )
+          }
+        },
+      )
+      .then(modifier)
+      .clipToBounds(),
     content = content,
   ) { measurables, constraints ->
     val fallbackContentHeight = when {

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import androidx.compose.ui.layout.IntrinsicMeasureScope
@@ -73,6 +74,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.swipe
 import androidx.compose.ui.test.swipeDown
 import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.test.waitUntilExactlyOneExists
@@ -2905,6 +2907,52 @@ class BottomSheetCommonTest {
 
     // Should return to original detent
     assertThat(state.currentDetent).isEqualTo(detent100)
+    assertThat(state.offset).isEqualTo(initialOffset)
+  }
+
+  @Test
+  fun drag_on_left_side_of_centered_sheet_does_not_move_sheet() = runComposeUiTest {
+    val collapsed = SheetDetent("collapsed") { _, _ -> 100.dp }
+    val expanded = SheetDetent("expanded") { _, _ -> 240.dp }
+
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(300.dp)) {
+        state = rememberBottomSheetState(
+          initialDetent = expanded,
+          detents = listOf(collapsed, expanded),
+        )
+
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.fillMaxSize().testTag("bottom_sheet"),
+        ) {
+          Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.TopCenter,
+          ) {
+            Sheet(Modifier.size(width = 100.dp, height = 240.dp).testTag("panel")) {
+              Box(Modifier.fillMaxSize())
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    val initialOffset = state.offset
+
+    onNodeWithTag("bottom_sheet").performTouchInput {
+      swipe(
+        start = Offset(x = 8f, y = height - 120f),
+        end = Offset(x = 8f, y = height - 20f),
+        durationMillis = 200,
+      )
+    }
+    waitForIdle()
+
+    assertThat(state.currentDetent).isEqualTo(expanded)
     assertThat(state.offset).isEqualTo(initialOffset)
   }
 

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheetRecompositionTest.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheetRecompositionTest.kt
@@ -139,7 +139,7 @@ class BottomSheetRecompositionTest {
   }
 
   @Test
-  fun updating_detents_recomposes_content_sized_content_once() = runComposeRecompositionTest {
+  fun updating_detents_does_not_recompose_content_sized_content() = runComposeRecompositionTest {
     val contentDetent = SheetDetent("content") { _, sheetHeight ->
       sheetHeight
     }
@@ -168,7 +168,7 @@ class BottomSheetRecompositionTest {
     state.detents = listOf(halfDetent, contentDetent)
     waitForIdle()
 
-    assertThat(recompositionCount("sheet-content")).isEqualTo(1)
+    assertThat(recompositionCount("sheet-content")).isEqualTo(0)
   }
 
   @Test

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -115,6 +115,7 @@ fun DropdownMenuDemo() {
           MenuItem(
             onClick = {},
             enabled = option.enabled,
+            indication = LocalIndication.current,
             modifier = Modifier
               .padding(4.dp)
               .sizeIn(minWidth = 40.dp, minHeight = 40.dp)


### PR DESCRIPTION
## Summary

- Move bottom sheet drag and tap-consumption handling from the internal full-width moving wrapper onto `Sheet()` itself.
- Keep container measurement and offset behavior on the existing wrapper so sheet layout/IME behavior stays intact.
- Add a regression test for dragging in the left gutter beside a centered narrow sheet.
- Update the detent recomposition expectation because detent list changes no longer recompose content that does not read the detents.
- Pass `LocalIndication.current` to dropdown menu items in the demo so item presses show feedback.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed

Commands run:

- `./gradlew :composeunstyled-bottom-sheet:jvmTest --tests 'com.composeunstyled.BottomSheetCommonTest.drag_on_left_side_of_centered_sheet_does_not_move_sheet'`
- `./gradlew :composeunstyled-bottom-sheet:jvmTest :composeunstyled-modal-bottom-sheet:jvmTest :composeunstyled-bottom-sheet:spotlessKotlinCheck`
- `./gradlew :demo:compileKotlinJvm`
- `./gradlew :demo:spotlessKotlinCheck`
- `./gradlew :visual-regressions:jvmScreenshotTest` fails with the same 5 screenshot diffs that also reproduce with this branch's changes stashed on clean `origin/main` in this environment:
  - `bottom-sheet-expanded-scrollable-content-final-row`
  - `modal-bottom-sheet-expanded-scrollable-content-final-row`
  - `modal-bottom-sheet-expanded-fixed-height-top-padding`
  - `modal-bottom-sheet-expanded-top-padding-content-grows`
  - `tristatecheckbox-demo`

Manual testing:

- Ran `./gradlew :demo:hotRunJvm --auto` and verified dropdown menu item indication in the demo.

## Related Issues

None.

## Screenshots/Videos

Not included. Behavior was verified manually in the running demo app.
