### PR TITLE
Add local release preflight script

### DIFF
--- a/.agents/skills/android-test-emulator/SKILL.md
+++ b/.agents/skills/android-test-emulator/SKILL.md
@@ -10,7 +10,10 @@ Use this skill before running Android connected tests such as `connectedAndroidT
 The required AVD name is `Unstyled_Tests`. If it does not exist, create it with:
 
 - API level: `23`
-- System image: `system-images;android-23;default;x86_64`
+- System image: `system-images;android-23;default;x86_64`, except Apple Silicon Macs use `system-images;android-23;default;arm64-v8a`
+- Display: `320x640`
+- Density: `160 dpi`
+- CPU cores: `2`
 - Disk size: `2048M`
 
 ## Workflow
@@ -23,13 +26,19 @@ The required AVD name is `Unstyled_Tests`. If it does not exist, create it with:
 
 2. If a device is already connected and booted, use it.
 
-3. Otherwise launch/create the project emulator:
+3. Create the project emulator if it does not exist:
 
    ```bash
-   bash .agents/skills/android-test-emulator/scripts/launch_unstyled_tests_emulator.sh
+   bash scripts/createAndroidEmulator
    ```
 
-4. Wait until boot is complete before running Android tests. The script waits for:
+4. Launch the project emulator:
+
+   ```bash
+   bash scripts/launchAndroidEmulator
+   ```
+
+5. Wait until boot is complete before running Android tests. The script waits for:
 
    ```bash
    adb shell getprop sys.boot_completed

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -45,7 +45,22 @@ Use this skill only in `/Users/alexstyl/projects/composeunstyled.com`.
 3. Validate the changelog section exactly matches the release workflow parser:
    - The heading must be `## [x.y.z] - YYYY-MM-DD`.
    - The tag must be `x.y.z`.
-4. Do not run tests during this final release PR/tag flow unless the user explicitly asks. The release PR and tag workflows provide the verification.
+4. Before opening the release PR, run the local checks that correspond to the release changes:
+   - Always run:
+     ```bash
+     ./gradlew --console=plain jvmTest
+     ./gradlew --console=plain spotlessCheck
+     ```
+   - If the release includes Kotlin, Compose, Gradle, test infrastructure, platform, or dependency changes, also run the relevant Android connected tests locally. Launch the project test emulator first:
+     ```bash
+     bash scripts/createAndroidEmulator
+     bash scripts/launchAndroidEmulator
+     adb devices
+     adb shell getprop sys.boot_completed
+     ./gradlew --console=plain :composeunstyled-<module>:connectedDebugAndroidTest
+     ```
+   - For broad or uncertain release contents, run connected tests for every affected `composeunstyled-*` module. Do not rely on the tag workflow as the first Android signal.
+   - Fix all failures before pushing the release branch.
 5. Commit on a release branch:
    ```bash
    git switch -c release/x.y.z
@@ -68,15 +83,31 @@ Use this skill only in `/Users/alexstyl/projects/composeunstyled.com`.
    git pull --ff-only origin main
    git fetch --tags origin
    ```
-2. Create the tag on the merge commit:
+2. Re-run local pre-tag verification on the exact merge commit before creating the tag:
+   - Always run:
+     ```bash
+     ./gradlew --console=plain jvmTest
+     ./gradlew --console=plain spotlessCheck
+     ```
+   - Launch the Android test emulator and run all Android connected tests that are relevant to the release contents:
+     ```bash
+     bash scripts/createAndroidEmulator
+     bash scripts/launchAndroidEmulator
+     adb devices
+     adb shell getprop sys.boot_completed
+     ./gradlew --console=plain :composeunstyled-<module>:connectedDebugAndroidTest
+     ```
+   - If the relevant module set is unclear, inspect the changed modules since the previous tag and err on the side of running more connected tests locally.
+   - Do not tag until these checks pass.
+3. Create the tag on the merge commit:
    ```bash
    git tag x.y.z
    ```
-3. Push the tag:
+4. Push the tag:
    ```bash
    git push origin x.y.z
    ```
-4. If the workflow must be rerun manually, use the `Release` workflow with input `tag = x.y.z`.
+5. If the workflow must be rerun manually, use the `Release` workflow with input `tag = x.y.z`.
 
 ## Do Not
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+## Working with Android
+
+The recommended way to build and develop on Unstyled is using the JVM target. However, for your PRs
+to be merged, the related Android connected tests must pass.
+
+We use the following emulator spec on our CI, and it is recommended that you create the same setup
+locally.
+
+This will guarantee that the local tests will behave as close as possible to the environment running
+on the CI.
+
+Use the `scripts/createAndroidEmulator` script to create the emulator.
+
+### Emulator Spec
+
+- AVD name: `Unstyled_Tests`
+- API level: `23`
+- Target: `default`
+- System image:
+  - CI and non-Apple-Silicon machines: `system-images;android-23;default;x86_64`
+  - Apple Silicon Macs: `system-images;android-23;default;arm64-v8a`
+- CPU architecture:
+  - CI and non-Apple-Silicon machines: `x86_64`
+  - Apple Silicon Macs: `arm64-v8a`
+- Hardware profile: none. Do not pass `--device` to `avdmanager`.
+- Display: `320x640`
+- Density: `160 dpi`
+- CPU cores: `2`
+- Disk size: `2048M`
+- Runtime options:
+  ```bash
+  -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+  ```
+- Test execution disables system animations before running connected tests.

--- a/scripts/androidEmulatorProfile
+++ b/scripts/androidEmulatorProfile
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+AVD_NAME="Unstyled_Tests"
+API_LEVEL="23"
+if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+  ARCH="arm64-v8a"
+else
+  ARCH="x86_64"
+fi
+DISK_SIZE="2048M"
+SYSTEM_IMAGE="system-images;android-${API_LEVEL};default;${ARCH}"
+AVD_DIR="$HOME/.android/avd/${AVD_NAME}.avd"
+CONFIG="$AVD_DIR/config.ini"
+
+if [ -n "${ANDROID_HOME:-}" ]; then
+  SDK_ROOT="$ANDROID_HOME"
+elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+  SDK_ROOT="$ANDROID_SDK_ROOT"
+else
+  SDK_ROOT="$HOME/Library/Android/sdk"
+fi
+
+export ANDROID_HOME="$SDK_ROOT"
+export ANDROID_SDK_ROOT="$SDK_ROOT"
+
+SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+AVDMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/avdmanager"
+EMULATOR="$SDK_ROOT/emulator/emulator"
+ADB="$SDK_ROOT/platform-tools/adb"
+
+config_value() {
+  awk -F= -v key="$1" '$1 == key { value = $2 } END { print value }' "$CONFIG"
+}
+
+avd_matches_expected_profile() {
+  [ -f "$CONFIG" ] || return 1
+
+  [ "$(config_value "abi.type")" = "$ARCH" ] &&
+    [ "$(config_value "hw.cpu.arch")" = "${ARCH%%-*}" ] &&
+    [ "$(config_value "image.sysdir.1")" = "system-images/android-23/default/${ARCH}/" ] &&
+    [ "$(config_value "hw.lcd.width")" = "320" ] &&
+    [ "$(config_value "hw.lcd.height")" = "640" ] &&
+    [ "$(config_value "hw.lcd.density")" = "160" ] &&
+    [ "$(config_value "hw.cpu.ncore")" = "2" ] &&
+    [ "$(config_value "disk.dataPartition.size")" = "2048M" ]
+}

--- a/scripts/createAndroidEmulator
+++ b/scripts/createAndroidEmulator
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/androidEmulatorProfile
+source "$SCRIPT_DIR/androidEmulatorProfile"
+
+for tool in "$SDKMANAGER" "$AVDMANAGER" "$EMULATOR"; do
+  if [ ! -x "$tool" ]; then
+    echo "Required Android SDK tool not found or not executable: $tool" >&2
+    exit 1
+  fi
+done
+
+set_config_value() {
+  key="$1"
+  value="$2"
+
+  if grep -q "^${key}=" "$CONFIG"; then
+    sed -i.bak "s/^${key}=.*/${key}=${value}/" "$CONFIG"
+  else
+    printf "%s=%s\n" "$key" "$value" >> "$CONFIG"
+  fi
+}
+
+if "$EMULATOR" -list-avds | grep -Fxq "$AVD_NAME"; then
+  if avd_matches_expected_profile; then
+    echo "Android emulator $AVD_NAME already matches the expected local test profile."
+    exit 0
+  fi
+
+  echo "Android emulator $AVD_NAME already exists but does not match the expected local test profile." >&2
+  echo "Delete or update it manually, then rerun this script." >&2
+  exit 1
+fi
+
+"$SDKMANAGER" "platform-tools" "emulator" "platforms;android-${API_LEVEL}" "$SYSTEM_IMAGE"
+printf "no\n" | "$AVDMANAGER" create avd \
+  --force \
+  --name "$AVD_NAME" \
+  --package "$SYSTEM_IMAGE"
+
+if [ -f "$CONFIG" ]; then
+  set_config_value "hw.cpu.ncore" "2"
+  set_config_value "disk.dataPartition.size" "$DISK_SIZE"
+fi
+
+if ! avd_matches_expected_profile; then
+  echo "Android emulator $AVD_NAME was created but does not match the expected local test profile." >&2
+  exit 1
+fi
+
+echo "Android emulator $AVD_NAME created."

--- a/scripts/launchAndroidEmulator
+++ b/scripts/launchAndroidEmulator
@@ -1,29 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-AVD_NAME="Unstyled_Tests"
-API_LEVEL="23"
-ARCH="x86_64"
-DISK_SIZE="2048M"
-SYSTEM_IMAGE="system-images;android-${API_LEVEL};default;${ARCH}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/androidEmulatorProfile
+source "$SCRIPT_DIR/androidEmulatorProfile"
 
-if [ -n "${ANDROID_HOME:-}" ]; then
-  SDK_ROOT="$ANDROID_HOME"
-elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
-  SDK_ROOT="$ANDROID_SDK_ROOT"
-else
-  SDK_ROOT="$HOME/Library/Android/sdk"
-fi
-
-export ANDROID_HOME="$SDK_ROOT"
-export ANDROID_SDK_ROOT="$SDK_ROOT"
-
-SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
-AVDMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/avdmanager"
-EMULATOR="$SDK_ROOT/emulator/emulator"
-ADB="$SDK_ROOT/platform-tools/adb"
-
-for tool in "$SDKMANAGER" "$AVDMANAGER" "$EMULATOR" "$ADB"; do
+for tool in "$EMULATOR" "$ADB"; do
   if [ ! -x "$tool" ]; then
     echo "Required Android SDK tool not found or not executable: $tool" >&2
     exit 1
@@ -31,21 +13,15 @@ for tool in "$SDKMANAGER" "$AVDMANAGER" "$EMULATOR" "$ADB"; do
 done
 
 if ! "$EMULATOR" -list-avds | grep -Fxq "$AVD_NAME"; then
-  "$SDKMANAGER" "platform-tools" "emulator" "platforms;android-${API_LEVEL}" "$SYSTEM_IMAGE"
-  printf "no\n" | "$AVDMANAGER" create avd \
-    --force \
-    --name "$AVD_NAME" \
-    --package "$SYSTEM_IMAGE" \
-    --device "pixel"
+  echo "Android emulator $AVD_NAME does not exist." >&2
+  echo "Run scripts/createAndroidEmulator first." >&2
+  exit 1
+fi
 
-  CONFIG="$HOME/.android/avd/${AVD_NAME}.avd/config.ini"
-  if [ -f "$CONFIG" ]; then
-    if grep -q '^disk.dataPartition.size=' "$CONFIG"; then
-      sed -i.bak "s/^disk.dataPartition.size=.*/disk.dataPartition.size=${DISK_SIZE}/" "$CONFIG"
-    else
-      printf "\ndisk.dataPartition.size=%s\n" "$DISK_SIZE" >> "$CONFIG"
-    fi
-  fi
+if ! avd_matches_expected_profile; then
+  echo "Android emulator $AVD_NAME does not match the expected local test profile." >&2
+  echo "Delete or update it manually, then run scripts/createAndroidEmulator." >&2
+  exit 1
 fi
 
 if "$ADB" devices | awk 'NR > 1 && $2 == "device" { found = 1 } END { exit found ? 0 : 1 }'; then
@@ -57,7 +33,7 @@ if "$ADB" devices | awk 'NR > 1 && $2 == "device" { found = 1 } END { exit found
   fi
 fi
 
-"$EMULATOR" \
+nohup "$EMULATOR" \
   -avd "$AVD_NAME" \
   -no-snapshot-save \
   -no-window \

--- a/scripts/preflight
+++ b/scripts/preflight
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ -n "${ANDROID_HOME:-}" ]; then
+  SDK_ROOT="$ANDROID_HOME"
+elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+  SDK_ROOT="$ANDROID_SDK_ROOT"
+else
+  SDK_ROOT="$HOME/Library/Android/sdk"
+fi
+
+ADB="$SDK_ROOT/platform-tools/adb"
+
+echo "Running JVM, formatting, and screenshot checks..."
+./gradlew --console=plain spotlessCheck jvmTest :demo:jvmTest :visual-regressions:jvmScreenshotTest
+
+echo "Creating Android emulator if needed..."
+bash scripts/createAndroidEmulator
+
+echo "Launching Android emulator..."
+bash scripts/launchAndroidEmulator
+
+echo "Verifying Android emulator boot state..."
+"$ADB" devices
+boot_completed="$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)"
+if [ "$boot_completed" != "1" ]; then
+  echo "Android emulator is not booted. sys.boot_completed=$boot_completed" >&2
+  exit 1
+fi
+
+echo "Discovering Android connected test tasks..."
+android_test_modules=()
+while IFS= read -r module; do
+  android_test_modules+=("$module")
+done < <(
+  ./gradlew --console=plain tasks --all |
+    awk -F: '/^composeunstyled-[^:]+:connectedDebugAndroidTest / { print $1 }' |
+    sort -u
+)
+
+if [ "${#android_test_modules[@]}" -eq 0 ]; then
+  echo "No composeunstyled-* connectedDebugAndroidTest tasks found." >&2
+  exit 1
+fi
+
+android_test_tasks=()
+for module in "${android_test_modules[@]}"; do
+  android_test_tasks+=(":${module}:connectedDebugAndroidTest")
+done
+
+echo "Running Android connected tests:"
+printf '  %s\n' "${android_test_tasks[@]}"
+for task in "${android_test_tasks[@]}"; do
+  ./gradlew --console=plain --no-parallel "$task"
+done


### PR DESCRIPTION
## Summary

Adds a local preflight script for release readiness checks, including JVM tests, formatting checks, screenshot tests, and all Android connected tests. Splits Android emulator setup into separate create and launch scripts, and documents the expected emulator profile in CONTRIBUTING.md.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed

Ran:

```bash
bash -n scripts/androidEmulatorProfile scripts/createAndroidEmulator scripts/launchAndroidEmulator scripts/preflight
bash scripts/createAndroidEmulator
bash scripts/launchAndroidEmulator
bash scripts/preflight
```

`bash scripts/preflight` completed successfully, including JVM/Spotless/screenshot checks and all discovered Android connected test tasks.

## Related Issues

None.

## Screenshots/Videos

Not applicable.