### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-06-01
+
+### Added
+
+- Introduce Breakpoints API for building responsive layouts. (#403)
+
+### Changed
+
+- Compose Unstyled now uses Compose Multiplatform `1.11.0`.
+- Deprecated `currentWindowContainerSize()` in favor of `LocalWindowInfo.current.containerDpSize`. (#402)
+
 ## [2.4.1] - 2026-05-31
 
 ### Fixed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-unstyled = "2.4.1"
+unstyled = "2.5.0"
 
 kotlin = "2.3.20"
 compose = "1.11.0"


### PR DESCRIPTION
## Summary

Prepare the 2.5.0 release by finalizing the changelog and bumping the Compose Unstyled version.

## Test Plan

Release metadata only. Per the release flow, tests run in the release PR and tag workflows.

- [ ] Tests added/updated
- [ ] Manual testing performed

## Related Issues

#402
#403

## Screenshots/Videos

Not applicable.