### PR TITLE
Release 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-05-31
+
+### Fixed
+
+- Fixed a bug where bottom sheets could be dragged from outside their visible bounds. (#396)
+
 ## [2.4.0] - 2026-05-23
 
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-unstyled = "2.4.0"
+unstyled = "2.4.1"
 
 kotlin = "2.3.20"
 compose = "1.11.0-alpha01"


### PR DESCRIPTION
## Summary

- Bump Compose Unstyled to `2.4.1`.
- Move the bottom sheet drag-bounds fix into the `2.4.1` changelog section.

## Test Plan

- [ ] Tests added/updated
- [ ] Manual testing performed

Checks run:

- `git diff --check`

## Related Issues

None.

## Screenshots/Videos

Not applicable.
