### PR TITLE
Fix slider thumb initial placement

### DIFF
--- a/composeunstyled-slider/src/commonMain/kotlin/com/composeunstyled/Slider.kt
+++ b/composeunstyled-slider/src/commonMain/kotlin/com/composeunstyled/Slider.kt
@@ -39,7 +39,6 @@ import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.progressSemantics
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
@@ -50,7 +49,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -65,12 +63,12 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.setProgress
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.util.fastAll
@@ -218,8 +216,6 @@ fun UnstyledSlider(
   val maxPx: Float = max(sliderMainAxisSize - (thumbMainAxisSize / 2), 0f)
   val minPx: Float = min(thumbMainAxisSize / 2, maxPx)
 
-  val offset = (sliderMainAxisSize - thumbMainAxisSize) * displayFraction
-
   val isDragging = dragging || isDragged
   val state = remember(
     coerced,
@@ -343,7 +339,7 @@ fun UnstyledSlider(
       }
     }
 
-  Box(
+  Layout(
     modifier = modifier
       .then(dragOnTap)
       .focusRequester(focusRequester)
@@ -380,25 +376,42 @@ fun UnstyledSlider(
         onValueChange = onValueChange,
         onValueChangeFinished = onValueChangeFinished,
       ),
-    contentAlignment = when (orientation) {
-      Orientation.Horizontal -> Alignment.CenterStart
-      Orientation.Vertical -> Alignment.TopCenter
+    content = {
+      Box { track(state) }
+      Box(Modifier.onSizeChanged { thumbSize = it }) { thumb(state) }
     },
-  ) {
-    track(state)
+  ) { measurables, constraints ->
+    val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+    val trackPlaceable = measurables[0].measure(looseConstraints)
+    val thumbPlaceable = measurables[1].measure(looseConstraints)
+    val width = max(trackPlaceable.width, thumbPlaceable.width).coerceIn(
+      constraints.minWidth,
+      constraints.maxWidth,
+    )
+    val height = max(trackPlaceable.height, thumbPlaceable.height).coerceIn(
+      constraints.minHeight,
+      constraints.maxHeight,
+    )
+    val offset = if (orientation == Orientation.Horizontal) {
+      (width - thumbPlaceable.width) * displayFraction
+    } else {
+      (height - thumbPlaceable.height) * displayFraction
+    }
 
-    Box(
-      Modifier
-        .onSizeChanged { thumbSize = it }
-        .offset {
-          if (orientation == Orientation.Horizontal) {
-            IntOffset(x = offset.roundToInt(), y = 0)
-          } else {
-            IntOffset(x = 0, y = offset.roundToInt())
-          }
-        },
-    ) {
-      thumb(state)
+    layout(width, height) {
+      if (orientation == Orientation.Horizontal) {
+        trackPlaceable.placeRelative(x = 0, y = (height - trackPlaceable.height) / 2)
+        thumbPlaceable.placeRelative(
+          x = offset.roundToInt(),
+          y = (height - thumbPlaceable.height) / 2,
+        )
+      } else {
+        trackPlaceable.placeRelative(x = (width - trackPlaceable.width) / 2, y = 0)
+        thumbPlaceable.placeRelative(
+          x = (width - thumbPlaceable.width) / 2,
+          y = offset.roundToInt(),
+        )
+      }
     }
   }
 }

--- a/composeunstyled-slider/src/commonTest/kotlin/Slider.test.kt
+++ b/composeunstyled-slider/src/commonTest/kotlin/Slider.test.kt
@@ -30,15 +30,19 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.KeyInjectionScope
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performSemanticsAction
@@ -255,6 +259,31 @@ class SliderTest {
       .top
 
     assertThat(bottomValueThumbTop).isGreaterThan(topValueThumbTop)
+  }
+
+  @Test
+  fun thumbStartsAtInitialValuePosition() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val thumbPositions = mutableStateListOf<Int>()
+
+    setContent {
+      TestSlider(
+        value = 0.45f,
+        thumb = {
+          Box(
+            Modifier
+              .onGloballyPositioned { thumbPositions += it.positionInRoot().x.toInt() }
+              .size(20.dp)
+              .testTag("thumb"),
+          )
+        },
+      )
+    }
+
+    mainClock.advanceTimeByFrame()
+
+    assertThat(thumbPositions.distinct()).containsExactly(81)
+    onNodeWithTag("thumb", useUnmergedTree = true).assertLeftPositionInRootIsEqualTo(81.dp)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes `UnstyledSlider` thumb placement so the thumb is measured and placed at the initial value position during the first layout pass, instead of briefly rendering at the start of the track before size state updates.

Adds a regression test for a non-zero initial slider value to verify the first observed thumb position matches the value-derived offset.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

```bash
./gradlew :composeunstyled-slider:jvmTest --tests com.composeunstyled.SliderTest.thumbStartsAtInitialValuePosition
./gradlew :composeunstyled-slider:jvmTest
./gradlew jvmTest spotlessCheck
```

## Related Issues

Fixes #429

## Screenshots/Videos

Not applicable.