### PR TITLE
Introduce hosted modal APIs

### DIFF
--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -61,6 +61,14 @@ interface DialogOverlayScope
 private object DialogOverlayScopeInstance : DialogOverlayScope
 
 @Composable
+fun DialogHost(
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  ModalHost(modifier = modifier, content = content)
+}
+
+@Composable
 fun DialogOverlayScope.Scrim(
   modifier: Modifier = Modifier,
   scrimColor: Color = Color.Black.copy(alpha = 0.6f),

--- a/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
+++ b/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
@@ -115,6 +115,24 @@ class DialogTest {
   }
 
   @Test
+  fun dialogHostRendersDialogInsideHost() = runComposeUiTest {
+    setContent {
+      DialogHost(Modifier.testTag("dialog_host")) {
+        UnstyledDialog(
+          visible = true,
+          onDismissRequest = {},
+        ) {
+          DialogPanel(Modifier.testTag("dialog_content")) {
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("dialog_host").assertExists()
+    onNodeWithTag("dialog_content").assertExists()
+  }
+
+  @Test
   fun dialogPanelSetsPaneTitleSemanticsWhenPresent() = runComposeUiTest {
     setContent {
       UnstyledDialog(

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -57,6 +57,14 @@ import kotlinx.coroutines.launch
 
 private val DoNothing: () -> Unit = {}
 
+@Composable
+fun ModalBottomSheetHost(
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  ModalHost(modifier = modifier, content = content)
+}
+
 class ModalBottomSheetScope internal constructor(
   internal val bottomSheetScope: BottomSheetScope,
 )

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -183,6 +183,23 @@ class ModalBottomSheetTest {
   }
 
   @Test
+  fun modal_bottom_sheet_host_renders_sheet_inside_host() = runComposeUiTest {
+    setContent {
+      ModalBottomSheetHost(Modifier.testTag("sheet_host")) {
+        UnstyledModalBottomSheet(
+          state = rememberModalBottomSheetState(initialDetent = SheetDetent.FullyExpanded),
+          overlay = { Scrim() },
+        ) {
+          Sheet { Box(Modifier.testTag("sheet").size(40.dp)) }
+        }
+      }
+    }
+
+    onNodeWithTag("sheet_host").assertExists()
+    onNodeWithTag("sheet").assertExists()
+  }
+
+  @Test
   fun dialog_exists_when_going_from_hidden_to_visible() = runComposeUiTest {
     lateinit var state: ModalBottomSheetState
     setContent {

--- a/composeunstyled-modal/build.gradle.kts
+++ b/composeunstyled-modal/build.gradle.kts
@@ -79,6 +79,7 @@ kotlin {
     val commonMain by getting {
       dependencies {
         implementation(libs.compose.foundation)
+        implementation(projects.composeunstyledPortal)
       }
     }
 

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -58,18 +58,11 @@ import com.composeunstyled.modal.R
 import java.util.UUID
 
 @Composable
-actual fun Modal(
+internal actual fun PlatformModal(
   state: ModalState,
   onKeyEvent: (KeyEvent) -> Boolean,
   content: @Composable ModalScope.() -> Unit,
 ) {
-  if (
-    state.transitionState.targetState.not() &&
-    state.mountedFragments == 0
-  ) {
-    return
-  }
-
   val parentView = LocalView.current
   val context = LocalContext.current
   val layoutDirection = LocalLayoutDirection.current

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -22,7 +22,10 @@
 package com.composeunstyled
 
 import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -36,6 +39,9 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.semantics.dialog
+import androidx.compose.ui.semantics.semantics
 import kotlinx.coroutines.flow.first
 
 @Stable
@@ -68,16 +74,93 @@ val LocalModalState = staticCompositionLocalOf<ModalState> {
   ModalState()
 }
 
+internal val LocalIsInModalHost = staticCompositionLocalOf { false }
+
+@Composable
+fun ModalHost(
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  CompositionLocalProvider(LocalIsInModalHost provides true) {
+    PortalHost(modifier = modifier, content = content)
+  }
+}
+
 interface ModalScope
 
 internal object ModalScopeInstance : ModalScope
 
 @Composable
-expect fun Modal(
+fun Modal(
   state: ModalState,
   onKeyEvent: (KeyEvent) -> Boolean = { false },
   content: @Composable ModalScope.() -> Unit,
+) {
+  if (
+    state.transitionState.targetState.not() &&
+    state.mountedFragments == 0
+  ) {
+    return
+  }
+
+  if (LocalIsInModalHost.current) {
+    PortalModal(
+      state = state,
+      onKeyEvent = onKeyEvent,
+      content = content,
+    )
+  } else {
+    PlatformModal(
+      state = state,
+      onKeyEvent = onKeyEvent,
+      content = content,
+    )
+  }
+}
+
+@Composable
+internal expect fun PlatformModal(
+  state: ModalState,
+  onKeyEvent: (KeyEvent) -> Boolean,
+  content: @Composable ModalScope.() -> Unit,
 )
+
+@Composable
+internal fun PortalModal(
+  state: ModalState,
+  onKeyEvent: (KeyEvent) -> Boolean,
+  content: @Composable ModalScope.() -> Unit,
+) {
+  Portal {
+    ModalContent(state = state, onKeyEvent = onKeyEvent, content = content)
+  }
+}
+
+@Composable
+internal fun ModalContent(
+  state: ModalState,
+  onKeyEvent: (KeyEvent) -> Boolean,
+  content: @Composable ModalScope.() -> Unit,
+) {
+  Box(
+    Modifier
+      .fillMaxSize()
+      .onKeyEvent(onKeyEvent)
+      .semantics { dialog() },
+  ) {
+    CompositionLocalProvider(LocalModalState provides state) {
+      DisposableEffect(state) {
+        state.attachedToWindow = true
+        onDispose {
+          state.attachedToWindow = false
+        }
+      }
+      if (state.attachedToWindow) {
+        ModalScopeInstance.content()
+      }
+    }
+  }
+}
 
 @Composable
 fun Modifier.modalFragment(): Modifier {

--- a/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
+++ b/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
@@ -79,7 +79,76 @@ class ModalTest {
   }
 
   @Test
-  fun awaitAttachedToWindow_resumes_when_modal_host_attaches() = runComposeUiTest {
+  fun modal_host_renders_content_inside_portal_host() = runComposeUiTest {
+    setContent {
+      ModalHost(Modifier.testTag("modal_host")) {
+        Modal(state = rememberModalState(initiallyVisible = true)) {
+          Box(Modifier.testTag("modal_content").modalFragment())
+        }
+      }
+    }
+
+    onNodeWithTag("modal_host").assertExists()
+    onNodeWithTag("modal_content").assertExists()
+  }
+
+  @Test
+  fun modal_host_modal_resumes_after_attaching() = runComposeUiTest {
+    lateinit var state: ModalState
+    var attachedToWindow by mutableStateOf(false)
+
+    setContent {
+      state = rememberModalState(initiallyVisible = true)
+      ModalHost {
+        Modal(state = state) {
+          LaunchedEffect(state.transitionState.targetState) {
+            if (state.transitionState.targetState) {
+              state.awaitAttachedToWindow()
+              attachedToWindow = true
+            }
+          }
+          Box(Modifier.testTag("modal_content").modalFragment())
+        }
+      }
+    }
+
+    waitUntil { attachedToWindow }
+
+    onNodeWithTag("modal_content").assertExists()
+    assertThat(state.attachedToWindow).isTrue()
+  }
+
+  @Test
+  fun modal_uses_window_when_outside_modal_host() = runComposeUiTest {
+    lateinit var state: ModalState
+    var attachedToWindow by mutableStateOf(false)
+
+    setContent {
+      state = rememberModalState(initiallyVisible = true)
+      ModalHost {
+        Box(Modifier.testTag("modal_host"))
+      }
+
+      Modal(state = state) {
+        LaunchedEffect(state.transitionState.targetState) {
+          if (state.transitionState.targetState) {
+            state.awaitAttachedToWindow()
+            attachedToWindow = true
+          }
+        }
+        Box(Modifier.testTag("window_modal_content").modalFragment())
+      }
+    }
+
+    waitUntil { attachedToWindow }
+
+    onNodeWithTag("modal_host").assertExists()
+    onNodeWithTag("window_modal_content").assertExists()
+    assertThat(state.attachedToWindow).isTrue()
+  }
+
+  @Test
+  fun awaitAttachedToWindow_resumes_when_modal_attaches() = runComposeUiTest {
     lateinit var state: ModalState
     var attachedToWindow by mutableStateOf(false)
 

--- a/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
+++ b/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
@@ -36,18 +36,11 @@ import androidx.compose.ui.window.DialogProperties
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-actual fun Modal(
+internal actual fun PlatformModal(
   state: ModalState,
   onKeyEvent: (KeyEvent) -> Boolean,
   content: @Composable ModalScope.() -> Unit,
 ) {
-  if (
-    state.transitionState.targetState.not() &&
-    state.mountedFragments == 0
-  ) {
-    return
-  }
-
   Dialog(
     onDismissRequest = {},
     properties = DialogProperties(

--- a/demo/src/commonMain/kotlin/Demo.kt
+++ b/demo/src/commonMain/kotlin/Demo.kt
@@ -117,6 +117,7 @@ private val availablePrimitives = listOf(
   ),
   DemoItem("Icon", "icon", { IconDemo() }),
   DemoItem("Modal", "modal", { ModalDemo() }),
+  DemoItem("Modal Render Host", "modal-render-host", { ModalRenderHostDemo() }),
   DemoItem("Progress Indicator", "progressindicator", { ProgressIndicatorDemo() }),
   DemoItem("Radio Group", "radiogroup", { RadioGroupDemo() }),
   DemoItem("Scrollbars", "scrollbars", { ScrollbarsDemo() }),

--- a/demo/src/commonMain/kotlin/ModalRenderHostDemo.kt
+++ b/demo/src/commonMain/kotlin/ModalRenderHostDemo.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled.demo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.composeunstyled.Modal
+import com.composeunstyled.ModalHost
+import com.composeunstyled.Scrim
+import com.composeunstyled.UnstyledButton
+import com.composeunstyled.rememberModalState
+
+@Composable
+fun ModalRenderHostDemo() {
+  val windowModalState = rememberModalState(initiallyVisible = false)
+  val portalModalState = rememberModalState(initiallyVisible = false)
+
+  Box(
+    modifier = Modifier.fillMaxSize(),
+    contentAlignment = Alignment.Center,
+  ) {
+    ModalHost(Modifier.fillMaxSize()) {
+      Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+      ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+          DemoButton(
+            text = "Show in modal",
+            onClick = {
+              windowModalState.transitionState.targetState = true
+            },
+          )
+          DemoButton(
+            text = "Show in portal",
+            onClick = {
+              portalModalState.transitionState.targetState = true
+            },
+          )
+        }
+      }
+
+      Modal(state = portalModalState) {
+        Scrim(
+          modifier = Modifier.pointerInput(Unit) {
+            detectTapGestures {
+              portalModalState.transitionState.targetState = false
+            }
+          },
+          scrimColor = Color.Black.copy(alpha = 0.32f),
+        )
+      }
+    }
+
+    Modal(state = windowModalState) {
+      Scrim(
+        modifier = Modifier.pointerInput(Unit) {
+          detectTapGestures {
+            windowModalState.transitionState.targetState = false
+          }
+        },
+        scrimColor = Color.Black.copy(alpha = 0.32f),
+      )
+    }
+  }
+}
+
+@Composable
+private fun DemoButton(
+  text: String,
+  onClick: () -> Unit,
+) {
+  UnstyledButton(
+    onClick = onClick,
+    modifier = Modifier
+      .clip(RoundedCornerShape(8.dp))
+      .background(Color(0xFF18181B)),
+  ) {
+    BasicText(
+      text,
+      modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+      style = TextStyle(
+        color = Color.White,
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Medium,
+      ),
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Introduces host APIs that let window-backed overlay primitives render inside the current composition:

- `ModalHost` in `composeunstyled-modal`
- `DialogHost` in `composeunstyled-dialog`
- `ModalBottomSheetHost` in `composeunstyled-modal-bottom-sheet`

`ModalHost` owns the actual routing behavior. Dialog and modal bottom sheet hosts delegate to it so users can opt in from the module they already depend on.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Commands run:

- `./gradlew :composeunstyled-modal:jvmTest --tests ModalTest`
- `./gradlew :composeunstyled-dialog:jvmTest --tests DialogTest`
- `./gradlew :composeunstyled-modal-bottom-sheet:jvmTest --tests ModalBottomSheetTest`
- `./gradlew :composeunstyled-modal:compileDebugKotlinAndroid`
- `./gradlew :demo:hotReloadJvmMain`
- `./gradlew jvmTest`
- `./gradlew spotlessCheck`

Also published the modal and portal snapshot locally during the spike with:

- `./gradlew -PpublishVersion=2.5.0-SNAPSHOT :composeunstyled-portal:publishToMavenLocal :composeunstyled-modal:publishToMavenLocal`

## Related Issues


## Screenshots/Videos

