### PR TITLE
Add unscoped radio button API

### DIFF
--- a/composeunstyled-radio-group/build.gradle.kts
+++ b/composeunstyled-radio-group/build.gradle.kts
@@ -91,6 +91,7 @@ kotlin {
     commonTest.dependencies {
       implementation(kotlin("test"))
       implementation(libs.assertk)
+      implementation(projects.composeunstyledTest)
 
       @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
       implementation(libs.compose.ui.test)

--- a/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
+++ b/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
@@ -54,10 +53,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 
-private val KeyEvent.isKeyDown: Boolean
-  get() = type == KeyEventType.KeyDown
-
-private val LocalInnerRadioGroupState = staticCompositionLocalOf { InnerRadioGroupState() }
+private val LocalRadioGroupState = staticCompositionLocalOf<InnerRadioGroupState?> { null }
 
 @Composable
 fun <T> UnstyledRadioGroup(
@@ -90,14 +86,14 @@ fun <T> UnstyledRadioGroup(
       .onKeyEvent { event ->
         when (event.key) {
           Key.DirectionDown, Key.DirectionRight -> {
-            if (event.isKeyDown) {
+            if (event.type == KeyEventType.KeyDown) {
               focusManager.moveFocus(FocusDirection.Next)
             }
             true
           }
 
           Key.DirectionUp, Key.DirectionLeft -> {
-            if (event.isKeyDown) {
+            if (event.type == KeyEventType.KeyDown) {
               focusManager.moveFocus(FocusDirection.Previous)
             }
             true
@@ -107,7 +103,7 @@ fun <T> UnstyledRadioGroup(
         }
       },
   ) {
-    CompositionLocalProvider(LocalInnerRadioGroupState provides state) {
+    CompositionLocalProvider(LocalRadioGroupState provides state) {
       scope.content()
     }
   }
@@ -128,13 +124,30 @@ fun <T> RadioGroupScope.RadioButton(
   interactionSource: MutableInteractionSource? = null,
   indication: Indication? = null,
   content: @Composable RadioButtonScope.() -> Unit,
+) = UnstyledRadioButton(
+  value = value,
+  modifier = modifier,
+  enabled = enabled,
+  interactionSource = interactionSource,
+  indication = indication,
+  content = content,
+)
+
+@Composable
+fun <T> UnstyledRadioButton(
+  value: T,
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  interactionSource: MutableInteractionSource? = null,
+  indication: Indication? = null,
+  content: @Composable RadioButtonScope.() -> Unit,
 ) {
-  val state = LocalInnerRadioGroupState.current
-  val selected = state.value == value
+  val state = LocalRadioGroupState.current
+  val selected = state?.value == value
+  val radioEnabled = enabled && state != null
   val radioInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
   val scope = RadioButtonScope(
     selected = selected,
-    enabled = enabled,
     interactionSource = radioInteractionSource,
   )
 
@@ -144,11 +157,11 @@ fun <T> RadioGroupScope.RadioButton(
         value = selected,
         onValueChange = { selected ->
           if (selected) {
-            state.onValueChange(value)
+            state?.onValueChange(value)
           }
         },
         role = Role.RadioButton,
-        enabled = enabled,
+        enabled = radioEnabled,
         indication = indication,
         interactionSource = radioInteractionSource,
       )
@@ -160,7 +173,6 @@ fun <T> RadioGroupScope.RadioButton(
 
 class RadioButtonScope internal constructor(
   internal val selected: Boolean,
-  internal val enabled: Boolean,
   internal val interactionSource: MutableInteractionSource,
 )
 

--- a/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
+++ b/composeunstyled-radio-group/src/commonMain/kotlin/com/composeunstyled/RadioGroup.kt
@@ -35,11 +35,7 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
@@ -64,16 +60,14 @@ fun <T> UnstyledRadioGroup(
   content: @Composable RadioGroupScope.() -> Unit,
 ) {
   val focusManager = LocalFocusManager.current
-  val state = remember { InnerRadioGroupState() }
-  val scope = remember { RadioGroupScope() }
-
-  SideEffect {
-    state.value = value
-    state.onValueChange = { nextValue ->
+  val state = InnerRadioGroupState(
+    value = value,
+    onValueChange = { nextValue ->
       @Suppress("UNCHECKED_CAST")
       onValueChange(nextValue as T)
-    }
-  }
+    },
+  )
+  val scope = remember { RadioGroupScope() }
 
   Box(
     modifier
@@ -111,10 +105,10 @@ fun <T> UnstyledRadioGroup(
 
 class RadioGroupScope internal constructor()
 
-private class InnerRadioGroupState {
-  var value by mutableStateOf<Any?>(null)
-  var onValueChange by mutableStateOf<(Any?) -> Unit>({})
-}
+private class InnerRadioGroupState(
+  val value: Any?,
+  val onValueChange: (Any?) -> Unit,
+)
 
 @Composable
 fun <T> RadioGroupScope.RadioButton(

--- a/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupRecompositionTest.kt
+++ b/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupRecompositionTest.kt
@@ -35,7 +35,7 @@ import kotlin.test.Test
 
 class RadioGroupRecompositionTest {
   @Test
-  fun selectingUnstyledRadioButtonRecomposesRadioContentTwice() = runComposeRecompositionTest {
+  fun selectingUnstyledRadioButtonRecomposesRadioContentOnce() = runComposeRecompositionTest {
     var selectedValue by mutableStateOf("light")
 
     setContent {
@@ -65,7 +65,7 @@ class RadioGroupRecompositionTest {
     selectedValue = "dark"
     waitForIdle()
 
-    assertThat(recompositionCount("light-content")).isEqualTo(2)
-    assertThat(recompositionCount("dark-content")).isEqualTo(2)
+    assertThat(recompositionCount("light-content")).isEqualTo(1)
+    assertThat(recompositionCount("dark-content")).isEqualTo(1)
   }
 }

--- a/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupRecompositionTest.kt
+++ b/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupRecompositionTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.composeunstyled.test.runComposeRecompositionTest
+import kotlin.test.Test
+
+class RadioGroupRecompositionTest {
+  @Test
+  fun selectingUnstyledRadioButtonRecomposesRadioContentTwice() = runComposeRecompositionTest {
+    var selectedValue by mutableStateOf("light")
+
+    setContent {
+      UnstyledRadioGroup(
+        value = selectedValue,
+        onValueChange = { selectedValue = it },
+      ) {
+        UnstyledRadioButton(value = "light") {
+          RecompositionCount("light-content")
+          SelectedIndicator {
+            Box(Modifier.size(1.dp))
+          }
+        }
+
+        UnstyledRadioButton(value = "dark") {
+          RecompositionCount("dark-content")
+          SelectedIndicator {
+            Box(Modifier.size(1.dp))
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    resetRecompositionCounts("light-content", "dark-content")
+
+    selectedValue = "dark"
+    waitForIdle()
+
+    assertThat(recompositionCount("light-content")).isEqualTo(2)
+    assertThat(recompositionCount("dark-content")).isEqualTo(2)
+  }
+}

--- a/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupTest.kt
+++ b/composeunstyled-radio-group/src/commonTest/kotlin/com/composeunstyled/RadioGroupTest.kt
@@ -90,6 +90,28 @@ class RadioGroupTest {
   }
 
   @Test
+  fun unstyledRadioButtonSelectsValue() = runComposeUiTest {
+    var selectedValue: String? = null
+    setContent {
+      UnstyledRadioGroup(
+        value = selectedValue,
+        onValueChange = { selectedValue = it },
+      ) {
+        UnstyledRadioButton(
+          value = "option",
+          modifier = Modifier.testTag("radio"),
+        ) {
+          Box(Modifier.size(20.dp))
+        }
+      }
+    }
+
+    onNodeWithTag("radio").performClick()
+
+    assertThat(selectedValue).isEqualTo("option")
+  }
+
+  @Test
   fun clickDoesNotSelectRadioButtonWhenDisabled() = runComposeUiTest {
     var selectedValue: String? = null
     setContent {
@@ -213,5 +235,23 @@ class RadioGroupTest {
     }
 
     onNodeWithTag("selected_indicator", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun unstyledRadioButtonOutsideGroupRendersUnselectedContent() = runComposeUiTest {
+    setContent {
+      UnstyledRadioButton(
+        value = "option",
+        modifier = Modifier.testTag("radio"),
+      ) {
+        Box(Modifier.size(20.dp).testTag("content"))
+        SelectedIndicator {
+          Box(Modifier.size(8.dp).testTag("selected_indicator"))
+        }
+      }
+    }
+
+    onNodeWithTag("content", useUnmergedTree = true).assertIsDisplayed()
+    onAllNodesWithTag("selected_indicator", useUnmergedTree = true).assertCountEquals(0)
   }
 }

--- a/demo/src/commonMain/kotlin/RadioGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/RadioGroupDemo.kt
@@ -46,8 +46,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.RadioButton
 import com.composeunstyled.SelectedIndicator
+import com.composeunstyled.UnstyledRadioButton
 import com.composeunstyled.UnstyledRadioGroup
 
 @Composable
@@ -76,7 +76,7 @@ fun RadioGroupDemo() {
         values.forEach { value ->
           val selected = selectedValue == value
           val itemShape = RoundedCornerShape(14.dp)
-          RadioButton(
+          UnstyledRadioButton(
             value = value,
             modifier = Modifier
               .fillMaxWidth()


### PR DESCRIPTION
## Summary

Adds a top-level `UnstyledRadioButton` API so design-system wrappers can build radio components without carrying `RadioGroupScope` through their own API.

The existing scoped `RadioButton` remains available and delegates to `UnstyledRadioButton`, so current call sites continue to work. The new top-level radio button reads group state from the internal composition local, renders inert/unselected content outside `UnstyledRadioGroup`, and the demo now uses the new API.

This also adds radio group recomposition coverage and removes the delayed `SideEffect` state sync so selection changes recompose affected radio content once instead of twice.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed

```bash
./gradlew :composeunstyled-radio-group:jvmTest
./gradlew :demo:hotReloadJvmMain
./gradlew jvmTest
./gradlew spotlessCheck
```

## Related Issues

Closes #416

## Screenshots/Videos

N/A