### PR TITLE
Add unscoped tab group primitives

### DIFF
--- a/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
+++ b/composeunstyled-tab-group/src/commonMain/kotlin/com/composeunstyled/TabGroup.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -39,6 +40,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
@@ -59,6 +61,9 @@ import androidx.compose.ui.semantics.Role
 
 typealias TabKey = String
 
+private val LocalTabGroupRegistry = staticCompositionLocalOf<TabsRegistry<Any?>?> { null }
+private val LocalTabListRegistry = staticCompositionLocalOf<TabsRegistry<Any?>?> { null }
+
 private val KeyEvent.isKeyDown: Boolean
   get() = type == KeyEventType.KeyDown
 
@@ -75,18 +80,23 @@ internal class TabsRegistry<T> {
   var panelsFocusRequesters: Map<T, FocusRequester> by mutableStateOf(emptyMap())
 }
 
-class TabGroupScope<T> internal constructor(
-  internal val registry: TabsRegistry<T>,
-)
+class TabGroupScope<T> internal constructor()
 
-class TabListScope<T> internal constructor(
-  internal val registry: TabsRegistry<T>,
-)
+class TabListScope<T> internal constructor()
 
 class TabScope internal constructor(
   val selected: Boolean,
   val enabled: Boolean,
 )
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> TabsRegistry<T>.asAnyRegistry(): TabsRegistry<Any?> = this as TabsRegistry<Any?>
+
+@Composable
+private fun currentTabGroupRegistry(): TabsRegistry<Any?>? = LocalTabGroupRegistry.current
+
+@Composable
+private fun currentTabListRegistry(): TabsRegistry<Any?>? = LocalTabListRegistry.current
 
 @Composable
 fun <T> UnstyledTabGroup(
@@ -128,10 +138,12 @@ fun <T> UnstyledTabGroup(
       }
       .focusGroup(),
   ) {
-    val tabGroupScope = remember(registry) {
-      TabGroupScope(registry)
+    val tabGroupScope = remember {
+      TabGroupScope<T>()
     }
-    tabGroupScope.content()
+    CompositionLocalProvider(LocalTabGroupRegistry provides registry.asAnyRegistry()) {
+      tabGroupScope.content()
+    }
   }
 }
 
@@ -140,8 +152,29 @@ fun <T> TabGroupScope<T>.TabList(
   modifier: Modifier = Modifier,
   orientation: Orientation = Orientation.Horizontal,
   content: @Composable TabListScope<T>.() -> Unit,
+) = UnstyledTabList(
+  modifier = modifier,
+  orientation = orientation,
 ) {
-  val registry = registry
+  val tabListScope = remember {
+    TabListScope<T>()
+  }
+  tabListScope.content()
+}
+
+@Composable
+fun UnstyledTabList(
+  modifier: Modifier = Modifier,
+  orientation: Orientation = Orientation.Horizontal,
+  content: @Composable () -> Unit,
+) {
+  val registry = currentTabGroupRegistry()
+  if (registry == null) {
+    Box(modifier) {
+      content()
+    }
+    return
+  }
   val tabKeys = registry.tabKeys
 
   Box(
@@ -242,10 +275,9 @@ fun <T> TabGroupScope<T>.TabList(
         }
       },
   ) {
-    val tabListScope = remember(registry) {
-      TabListScope(registry)
+    CompositionLocalProvider(LocalTabListRegistry provides registry) {
+      content()
     }
-    tabListScope.content()
   }
 }
 
@@ -258,11 +290,55 @@ fun <T> TabListScope<T>.Tab(
   indication: Indication? = null,
   interactionSource: MutableInteractionSource? = null,
   content: @Composable TabScope.() -> Unit,
+) = UnstyledTab(
+  key = key,
+  modifier = modifier,
+  enabled = enabled,
+  activateOnFocus = activateOnFocus,
+  indication = indication,
+  interactionSource = interactionSource,
+  content = content,
+)
+
+@Composable
+fun <T> UnstyledTab(
+  key: T,
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  activateOnFocus: Boolean = true,
+  indication: Indication? = null,
+  interactionSource: MutableInteractionSource? = null,
+  content: @Composable TabScope.() -> Unit,
 ) {
-  val registry = registry
+  val registry = currentTabListRegistry()
+  if (registry == null) {
+    val tabScope = remember {
+      TabScope(
+        selected = false,
+        enabled = false,
+      )
+    }
+    Box(modifier) {
+      tabScope.content()
+    }
+    return
+  }
   val focusManager = LocalFocusManager.current
   val focusRequester = registry.tabFocusRequesters[key] ?: FocusRequester.Default
   val activatedTab = registry.activatedTab
+  val isRegisteredTab = key in registry.tabKeys
+  if (isRegisteredTab.not()) {
+    val tabScope = remember {
+      TabScope(
+        selected = false,
+        enabled = false,
+      )
+    }
+    Box(modifier) {
+      tabScope.content()
+    }
+    return
+  }
   val selected = activatedTab == key
   val tabScope = remember(selected, enabled) {
     TabScope(
@@ -336,8 +412,19 @@ fun <T> TabGroupScope<T>.TabPanel(
   key: T,
   modifier: Modifier = Modifier,
   content: @Composable () -> Unit,
+) = UnstyledTabPanel(
+  key = key,
+  modifier = modifier,
+  content = content,
+)
+
+@Composable
+fun <T> UnstyledTabPanel(
+  key: T,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
 ) {
-  val registry = registry
+  val registry = currentTabGroupRegistry() ?: return
 
   if (registry.activatedTab == key) {
     val focusRequester = registry.panelsFocusRequesters[key] ?: FocusRequester.Default

--- a/composeunstyled-tab-group/src/commonTest/kotlin/TabGroup.test.kt
+++ b/composeunstyled-tab-group/src/commonTest/kotlin/TabGroup.test.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
 class TabGroupCommonTest {
@@ -138,5 +140,235 @@ class TabGroupCommonTest {
 
     onNodeWithText("Account panel").assertDoesNotExist()
     onNodeWithText("Billing panel").isDisplayed()
+  }
+
+  @Test
+  fun tabWithUnknownKeyRendersDisabledUnselectedContent() = runComposeUiTest {
+    var selectedTab by mutableStateOf("known")
+
+    setContent {
+      UnstyledTabGroup(
+        selectedTab = selectedTab,
+        onSelectedTabChange = { selectedTab = it },
+        tabs = listOf("known"),
+      ) {
+        TabList {
+          Tab(
+            key = "unknown",
+            modifier = Modifier.testTag("unknown"),
+          ) {
+            BasicText(
+              text = when {
+                selected -> "selected"
+                enabled.not() -> "disabled"
+                else -> "unselected"
+              },
+            )
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("unknown").performClick()
+
+    assertThat(selectedTab).isEqualTo("known")
+    onNodeWithText("disabled").isDisplayed()
+  }
+
+  @Test
+  fun unscopedTabsShowPanelOfTheActivatedTab() = runComposeUiTest {
+    var selectedTab by mutableStateOf("tab1")
+
+    setContent {
+      UnstyledTabGroup(
+        selectedTab = selectedTab,
+        onSelectedTabChange = { selectedTab = it },
+        tabs = listOf("tab1", "tab2", "tab3"),
+      ) {
+        UnstyledTabList(Modifier.testTag("tablist").requiredWidth(160.dp)) {
+          UnstyledTab(
+            key = "tab1",
+            modifier = Modifier.testTag("tab1"),
+          ) {
+            BasicText("Tab #1")
+          }
+          UnstyledTab(
+            key = "tab2",
+            modifier = Modifier.testTag("tab2").offset(x = 48.dp),
+          ) {
+            BasicText("Tab #2")
+          }
+          UnstyledTab(
+            key = "tab3",
+            modifier = Modifier.testTag("tab3").offset(x = 96.dp),
+          ) {
+            BasicText("Tab #3")
+          }
+        }
+        UnstyledTabPanel(key = "tab1", Modifier.testTag("panelA")) {
+          BasicText("Panel A")
+        }
+        UnstyledTabPanel(key = "tab2", Modifier.testTag("panelB")) {
+          BasicText("Panel B")
+        }
+        UnstyledTabPanel(key = "tab3", Modifier.testTag("panelC")) {
+          BasicText("Panel C")
+        }
+      }
+    }
+
+    onNodeWithTag("tab1").performClick()
+    onNodeWithTag("panelA").isDisplayed()
+    onNodeWithTag("panelB").assertDoesNotExist()
+    onNodeWithTag("panelC").assertDoesNotExist()
+
+    onNodeWithTag("tab2").performClick()
+    onNodeWithTag("panelA").assertDoesNotExist()
+    onNodeWithTag("panelB").isDisplayed()
+    onNodeWithTag("panelC").assertDoesNotExist()
+
+    onNodeWithTag("tab3").performClick()
+    onNodeWithTag("panelA").assertDoesNotExist()
+    onNodeWithTag("panelB").assertDoesNotExist()
+    onNodeWithTag("panelC").isDisplayed()
+  }
+
+  @Test
+  fun unscopedTabsSupportTypedTabKeys() = runComposeUiTest {
+    var selectedTab by mutableStateOf(SettingsTab.Account)
+
+    setContent {
+      UnstyledTabGroup(
+        selectedTab = selectedTab,
+        onSelectedTabChange = { selectedTab = it },
+        tabs = SettingsTab.entries,
+      ) {
+        UnstyledTabList {
+          UnstyledTab(
+            key = SettingsTab.Account,
+            modifier = Modifier.testTag("account"),
+          ) {
+            BasicText("Account")
+          }
+          UnstyledTab(
+            key = SettingsTab.Billing,
+            modifier = Modifier.testTag("billing"),
+          ) {
+            BasicText("Billing")
+          }
+        }
+        UnstyledTabPanel(key = SettingsTab.Account) {
+          BasicText("Account panel")
+        }
+        UnstyledTabPanel(key = SettingsTab.Billing) {
+          BasicText("Billing panel")
+        }
+      }
+    }
+
+    onNodeWithTag("billing").performClick()
+
+    assertThat(selectedTab).isEqualTo(SettingsTab.Billing)
+    onNodeWithText("Account panel").assertDoesNotExist()
+    onNodeWithText("Billing panel").isDisplayed()
+  }
+
+  @Test
+  fun unscopedTabWithUnknownKeyRendersDisabledUnselectedContent() = runComposeUiTest {
+    var selectedTab by mutableStateOf("known")
+
+    setContent {
+      UnstyledTabGroup(
+        selectedTab = selectedTab,
+        onSelectedTabChange = { selectedTab = it },
+        tabs = listOf("known"),
+      ) {
+        UnstyledTabList {
+          UnstyledTab(
+            key = "unknown",
+            modifier = Modifier.testTag("unknown"),
+          ) {
+            BasicText(
+              text = when {
+                selected -> "selected"
+                enabled.not() -> "disabled"
+                else -> "unselected"
+              },
+            )
+          }
+        }
+      }
+    }
+
+    onNodeWithTag("unknown").performClick()
+
+    assertThat(selectedTab).isEqualTo("known")
+    onNodeWithText("disabled").isDisplayed()
+  }
+
+  @Test
+  fun unscopedTabListOutsideTabGroupRendersContent() = runComposeUiTest {
+    setContent {
+      UnstyledTabList {
+        BasicText("Tab list")
+      }
+    }
+
+    onNodeWithText("Tab list").isDisplayed()
+  }
+
+  @Test
+  fun unscopedTabOutsideTabListRendersDisabledUnselectedContent() = runComposeUiTest {
+    setContent {
+      UnstyledTab(
+        key = "tab",
+      ) {
+        BasicText(
+          text = when {
+            selected -> "selected"
+            enabled.not() -> "disabled"
+            else -> "unselected"
+          },
+        )
+      }
+    }
+
+    onNodeWithText("disabled").isDisplayed()
+  }
+
+  @Test
+  fun unscopedTabInsideTabGroupWithoutTabListRendersDisabledUnselectedContent() = runComposeUiTest {
+    setContent {
+      UnstyledTabGroup(
+        selectedTab = "tab",
+        onSelectedTabChange = {},
+        tabs = listOf("tab"),
+      ) {
+        UnstyledTab(
+          key = "tab",
+        ) {
+          BasicText(
+            text = when {
+              selected -> "selected"
+              enabled.not() -> "disabled"
+              else -> "unselected"
+            },
+          )
+        }
+      }
+    }
+
+    onNodeWithText("disabled").isDisplayed()
+  }
+
+  @Test
+  fun unscopedTabPanelOutsideTabGroupRendersNothing() = runComposeUiTest {
+    setContent {
+      UnstyledTabPanel(key = "tab") {
+        BasicText("Panel")
+      }
+    }
+
+    onNodeWithText("Panel").assertDoesNotExist()
   }
 }

--- a/demo/src/commonMain/kotlin/TabGroupDemo.kt
+++ b/demo/src/commonMain/kotlin/TabGroupDemo.kt
@@ -50,17 +50,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.composeunstyled.Tab
-import com.composeunstyled.TabList
-import com.composeunstyled.TabPanel
 import com.composeunstyled.UnstyledButton
+import com.composeunstyled.UnstyledTab
 import com.composeunstyled.UnstyledTabGroup
+import com.composeunstyled.UnstyledTabList
+import com.composeunstyled.UnstyledTabPanel
 
 @Composable
 fun TabGroupDemo() {
   class Article(val title: String, val relativeTime: String, val comments: Int, val points: Int)
 
-  val categories = mapOf<String, List<Article>>(
+  val categories = mapOf(
     "Trending" to listOf(
       Article(
         title = "I hosted my startup's backend on a Tamagotchi – AMA",
@@ -120,7 +120,7 @@ fun TabGroupDemo() {
       modifier = Modifier.widthIn(max = 450.dp),
     ) {
       Column {
-        TabList(
+        UnstyledTabList(
           modifier = Modifier
             .fillMaxWidth()
             .height(48.dp)
@@ -130,7 +130,7 @@ fun TabGroupDemo() {
         ) {
           Row(Modifier.fillMaxSize()) {
             categories.forEach { (key, _) ->
-              Tab(
+              UnstyledTab(
                 key = key,
                 modifier = Modifier.weight(1f).fillMaxHeight(),
                 indication = LocalIndication.current,
@@ -167,7 +167,7 @@ fun TabGroupDemo() {
 
         Spacer(modifier = Modifier.height(16.dp))
         categories.forEach { (key, items) ->
-          TabPanel(
+          UnstyledTabPanel(
             key = key,
             modifier = Modifier
               .fillMaxWidth()


### PR DESCRIPTION
## Summary

Adds unscoped tab group primitives backed by internal composition locals:

- `UnstyledTabList`
- `UnstyledTab`
- `UnstyledTabPanel`

The existing scoped `TabList`, `Tab`, and `TabPanel` APIs remain source-compatible and now delegate to the unscoped primitives, so behavior stays centralized in one path. Misplaced unscoped primitives fail silently instead of throwing: lists render their content without tab-list behavior, tabs render disabled/unselected content, and panels render nothing.

Tabs whose keys are not present in the parent `tabs` list also render disabled/unselected and do not trigger selection changes.

The tab group demo now uses the unscoped primitives.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Ran:

```bash
./gradlew :composeunstyled-tab-group:jvmTest
./gradlew :demo:compileKotlinJvm
./gradlew jvmTest
./gradlew spotlessCheck
```

## Related Issues

Closes #423

## Screenshots/Videos

N/A