### PR TITLE
Run Android tests for shared module changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
             android_changed_modules="$(
               printf '%s\n' "$changed_files" |
-                awk -F/ '$2 == "src" && ($3 == "androidMain" || $3 == "androidInstrumentedTest") { print ":" $1 }' |
+                awk -F/ '$2 == "src" && ($3 == "commonMain" || $3 == "commonTest" || $3 == "androidMain" || $3 == "androidInstrumentedTest") { print ":" $1 }' |
                 sort -u
             )"
 


### PR DESCRIPTION
## Summary

Updates PR Checks so Android connected tests run when a module's shared `commonMain` or `commonTest` sources change, not only when Android-specific sources change.

## Test Plan

- [ ] Tests added/updated
- [ ] Manual testing performed

Validated the module selector locally with synthetic changed files for dialog, modal bottom sheet, modal Android sources, and workflow-only changes.

## Related Issues

None.

## Screenshots/Videos

Not applicable.