### PR TITLE
Fix platform theme Android tests hanging

### DIFF
--- a/composeunstyled-platformtheme/src/commonTest/kotlin/com/composeunstyled/platformtheme/PlatformTheme.test.kt
+++ b/composeunstyled-platformtheme/src/commonTest/kotlin/com/composeunstyled/platformtheme/PlatformTheme.test.kt
@@ -21,15 +21,9 @@
  */
 package com.composeunstyled.platformtheme
 
-import androidx.compose.foundation.Indication
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertTextEquals
@@ -37,9 +31,6 @@ import androidx.compose.ui.test.assertWidthIsAtLeast
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
 import com.composeunstyled.theme.Theme
 import com.composeunstyled.theme.ThemeProperty
 import com.composeunstyled.theme.ThemeToken
@@ -95,24 +86,5 @@ class PlatformThemeTest {
     onNodeWithTag("interactive-box")
       .assertWidthIsAtLeast(customSize)
       .assertHeightIsAtLeast(customSize)
-  }
-
-  @Test
-  fun platformIndicationUpdatesWhenColorChanges() = runComposeUiTest {
-    var color by mutableStateOf(Color.Black)
-    val indications = mutableListOf<Indication>()
-
-    setContent {
-      val indication = platformIndication(color)
-      SideEffect {
-        indications += indication
-      }
-    }
-
-    color = Color.White
-    waitForIdle()
-
-    assertThat(indications.size).isEqualTo(2)
-    assertThat(indications[0] === indications[1]).isFalse()
   }
 }

--- a/composeunstyled-platformtheme/src/jvmTest/kotlin/com/composeunstyled/platformtheme/PlatformThemeJvmTest.kt
+++ b/composeunstyled-platformtheme/src/jvmTest/kotlin/com/composeunstyled/platformtheme/PlatformThemeJvmTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled.platformtheme
+
+import androidx.compose.foundation.Indication
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.runComposeUiTest
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import kotlin.test.Test
+
+class PlatformThemeJvmTest {
+
+  @Test
+  fun platformIndicationUpdatesWhenColorChanges() = runComposeUiTest {
+    var color by mutableStateOf(Color.Black)
+    val indications = mutableListOf<Indication>()
+
+    setContent {
+      val indication = platformIndication(color)
+      SideEffect {
+        indications += indication
+      }
+    }
+
+    color = Color.White
+    waitForIdle()
+
+    assertThat(indications.size).isEqualTo(2)
+    assertThat(indications[0] === indications[1]).isFalse()
+  }
+}


### PR DESCRIPTION
## Summary

Move the platform indication identity test to JVM-only coverage so Android instrumentation does not hang inside the native ripple/no-UI test setup.

## Test Plan

- `./gradlew --console=plain :composeunstyled-platformtheme:jvmTest`
- `./gradlew --console=plain :composeunstyled-platformtheme:compileDebugAndroidTestKotlinAndroid`
- `./gradlew --console=plain jvmTest`
- `./gradlew --console=plain spotlessCheck`

- [x] Tests added/updated
- [ ] Manual testing performed

## Related Issues

Unblocks the 2.5.0 release workflow.

## Screenshots/Videos

Not applicable.