### PR TITLE
Add accessibility label support to switches

### DIFF
--- a/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
+++ b/composeunstyled-toggle-switch/src/commonMain/kotlin/com/composeunstyled/ToggleSwitch.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.ParentDataModifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -78,6 +80,7 @@ fun UnstyledSwitch(
   enabled: Boolean = true,
   interactionSource: MutableInteractionSource? = null,
   indication: Indication? = null,
+  accessibilityLabel: String? = null,
   content: @Composable SwitchScope.() -> Unit,
 ) {
   val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
@@ -96,6 +99,13 @@ fun UnstyledSwitch(
                 role = Role.Switch,
                 onValueChange = onCheckedChange,
               ),
+            )
+          }
+          if (accessibilityLabel != null) {
+            add(
+              Modifier.semantics {
+                this.contentDescription = accessibilityLabel
+              },
             )
           }
         },

--- a/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
+++ b/composeunstyled-toggle-switch/src/commonTest/kotlin/com/composeunstyled/ToggleSwitchTest.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
 import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -111,6 +112,21 @@ class ToggleSwitchTest {
     onNodeWithTag("switch").performClick()
 
     onNodeWithTag("switch").assertIsOn()
+  }
+
+  @Test
+  fun exposesAccessibilityLabel() = runComposeUiTest {
+    setContent {
+      UnstyledSwitch(
+        checked = false,
+        onCheckedChange = {},
+        accessibilityLabel = "Notifications",
+      ) {
+        Box(Modifier.size(24.dp))
+      }
+    }
+
+    onNodeWithContentDescription("Notifications").assertIsDisplayed()
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds an optional `accessibilityLabel` parameter to `UnstyledSwitch` and applies it to switch semantics for icon-only or visually unlabeled switches.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Ran:
- `./gradlew --console=plain :composeunstyled-toggle-switch:jvmTest --tests com.composeunstyled.ToggleSwitchTest.exposesAccessibilityLabel`
- `./gradlew --console=plain jvmTest spotlessCheck`

## Related Issues

Closes #428

## Screenshots/Videos

N/A