### PR TITLE
Fix PR checks selecting base branch changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
 
           android_modules=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+            merge_base="$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+            changed_files="$(git diff --name-only "$merge_base" "${{ github.event.pull_request.head.sha }}")"
             android_changed_modules="$(
               printf '%s\n' "$changed_files" |
                 awk -F/ '$2 == "src" && ($3 == "commonMain" || $3 == "commonTest" || $3 == "androidMain" || $3 == "androidInstrumentedTest") { print ":" $1 }' |
@@ -81,7 +82,8 @@ jobs:
 
           changed_modules=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+            merge_base="$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+            changed_files="$(git diff --name-only "$merge_base" "${{ github.event.pull_request.head.sha }}")"
 
             while IFS= read -r file; do
               module="${file%%/*}"


### PR DESCRIPTION
## Summary

Fixes PR changed-file detection in `ci.yml` to diff from the PR merge base to the head commit instead of diffing the base branch tip against the head branch tip.

This prevents CI from selecting modules that changed on `main` after a PR branch split, such as unrelated radio-group Android tests running for a disclosure-only PR.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

Ran:

```bash
rg -n "git diff --name-only|merge-base" .github/workflows/ci.yml
git diff --check
base=origin/main; head=HEAD; merge_base=$(git merge-base "$base" "$head"); changed_files=$(git diff --name-only "$merge_base" "$head"); printf 'merge_base=%s\nchanged_files:\n%s\n' "$merge_base" "$changed_files"; printf '%s\n' "$changed_files" | awk -F/ '$2 == "src" && ($3 == "commonMain" || $3 == "commonTest" || $3 == "androidMain" || $3 == "androidInstrumentedTest") { print ":" $1 }' | sort -u
```

## Related Issues

Follow-up from #421.

## Screenshots/Videos

Not applicable; CI workflow change only.