### PR TITLE
Add track-scoped switch thumbs

### DIFF
--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -36,8 +36,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.ParentDataModifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -51,11 +55,20 @@ interface SwitchScope {
   val interactionSource: MutableInteractionSource
 }
 
+@Stable
+interface SwitchTrackScope : SwitchScope
+
 private class SwitchScopeImpl(
   override val checked: Boolean,
   override val enabled: Boolean,
   override val interactionSource: MutableInteractionSource,
 ) : SwitchScope
+
+private class SwitchTrackScopeImpl(
+  override val checked: Boolean,
+  override val enabled: Boolean,
+  override val interactionSource: MutableInteractionSource,
+) : SwitchTrackScope
 
 @Composable
 fun UnstyledSwitch(
@@ -95,27 +108,44 @@ fun UnstyledSwitch(
       )
       scope.content()
     },
-  ) {
-      measurables,
-      constraints,
-    ->
-    val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
-    val placeables = measurables.map { it.measure(looseConstraints) }
-    val contentWidth = placeables.maxOfOrNull { it.width } ?: 0
-    val contentHeight = placeables.maxOfOrNull { it.height } ?: 0
-    val width = contentWidth.coerceIn(constraints.minWidth, constraints.maxWidth)
-    val height = contentHeight.coerceIn(constraints.minHeight, constraints.maxHeight)
+    measurePolicy = { measurables, constraints ->
+      measureSwitchTrack(measurables, constraints)
+    },
+  )
+}
 
-    layout(width, height) {
-      placeables.forEach { placeable ->
-        val thumbData = placeable.parentData as? SwitchThumbParentData
-        val x = thumbData?.let {
-          ((width - placeable.width) * it.offsetFraction).roundToInt()
-        } ?: 0
-        placeable.placeRelative(x = max(0, x), y = 0)
-      }
-    }
-  }
+@Composable
+fun SwitchScope.Track(
+  modifier: Modifier = Modifier,
+  content: @Composable SwitchTrackScope.() -> Unit,
+) {
+  Layout(
+    modifier = modifier,
+    content = {
+      val scope = SwitchTrackScopeImpl(
+        checked = checked,
+        enabled = enabled,
+        interactionSource = interactionSource,
+      )
+      scope.content()
+    },
+    measurePolicy = { measurables, constraints ->
+      measureSwitchTrack(measurables, constraints)
+    },
+  )
+}
+
+@Composable
+fun SwitchTrackScope.Thumb(
+  modifier: Modifier = Modifier,
+  animationSpec: FiniteAnimationSpec<Dp> = snap(),
+  content: @Composable () -> Unit = {},
+) {
+  SwitchThumb(
+    modifier = modifier,
+    animationSpec = animationSpec,
+    content = content,
+  )
 }
 
 @Composable
@@ -140,6 +170,28 @@ fun SwitchScope.SwitchThumb(
 private data class SwitchThumbParentData(
   val offsetFraction: Float,
 )
+
+private fun MeasureScope.measureSwitchTrack(
+  measurables: List<Measurable>,
+  constraints: Constraints,
+): MeasureResult {
+  val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+  val placeables = measurables.map { it.measure(looseConstraints) }
+  val contentWidth = placeables.maxOfOrNull { it.width } ?: 0
+  val contentHeight = placeables.maxOfOrNull { it.height } ?: 0
+  val width = contentWidth.coerceIn(constraints.minWidth, constraints.maxWidth)
+  val height = contentHeight.coerceIn(constraints.minHeight, constraints.maxHeight)
+
+  return layout(width, height) {
+    placeables.forEach { placeable ->
+      val thumbData = placeable.parentData as? SwitchThumbParentData
+      val x = thumbData?.let {
+        ((width - placeable.width) * it.offsetFraction).roundToInt()
+      } ?: 0
+      placeable.placeRelative(x = max(0, x), y = 0)
+    }
+  }
+}
 
 private data class SwitchThumbParentDataModifier(
   val offsetFraction: Float,

--- a/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchRecompositionTest.kt
+++ b/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchRecompositionTest.kt
@@ -23,6 +23,7 @@ package com.composeunstyled
 
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -109,6 +110,95 @@ class ToggleSwitchRecompositionTest {
     switchWidth = 68
     waitForIdle()
 
+    assertThat(recompositionCount("thumb-content")).isEqualTo(0)
+  }
+
+  @Test
+  fun togglingCheckedRecomposesTrackAndThumbContentOnce() = runComposeRecompositionTest {
+    var checked by mutableStateOf(false)
+
+    setContent {
+      UnstyledSwitch(
+        checked = checked,
+        onCheckedChange = { checked = it },
+      ) {
+        Track(
+          modifier = Modifier
+            .width(58.dp)
+            .height(32.dp),
+        ) {
+          RecompositionCount("track-content")
+          Thumb(
+            animationSpec = tween(durationMillis = 1_000),
+            modifier = Modifier.size(24.dp),
+          ) {
+            RecompositionCount("thumb-content")
+            Box(Modifier.size(1.dp))
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts("track-content", "thumb-content")
+
+    checked = true
+    waitForIdle()
+
+    assertThat(recompositionCount("track-content")).isEqualTo(1)
+    assertThat(recompositionCount("thumb-content")).isEqualTo(1)
+  }
+
+  @Test
+  fun resizingLabeledSwitchDoesNotRecomposeTrackOrThumbContent() = runComposeRecompositionTest {
+    var switchWidth by mutableIntStateOf(120)
+
+    setContent {
+      Layout(
+        content = {
+          UnstyledSwitch(
+            checked = true,
+            onCheckedChange = {},
+            modifier = Modifier.height(32.dp),
+          ) {
+            Row {
+              Track(
+                modifier = Modifier
+                  .width(58.dp)
+                  .height(32.dp),
+              ) {
+                RecompositionCount("track-content")
+                Thumb(
+                  animationSpec = tween(durationMillis = 1_000),
+                  modifier = Modifier.size(24.dp),
+                ) {
+                  RecompositionCount("thumb-content")
+                  Box(Modifier.size(1.dp))
+                }
+              }
+
+              Box(Modifier.size(1.dp))
+            }
+          }
+        },
+      ) { measurables, _ ->
+        val width = switchWidth
+        val height = 32.dp.roundToPx()
+        val placeable = measurables.single().measure(Constraints.fixed(width, height))
+
+        layout(width, height) {
+          placeable.place(0, 0)
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts("track-content", "thumb-content")
+
+    switchWidth = 140
+    waitForIdle()
+
+    assertThat(recompositionCount("track-content")).isEqualTo(0)
     assertThat(recompositionCount("thumb-content")).isEqualTo(0)
   }
 }

--- a/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
+++ b/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
@@ -23,6 +23,7 @@ package com.composeunstyled
 
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -239,5 +240,66 @@ class ToggleSwitchTest {
     waitForIdle()
 
     onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(30.dp)
+  }
+
+  @Test
+  fun trackConstrainsThumbMovementInsideLabeledSwitch() = runComposeUiTest {
+    var checked by mutableStateOf(false)
+
+    setContent {
+      UnstyledSwitch(
+        checked = checked,
+        onCheckedChange = { checked = it },
+        modifier = Modifier.testTag("switch"),
+      ) {
+        Row {
+          Track(
+            modifier = Modifier
+              .width(58.dp)
+              .height(32.dp),
+          ) {
+            Thumb(
+              modifier = Modifier.size(24.dp),
+            ) {
+              Box(Modifier.size(1.dp).testTag("thumb-content"))
+            }
+          }
+
+          BasicText("Notifications")
+        }
+      }
+    }
+
+    waitForIdle()
+    onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(0.dp)
+
+    onNodeWithTag("switch").performClick()
+    waitForIdle()
+
+    onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(34.dp)
+  }
+
+  @Test
+  fun existingSwitchThumbCanBeUsedInsideTrack() = runComposeUiTest {
+    setContent {
+      UnstyledSwitch(
+        checked = true,
+        onCheckedChange = {},
+      ) {
+        Track(
+          modifier = Modifier
+            .width(58.dp)
+            .height(32.dp),
+        ) {
+          SwitchThumb(
+            modifier = Modifier.size(24.dp),
+          ) {
+            Box(Modifier.size(1.dp).testTag("thumb-content"))
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("thumb-content", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(34.dp)
   }
 }

--- a/demo/src/commonMain/kotlin/ToggleSwitchDemo.kt
+++ b/demo/src/commonMain/kotlin/ToggleSwitchDemo.kt
@@ -28,11 +28,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
@@ -45,54 +45,54 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.composeunstyled.SwitchThumb
+import com.composeunstyled.Thumb
+import com.composeunstyled.Track
 import com.composeunstyled.UnstyledSwitch
 
 @Composable
 fun ToggleSwitchDemo() {
   var toggled by remember { mutableStateOf(true) }
+  val backgroundColor by animateColorAsState(
+    if (toggled) Color.Black else Color(0xFFE0E0E0),
+  )
 
-  Row(
-    Modifier
+  UnstyledSwitch(
+    checked = toggled,
+    onCheckedChange = { toggled = it },
+    modifier = Modifier
       .width(300.dp)
-      .clip(RoundedCornerShape(10.dp))
-      .selectable(
-        selected = toggled,
-        onClick = { toggled = toggled.not() },
-        interactionSource = null,
-        role = Role.Switch,
-      ).padding(8.dp),
-    horizontalArrangement = Arrangement.SpaceBetween,
-    verticalAlignment = Alignment.CenterVertically,
+      .clip(RoundedCornerShape(10.dp)),
+    indication = LocalIndication.current,
   ) {
-    BasicText("Airplane Mode", style = TextStyle(fontSize = 18.sp))
-    val animatedColor by animateColorAsState(
-      if (toggled) Color.Black else Color(0xFFE0E0E0),
-    )
-    UnstyledSwitch(
-      checked = toggled,
-      onCheckedChange = null,
+    Row(
       modifier = Modifier
-        .width(58.dp)
-        .height(32.dp)
-        .clip(RoundedCornerShape(100))
-        .background(animatedColor, RoundedCornerShape(100))
-        .border(1.dp, Color(0xFFCACACA), RoundedCornerShape(100)),
-      indication = LocalIndication.current,
+        .fillMaxWidth()
+        .padding(8.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
     ) {
-      SwitchThumb(
-        animationSpec = tween(),
+      BasicText("Airplane Mode", style = TextStyle(fontSize = 18.sp))
+      Track(
         modifier = Modifier
-          .padding(4.dp)
-          .clip(CircleShape)
-          .background(Color(0xFFF8FAFC))
-          .border(1.dp, Color(0xFFCACACA), CircleShape)
-          .size(24.dp),
-      )
+          .width(58.dp)
+          .height(32.dp)
+          .clip(RoundedCornerShape(100))
+          .background(backgroundColor, RoundedCornerShape(100))
+          .border(1.dp, Color(0xFFCACACA), RoundedCornerShape(100)),
+      ) {
+        Thumb(
+          animationSpec = tween(),
+          modifier = Modifier
+            .padding(4.dp)
+            .clip(CircleShape)
+            .background(Color(0xFFF8FAFC))
+            .border(1.dp, Color(0xFFCACACA), CircleShape)
+            .size(24.dp),
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds an explicit `Track { Thumb() }` anatomy to `UnstyledSwitch` so the switch root can represent the full clickable/semantic control while the track defines the thumb positioning bounds.

This lets wrappers follow the same row-label pattern as checkbox:

```kotlin
UnstyledSwitch(...) {
  Row {
    Track {
      Thumb()
    }

    Label()
  }
}
```

Existing `SwitchThumb()` usage remains supported for standalone switches where the root also acts as the visual track. The demo now uses the new track-scoped API, and tests cover both the new anatomy and compatibility with `SwitchThumb` inside `Track`.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

```bash
./gradlew jvmTest spotlessCheck
```

## Related Issues

Closes #414

## Screenshots/Videos

Not applicable.