### PR TITLE
Fix modal sheet overlay dismissal timing

### DIFF
--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -256,6 +256,7 @@ fun UnstyledModalBottomSheet(
 
   fun requestDismiss() {
     dispatchDismiss()
+    state.modalState.transitionState.targetState = false
     state.pendingDetentChange?.cancel()
     state.launchPendingDetentChange {
       state.bottomSheetState.animateTo(SheetDetent.Hidden, state.dismissAnimationSpec)
@@ -315,7 +316,9 @@ fun UnstyledModalBottomSheet(
       overlay?.invoke(ModalBottomSheetOverlayScopeInstance)
       UnstyledBottomSheet(
         state = state.bottomSheetState,
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+          .fillMaxSize()
+          .keepModalMountedWhileSheetExits(state),
         offsetForIme = properties.offsetForIme,
       ) {
         val modalBottomSheetScope = remember(this) {
@@ -336,6 +339,22 @@ fun ModalBottomSheetScope.Sheet(
     modifier = modifier,
     content = content,
   )
+}
+
+@Composable
+private fun Modifier.keepModalMountedWhileSheetExits(state: ModalBottomSheetState): Modifier {
+  val remainMounted =
+    state.modalState.transitionState.targetState.not() &&
+      (
+        state.bottomSheetState.currentDetent != SheetDetent.Hidden ||
+          state.bottomSheetState.targetDetent != SheetDetent.Hidden
+        )
+
+  return this then buildModifier {
+    if (remainMounted) {
+      add(Modifier.modalFragment())
+    }
+  }
 }
 
 @Composable

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -366,6 +366,44 @@ class ModalBottomSheetTest {
   }
 
   @Test
+  fun outside_tap_starts_modal_fragment_exit_while_sheet_dismiss_animation_is_running() = runComposeUiTest {
+    lateinit var state: ModalBottomSheetState
+    setContent {
+      state = rememberModalBottomSheetState(
+        initialDetent = SheetDetent.FullyExpanded,
+        detents = listOf(SheetDetent.Hidden, SheetDetent.FullyExpanded),
+        animationSpec = tween(durationMillis = 1000),
+      )
+      UnstyledModalBottomSheet(
+        state = state,
+        properties = ModalBottomSheetProperties(dismissOnClickOutside = true),
+        overlay = {
+          Scrim(
+            modifier = Modifier.testTag("scrim"),
+            exit = androidx.compose.animation.fadeOut(tween(durationMillis = 1000)),
+          )
+        },
+      ) {
+        Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
+      }
+    }
+    waitForIdle()
+    onNode(isDialog()).assertExists()
+    onNodeWithTag("sheet").assertExists()
+    onNodeWithTag("scrim").assertExists()
+
+    mainClock.autoAdvance = false
+    onNode(isDialog()).performTouchInput { click(Offset(1f, 1f)) }
+    mainClock.advanceTimeByFrame()
+
+    assertThat(state.bottomSheetState.isIdle).isFalse()
+    assertThat(state.modalState.transitionState.targetState).isFalse()
+    onNode(isDialog()).assertExists()
+    onNodeWithTag("sheet").assertExists()
+    onNodeWithTag("scrim").assertExists()
+  }
+
+  @Test
   fun outside_tap_dismiss_uses_the_provided_dismiss_animation_spec() = runComposeUiTest {
     lateinit var state: ModalBottomSheetState
     setContent {


### PR DESCRIPTION
## Summary

Fixes modal bottom sheet outside/back dismissal so the modal fragment exit starts as soon as the sheet begins dismissing, instead of waiting for the sheet to finish animating to hidden.

The sheet now keeps the modal mounted while it is still exiting, using a private helper that derives the retention condition from modal and sheet state. This keeps the existing public modal fragment API unchanged.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Ran:

```bash
./gradlew :composeunstyled-modal-bottom-sheet:jvmTest --tests '*ModalBottomSheetTest.outside_tap_starts_modal_fragment_exit_while_sheet_dismiss_animation_is_running'
./gradlew :composeunstyled-modal-bottom-sheet:jvmTest
./gradlew :composeunstyled-modal-bottom-sheet:spotlessCheck
./gradlew jvmTest
./gradlew spotlessCheck
```

## Related Issues

None.

## Screenshots/Videos

Not applicable.