### PR TITLE
Bump Compose Multiplatform to stable 1.11.0

### DIFF
--- a/composeunstyled-anchored-api/build.gradle.kts
+++ b/composeunstyled-anchored-api/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledAnchoredApi"
       isStatic = true

--- a/composeunstyled-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-bottom-sheet/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledBottomSheet"
       isStatic = true

--- a/composeunstyled-build-modifier/build.gradle.kts
+++ b/composeunstyled-build-modifier/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledBuildModifier"
       isStatic = true

--- a/composeunstyled-button/build.gradle.kts
+++ b/composeunstyled-button/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-checkbox/build.gradle.kts
+++ b/composeunstyled-checkbox/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-colored-indication/build.gradle.kts
+++ b/composeunstyled-colored-indication/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledColoredIndication"
       isStatic = true

--- a/composeunstyled-dialog/build.gradle.kts
+++ b/composeunstyled-dialog/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledDialog"
       isStatic = true

--- a/composeunstyled-disclosure/build.gradle.kts
+++ b/composeunstyled-disclosure/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-dropdown-menu/build.gradle.kts
+++ b/composeunstyled-dropdown-menu/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledDropdownMenu"
       isStatic = true

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -300,7 +300,7 @@ fun DropdownMenuScope.DropdownMenuPanel(
             true
           }
 
-          Key.Home -> {
+          Key.MoveHome -> {
             if (event.isKeyDown) {
               scope.itemFocusTargets.firstOrNull()?.focusRequester?.requestFocus()
             }

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -677,7 +677,7 @@ class DropdownMenuPanelTest {
     onNodeWithTag("middle").assertIsFocused()
 
     onNodeWithTag("middle").performKeyInput {
-      pressKey(Key.Home)
+      pressKey(Key.MoveHome)
     }
 
     onNodeWithTag("first").assertIsFocused()
@@ -758,7 +758,7 @@ class DropdownMenuPanelTest {
     onNodeWithTag("last").assertIsFocused()
 
     onNodeWithTag("last").performKeyInput {
-      pressKey(Key.Home)
+      pressKey(Key.MoveHome)
     }
 
     onNodeWithTag("first").assertIsFocused()
@@ -797,7 +797,7 @@ class DropdownMenuPanelTest {
     waitForIdle()
 
     onNodeWithTag("middle").performKeyInput {
-      pressKey(Key.Home)
+      pressKey(Key.MoveHome)
     }
 
     onNodeWithTag("first").assertIsFocused()
@@ -810,7 +810,7 @@ class DropdownMenuPanelTest {
     waitForIdle()
 
     onNodeWithTag("middle").performKeyInput {
-      pressKey(Key.Home)
+      pressKey(Key.MoveHome)
     }
 
     onNodeWithTag("last").assertIsFocused()

--- a/composeunstyled-escape-handler/build.gradle.kts
+++ b/composeunstyled-escape-handler/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledEscapeHandler"
       isStatic = true

--- a/composeunstyled-focus-ring/build.gradle.kts
+++ b/composeunstyled-focus-ring/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-focus-ring/src/commonMain/kotlin/com/composeunstyled/FocusRing.kt
+++ b/composeunstyled-focus-ring/src/commonMain/kotlin/com/composeunstyled/FocusRing.kt
@@ -186,7 +186,7 @@ private fun isNavigationKey(key: Key): Boolean {
     Key.DirectionDown,
     Key.DirectionLeft,
     Key.DirectionRight,
-    Key.Home,
+    Key.MoveHome,
     Key.MoveEnd,
     Key.PageUp,
     Key.PageDown,

--- a/composeunstyled-icon/build.gradle.kts
+++ b/composeunstyled-icon/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-internal-anchored/build.gradle.kts
+++ b/composeunstyled-internal-anchored/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledInternalAnchored"
       isStatic = true

--- a/composeunstyled-modal-bottom-sheet/build.gradle.kts
+++ b/composeunstyled-modal-bottom-sheet/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledModalBottomSheet"
       isStatic = true

--- a/composeunstyled-modal/build.gradle.kts
+++ b/composeunstyled-modal/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledModal"
       isStatic = true

--- a/composeunstyled-outline/build.gradle.kts
+++ b/composeunstyled-outline/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-platformtheme/build.gradle.kts
+++ b/composeunstyled-platformtheme/build.gradle.kts
@@ -84,7 +84,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledPlatformTheme"
       isStatic = true

--- a/composeunstyled-portal/build.gradle.kts
+++ b/composeunstyled-portal/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-primitives/build.gradle.kts
+++ b/composeunstyled-primitives/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledPrimitives"
       isStatic = true

--- a/composeunstyled-progress/build.gradle.kts
+++ b/composeunstyled-progress/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-radio-group/build.gradle.kts
+++ b/composeunstyled-radio-group/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-scrollbars/build.gradle.kts
+++ b/composeunstyled-scrollbars/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledScrollbars"
       isStatic = true

--- a/composeunstyled-separators/build.gradle.kts
+++ b/composeunstyled-separators/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-slider/build.gradle.kts
+++ b/composeunstyled-slider/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-slider/src/commonMain/kotlin/com/composeunstyled/Slider.kt
+++ b/composeunstyled-slider/src/commonMain/kotlin/com/composeunstyled/Slider.kt
@@ -462,7 +462,7 @@ private fun Modifier.sliderKeyboardInteractions(
         true
       }
 
-      Key.Home -> {
+      Key.MoveHome -> {
         if (event.isKeyDown) {
           setValue(valueRange.start)
         } else {

--- a/composeunstyled-slider/src/commonTest/kotlin/Slider.test.kt
+++ b/composeunstyled-slider/src/commonTest/kotlin/Slider.test.kt
@@ -186,7 +186,7 @@ class SliderTest {
     assertThat(value).isEqualTo(1f)
 
     onNodeWithTag("slider").performKeyInput {
-      keyPress(Key.Home)
+      keyPress(Key.MoveHome)
     }
 
     assertThat(value).isEqualTo(0f)

--- a/composeunstyled-stack/build.gradle.kts
+++ b/composeunstyled-stack/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-tab-group/build.gradle.kts
+++ b/composeunstyled-tab-group/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -215,7 +215,7 @@ fun <T> TabGroupScope<T>.TabList(
             true
           }
 
-          event.key == Key.Home -> {
+          event.key == Key.MoveHome -> {
             if (event.isKeyDown && tabKeys.isNotEmpty()) {
               val tab = tabKeys.first()
               val focusRequester = registry.tabFocusRequesters.getValue(tab)

--- a/composeunstyled-tab-group/src/jvmTest/kotlin/TabGroupJvm.test.kt
+++ b/composeunstyled-tab-group/src/jvmTest/kotlin/TabGroupJvm.test.kt
@@ -895,7 +895,7 @@ class TabGroupTest {
 
     // Press Home key
     onRoot().performKeyInput {
-      keyPress(Key.Home)
+      keyPress(Key.MoveHome)
     }
 
     // Should move focus to the first tab

--- a/composeunstyled-test/build.gradle.kts
+++ b/composeunstyled-test/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledTest"
       isStatic = true

--- a/composeunstyled-text-field/build.gradle.kts
+++ b/composeunstyled-text-field/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-theming/build.gradle.kts
+++ b/composeunstyled-theming/build.gradle.kts
@@ -67,7 +67,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledTheming"
       isStatic = true

--- a/composeunstyled-toggle-switch/build.gradle.kts
+++ b/composeunstyled-toggle-switch/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-tooltip/build.gradle.kts
+++ b/composeunstyled-tooltip/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledTooltip"
       isStatic = true

--- a/composeunstyled-tri-state-checkbox/build.gradle.kts
+++ b/composeunstyled-tri-state-checkbox/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = frameworkBaseName
       isStatic = true

--- a/composeunstyled-window-container-size/build.gradle.kts
+++ b/composeunstyled-window-container-size/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyledWindowContainerSize"
       isStatic = true

--- a/composeunstyled/build.gradle.kts
+++ b/composeunstyled/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
     browser()
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeUnstyled"
       isStatic = true

--- a/demo-xml-theme/build.gradle.kts
+++ b/demo-xml-theme/build.gradle.kts
@@ -67,7 +67,7 @@ kotlin {
     }
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeApp"
       isStatic = true

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -87,7 +87,7 @@ kotlin {
     }
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "ComposeApp"
       isStatic = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 unstyled = "2.4.1"
 
 kotlin = "2.3.20"
-compose = "1.11.0-alpha01"
+compose = "1.11.0"
 compose-material3 = "1.11.0-alpha01"
 
 vanniktech = "0.35.0"


### PR DESCRIPTION
## Summary

Bumps Compose Multiplatform from `1.11.0-alpha01` to stable `1.11.0`.

Also applies required 1.11.0 migration updates:

- replaces deprecated `Key.Home` usage with `Key.MoveHome`
- removes `iosX64` targets because Compose Multiplatform 1.11.0 no longer supports Apple x86_64 targets

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

`./gradlew jvmTest spotlessCheck`

## Related Issues

None.

## Screenshots/Videos

Not applicable.