### PR TITLE
Add unscoped disclosure API

### DIFF
--- a/composeunstyled-disclosure/build.gradle.kts
+++ b/composeunstyled-disclosure/build.gradle.kts
@@ -85,6 +85,7 @@ kotlin {
     val commonMain by getting {
       dependencies {
         implementation(libs.compose.foundation)
+        implementation(projects.composeunstyledBuildModifier)
         implementation(projects.composeunstyledButton)
       }
     }

--- a/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
+++ b/composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt
@@ -31,8 +31,10 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.collapse
@@ -42,21 +44,15 @@ import androidx.compose.ui.unit.dp
 
 private val NoPadding = PaddingValues(0.dp)
 
-@Stable
-class DisclosureScope internal constructor(
-  val expanded: Boolean,
-  internal val onExpandedChange: (Boolean) -> Unit,
-)
+private val LocalDisclosureContext = staticCompositionLocalOf<DisclosureContext?> { null }
 
-@Composable
-private fun rememberDisclosureScope(
-  expanded: Boolean,
-  onExpandedChange: (Boolean) -> Unit,
-): DisclosureScope {
-  return remember(expanded, onExpandedChange) {
-    DisclosureScope(expanded, onExpandedChange)
-  }
-}
+@Stable
+class DisclosureScope internal constructor()
+
+private class DisclosureContext(
+  val expanded: Boolean,
+  val onExpandedChange: (Boolean) -> Unit,
+)
 
 @Composable
 fun UnstyledDisclosure(
@@ -65,10 +61,15 @@ fun UnstyledDisclosure(
   modifier: Modifier = Modifier,
   content: @Composable DisclosureScope.() -> Unit,
 ) {
-  val scope = rememberDisclosureScope(expanded, onExpandedChange)
+  val scope = remember { DisclosureScope() }
+  val context = remember(expanded, onExpandedChange) {
+    DisclosureContext(expanded, onExpandedChange)
+  }
 
   Box(modifier) {
-    scope.content()
+    CompositionLocalProvider(LocalDisclosureContext provides context) {
+      scope.content()
+    }
   }
 }
 
@@ -81,29 +82,77 @@ fun DisclosureScope.DisclosureButton(
   interactionSource: MutableInteractionSource? = null,
   contentAlignment: Alignment = Alignment.Center,
   content: @Composable () -> Unit,
+) = UnstyledDisclosureButton(
+  modifier = modifier,
+  enabled = enabled,
+  contentPadding = contentPadding,
+  indication = indication,
+  interactionSource = interactionSource,
+  contentAlignment = contentAlignment,
+  content = content,
+)
+
+@Composable
+fun UnstyledDisclosureButton(
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  contentPadding: PaddingValues = NoPadding,
+  indication: Indication? = null,
+  interactionSource: MutableInteractionSource? = null,
+  contentAlignment: Alignment = Alignment.Center,
+  content: @Composable () -> Unit,
 ) {
+  val context = LocalDisclosureContext.current
+
   UnstyledButton(
-    modifier = modifier.semantics {
-      if (expanded) {
-        collapse {
-          onExpandedChange(false)
-          true
-        }
-      } else {
-        expand {
-          onExpandedChange(true)
-          true
-        }
+    modifier = modifier then buildModifier {
+      if (context != null) {
+        add(
+          Modifier.semantics {
+            if (context.expanded) {
+              collapse {
+                context.onExpandedChange(false)
+                true
+              }
+            } else {
+              expand {
+                context.onExpandedChange(true)
+                true
+              }
+            }
+          },
+        )
       }
     },
-    onClick = { onExpandedChange(expanded.not()) },
+    onClick = { context?.onExpandedChange(context.expanded.not()) },
     interactionSource = interactionSource,
     indication = indication,
-    enabled = enabled,
+    enabled = enabled && context != null,
     contentPadding = contentPadding,
     contentAlignment = contentAlignment,
   ) {
     content()
+  }
+}
+
+@Composable
+fun UnstyledDisclosedContent(
+  modifier: Modifier = Modifier,
+  enter: EnterTransition = EnterTransition.None,
+  exit: ExitTransition = ExitTransition.None,
+  content: @Composable () -> Unit,
+) {
+  val context = LocalDisclosureContext.current
+
+  if (context != null) {
+    AnimatedVisibility(
+      modifier = modifier,
+      visible = context.expanded,
+      enter = enter,
+      exit = exit,
+    ) {
+      content()
+    }
   }
 }
 
@@ -113,13 +162,9 @@ fun DisclosureScope.DisclosedContent(
   enter: EnterTransition = EnterTransition.None,
   exit: ExitTransition = ExitTransition.None,
   content: @Composable () -> Unit,
-) {
-  AnimatedVisibility(
-    modifier = modifier,
-    visible = expanded,
-    enter = enter,
-    exit = exit,
-  ) {
-    content()
-  }
-}
+) = UnstyledDisclosedContent(
+  modifier = modifier,
+  enter = enter,
+  exit = exit,
+  content = content,
+)

--- a/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
+++ b/composeunstyled-disclosure/src/commonTest/kotlin/Disclosure.test.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
 import androidx.compose.ui.test.assertTopPositionInRootIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
@@ -57,7 +58,7 @@ class DisclosureTest {
         expanded = false,
         onExpandedChange = { nextValue = it },
       ) {
-        DisclosureButton(Modifier.testTag("button")) {
+        UnstyledDisclosureButton(Modifier.testTag("button")) {
           BasicText("Heading")
         }
       }
@@ -77,10 +78,10 @@ class DisclosureTest {
         expanded = expanded,
         onExpandedChange = { expanded = it },
       ) {
-        DisclosureButton(Modifier.testTag("button")) {
+        UnstyledDisclosureButton(Modifier.testTag("button")) {
           BasicText("Heading")
         }
-        DisclosedContent(Modifier.testTag("content")) {
+        UnstyledDisclosedContent(Modifier.testTag("content")) {
           BasicText("Panel")
         }
       }
@@ -94,13 +95,41 @@ class DisclosureTest {
   }
 
   @Test
+  fun unscopedButtonOutsideDisclosureIsDisabled() = runComposeUiTest {
+    setContent {
+      UnstyledDisclosureButton(Modifier.testTag("button")) {
+        BasicText("Heading")
+      }
+    }
+
+    onNodeWithTag("button")
+      .assertHasClickAction()
+      .assertIsNotEnabled()
+      .assert(hasNoExpandAction())
+      .assert(hasNoCollapseAction())
+
+    onNodeWithTag("button").performClick()
+  }
+
+  @Test
+  fun unscopedContentOutsideDisclosureDoesNotRender() = runComposeUiTest {
+    setContent {
+      UnstyledDisclosedContent(Modifier.testTag("content")) {
+        BasicText("Panel")
+      }
+    }
+
+    onNodeWithTag("content").assertDoesNotExist()
+  }
+
+  @Test
   fun disclosureButtonExposesButtonRoleAndExpandActionWhenCollapsed() = runComposeUiTest {
     setContent {
       UnstyledDisclosure(
         expanded = false,
         onExpandedChange = {},
       ) {
-        DisclosureButton(Modifier.testTag("button")) {
+        UnstyledDisclosureButton(Modifier.testTag("button")) {
           BasicText("Heading")
         }
       }
@@ -120,7 +149,7 @@ class DisclosureTest {
         expanded = true,
         onExpandedChange = {},
       ) {
-        DisclosureButton(Modifier.testTag("button")) {
+        UnstyledDisclosureButton(Modifier.testTag("button")) {
           BasicText("Heading")
         }
       }
@@ -140,7 +169,7 @@ class DisclosureTest {
         expanded = false,
         onExpandedChange = {},
       ) {
-        DisclosureButton(
+        UnstyledDisclosureButton(
           modifier = Modifier.size(100.dp).testTag("button"),
           contentPadding = PaddingValues(10.dp),
           contentAlignment = Alignment.BottomEnd,

--- a/scripts/generate-compose-unstyled-api.mjs
+++ b/scripts/generate-compose-unstyled-api.mjs
@@ -79,6 +79,8 @@ const apiReferences = {
   disclosure: [
     source('composeunstyled-disclosure/src/commonMain/kotlin/com/composeunstyled/Disclosure.kt', [
       fn('UnstyledDisclosure'),
+      fn('UnstyledDisclosureButton'),
+      fn('UnstyledDisclosedContent'),
       fn('DisclosureButton', 'DisclosureScope.DisclosureButton'),
       fn('DisclosedContent', 'DisclosureScope.DisclosedContent'),
     ]),


### PR DESCRIPTION
## Summary

Adds top-level `UnstyledDisclosureButton` and `UnstyledDisclosedContent` APIs that read the current disclosure context internally, so styled wrappers can expose child parts without leaking `DisclosureScope`.

The existing scoped `DisclosureButton` and `DisclosedContent` APIs remain in place and delegate through the same implementation. When the new unscoped parts are used outside `UnstyledDisclosure`, the trigger renders disabled and the disclosed content renders nothing instead of crashing.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Ran:

```bash
./gradlew :composeunstyled-disclosure:jvmTest --tests DisclosureTest
./gradlew jvmTest spotlessCheck
./gradlew spotlessCheck
```

## Related Issues

Closes #420

## Screenshots/Videos

Not applicable; API behavior change only.