### PR TITLE
Add Stack to the Compose Unstyled bundle

### DIFF
--- a/composeunstyled/build.gradle.kts
+++ b/composeunstyled/build.gradle.kts
@@ -90,6 +90,7 @@ kotlin {
       api(projects.composeunstyledScrollbars)
       api(projects.composeunstyledSeparators)
       api(projects.composeunstyledSlider)
+      api(projects.composeunstyledStack)
       api(projects.composeunstyledTabGroup)
       api(projects.composeunstyledTextField)
       api(projects.composeunstyledToggleSwitch)


### PR DESCRIPTION
## Summary

Adds the existing `composeunstyled-stack` module to the aggregate `composeunstyled` artifact dependencies so consumers of the bundle get Stack as well.

## Test Plan

- [x] `./gradlew :composeunstyled:jvmTest :composeunstyled:spotlessCheck`
- [ ] Tests added/updated
- [ ] Manual testing performed

## Related Issues

None.

## Screenshots/Videos

Not applicable.