### PR TITLE
Introduce Theme extend API

### DIFF
--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
@@ -28,10 +28,14 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositeKeyHashCode
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.currentCompositeKeyHashCode
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
@@ -81,6 +85,7 @@ data class ThemeValues<T> internal constructor(
 
 internal typealias ComposableWithContent = @Composable (@Composable () -> Unit) -> Unit
 typealias ThemeComposable = ComposableWithContent
+internal typealias ThemeExtension = @Composable (@Composable () -> Unit) -> Unit
 
 data class ThemeProperty<T>(val name: String)
 data class ThemeToken<T>(val name: String)
@@ -113,7 +118,19 @@ fun buildTheme(themeAction: @Composable ThemeBuilder.() -> Unit = {}): ThemeComp
       LocalTextSelectionColors provides textSelectionColors,
       LocalMinimumComponentInteractiveSize provides finalInteractiveSize,
     ) {
-      content()
+      val currentExtendedTheme = builder.extendedTheme
+
+      if (currentExtendedTheme == null) {
+        content()
+      } else {
+        val tracker = remember { CompositionCallTracker() }
+
+        currentExtendedTheme {
+          tracker.once {
+            content()
+          }
+        }
+      }
     }
   }
 }
@@ -123,10 +140,36 @@ internal class ResolvedTheme(
   internal val properties: Map<ThemeProperty<*>, ThemeValues<*>>,
 )
 
+private class CompositionCallTracker {
+  private var activeContentKey: CompositeKeyHashCode? = null
+
+  @Composable
+  fun once(content: @Composable () -> Unit) {
+    val currentKey = currentCompositeKeyHashCode
+
+    DisposableEffect(currentKey) {
+      check(activeContentKey == null || activeContentKey == currentKey) {
+        "You may call the content lambda of extend {} exactly once."
+      }
+
+      activeContentKey = currentKey
+
+      onDispose {
+        if (activeContentKey == currentKey) {
+          activeContentKey = null
+        }
+      }
+    }
+
+    content()
+  }
+}
+
 internal val LocalTheme =
   staticCompositionLocalOf<ResolvedTheme> {
     error(
-      "No theme was set. In order to use the Theme object you need to wrap your content with a theme @Composable returned by the buildTheme {} function.",
+      "No theme was set. In order to use the Theme object you need to wrap " +
+        "your content with a theme @Composable returned by the buildTheme {} function.",
     )
   }
 
@@ -139,7 +182,8 @@ private val UnspecifiedTextSelectionColors = TextSelectionColors(
 annotation class ThemeBuilderMarker
 
 @Deprecated(
-  message = "This will be removed in 3.0. It is now up to you to implement this behavior if it is a requirement for your design system.",
+  message = "This will be removed in 3.0. It is now up to you to implement " +
+    "this behavior if it is a requirement for your design system.",
 )
 data class ComponentInteractiveSize(
   val nonTouchInteractionSize: Dp = Dp.Unspecified,
@@ -147,7 +191,8 @@ data class ComponentInteractiveSize(
 )
 
 @Deprecated(
-  message = "This will be removed in 3.0. It is now up to you to implement this behavior if it is a requirement for your design system.",
+  message = "This will be removed in 3.0. It is now up to you to implement " +
+    "this behavior if it is a requirement for your design system.",
 )
 fun ComponentInteractiveSize(size: Dp): ComponentInteractiveSize {
   return ComponentInteractiveSize(size, size)
@@ -163,13 +208,32 @@ class ThemeBuilder internal constructor() {
   var defaultTextSelectionColors: TextSelectionColors? by mutableStateOf(null)
 
   @Deprecated(
-    message = "This will be removed in 3.0. It is now up to you to implement this behavior if it is a requirement for your design system.",
+    message = "This will be removed in 3.0. It is now up to you to implement this " +
+      "behavior if it is a requirement for your design system.",
   )
   var defaultComponentInteractiveSize: ComponentInteractiveSize by mutableStateOf(
     ComponentInteractiveSize(Dp.Unspecified, Dp.Unspecified),
   )
 
   val properties = MutableThemeProperties()
+
+  internal var extendedTheme: ThemeExtension? = null
+    private set
+
+  private var extensionKey: CompositeKeyHashCode? = null
+
+  @Composable
+  fun extend(extension: @Composable (@Composable () -> Unit) -> Unit) {
+    val currentKey = currentCompositeKeyHashCode
+
+    check(extensionKey == null || extensionKey == currentKey) {
+      "Themes can only be extended exactly once. " +
+        "Make sure you use the `extend {}` block within your buildTheme {} only once."
+    }
+
+    extensionKey = currentKey
+    this.extendedTheme = extension
+  }
 }
 
 class MutableThemeProperties internal constructor() {

--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
@@ -184,9 +184,3 @@ class MutableThemeProperties internal constructor() {
       ?: error("No theme was set. In order to use the theme @Composable function.")
   }
 }
-
-data class OverriddenValue<T>(val token: ThemeToken<T>, val value: T)
-
-infix fun <T> ThemeToken<T>.provides(value: T): OverriddenValue<T> {
-  return OverriddenValue(this, value)
-}

--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
@@ -79,7 +79,7 @@ data class ThemeValues<T> internal constructor(
   }
 }
 
-typealias ComposableWithContent = @Composable (@Composable () -> Unit) -> Unit
+internal typealias ComposableWithContent = @Composable (@Composable () -> Unit) -> Unit
 typealias ThemeComposable = ComposableWithContent
 
 data class ThemeProperty<T>(val name: String)

--- a/composeunstyled-theming/src/commonTest/kotlin/Theme.test.kt
+++ b/composeunstyled-theming/src/commonTest/kotlin/Theme.test.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.neverEqualPolicy
@@ -35,7 +36,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
+import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import com.composeunstyled.theme.NoIndication
 import com.composeunstyled.theme.Theme
@@ -155,6 +158,125 @@ class ThemeCommonTest {
     assertThat(currentSelectionColors.backgroundColor).isEqualTo(Color.Unspecified)
   }
 
+  @Test
+  fun extendWrapsThemeContent() = runComposeUiTest {
+    val testTheme = buildTheme {
+      extend { content ->
+        CompositionLocalProvider(LocalExtendedLabel provides "Extended") {
+          content()
+        }
+      }
+    }
+
+    setContent {
+      testTheme {
+        BasicText(LocalExtendedLabel.current)
+      }
+    }
+
+    onNodeWithText("Extended").assertExists()
+    onNodeWithText("Default").assertDoesNotExist()
+  }
+
+  @Test
+  fun extendCanOnlyBeCalledOnce() {
+    assertFailure {
+      runComposeUiTest {
+        val testTheme = buildTheme {
+          extend { content ->
+            content()
+          }
+          extend { content ->
+            content()
+          }
+        }
+
+        setContent {
+          testTheme {
+            BasicText("Theme")
+          }
+        }
+      }
+    }.hasMessage(
+      "Themes can only be extended exactly once. " +
+        "Make sure you use the `extend {}` block within your buildTheme {} only once.",
+    )
+  }
+
+  @Test
+  fun extendedContentCanOnlyBeEmittedOnce() {
+    assertFailure {
+      runComposeUiTest {
+        val testTheme = buildTheme {
+          extend { content ->
+            content()
+            content()
+          }
+        }
+
+        setContent {
+          testTheme {
+            BasicText("Theme")
+          }
+        }
+      }
+    }.hasMessage("You may call the content lambda of extend {} exactly once.")
+  }
+
+  @Test
+  fun extendedContentCanRecompose() = runComposeUiTest {
+    var label by mutableStateOf("First")
+    val testTheme = buildTheme {
+      extend { content ->
+        CompositionLocalProvider(LocalExtendedLabel provides label) {
+          content()
+        }
+      }
+    }
+
+    setContent {
+      testTheme {
+        BasicText(LocalExtendedLabel.current)
+      }
+    }
+
+    onNodeWithText("First").assertExists()
+
+    label = "Second"
+
+    onNodeWithText("Second").assertExists()
+    onNodeWithText("First").assertDoesNotExist()
+  }
+
+  @Test
+  fun themeBuilderActionCanRecomposeWithExtend() = runComposeUiTest {
+    var label by mutableStateOf("First")
+    val testTheme = buildTheme {
+      val currentLabel = label
+
+      extend { content ->
+        CompositionLocalProvider(LocalExtendedLabel provides currentLabel) {
+          content()
+        }
+      }
+    }
+
+    setContent {
+      testTheme {
+        BasicText(LocalExtendedLabel.current)
+      }
+    }
+
+    onNodeWithText("First").assertExists()
+
+    label = "Second"
+
+    onNodeWithText("Second").assertExists()
+    onNodeWithText("First").assertDoesNotExist()
+  }
+
   val strings = ThemeProperty<String>("strings")
   val text = ThemeToken<String>("label")
+
+  val LocalExtendedLabel = compositionLocalOf { "Default" }
 }

--- a/demo/src/commonMain/kotlin/Demo.kt
+++ b/demo/src/commonMain/kotlin/Demo.kt
@@ -147,6 +147,7 @@ private val availableModifiers = listOf(
 
 private val themingDemos = listOf(
   DemoItem("Platform Theme", "platform-theme", { PlatformThemeDemo() }),
+  DemoItem("Theme Extend", "theme-extend", { ThemeExtendDemo() }),
   DemoItem("Theming", "theme", { ThemingDemo() }),
 )
 

--- a/demo/src/commonMain/kotlin/ThemeDemo.kt
+++ b/demo/src/commonMain/kotlin/ThemeDemo.kt
@@ -21,742 +21,113 @@
  */
 package com.composeunstyled.demo
 
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Pause
-import com.composables.icons.lucide.SkipBack
-import com.composables.icons.lucide.SkipForward
-import com.composeunstyled.ProvideContentColor
-import com.composeunstyled.Text
-import com.composeunstyled.UnstyledButton
-import com.composeunstyled.UnstyledIcon
-import com.composeunstyled.UnstyledSlider
-import com.composeunstyled.outline
 import com.composeunstyled.theme.Theme
 import com.composeunstyled.theme.ThemeProperty
 import com.composeunstyled.theme.ThemeToken
 import com.composeunstyled.theme.buildTheme
-import org.jetbrains.compose.resources.Font
-import org.jetbrains.compose.resources.painterResource
-import unstyled.demo.generated.resources.BebasNeue
-import unstyled.demo.generated.resources.Inter
-import unstyled.demo.generated.resources.Res
-import unstyled.demo.generated.resources.Roboto
-import unstyled.demo.generated.resources.just_hoist_it_cover
 
 private val colors = ThemeProperty<Color>("colors")
-private val typography = ThemeProperty<TextStyle>("typography")
-private val shapes = ThemeProperty<Shape>("shapes")
-private val elevation = ThemeProperty<Dp>("elevation")
+private val textStyles = ThemeProperty<TextStyle>("textStyles")
 
 private val background = ThemeToken<Color>("background")
-private val card = ThemeToken<Color>("surface")
-private val onCard = ThemeToken<Color>("onCard")
-private val outline = ThemeToken<Color>("outline")
-private val accent = ThemeToken<Color>("accent")
+private val surface = ThemeToken<Color>("surface")
 private val primary = ThemeToken<Color>("primary")
+private val onSurface = ThemeToken<Color>("onSurface")
 private val onPrimary = ThemeToken<Color>("onPrimary")
-private val onSecondary = ThemeToken<Color>("onSecondary")
-private val secondary = ThemeToken<Color>("secondary")
 
-private val subtle = ThemeToken<Dp>("subtle")
+private val title = ThemeToken<TextStyle>("title")
+private val body = ThemeToken<TextStyle>("body")
 
-private val titleMedium = ThemeToken<TextStyle>("titleMedium")
-private val bodyMedium = ThemeToken<TextStyle>("bodyMedium")
-
-private val cardShape = ThemeToken<Shape>("cardShape")
-private val albumCoverShape = ThemeToken<Shape>("albumCoverShape")
-private val buttonShape = ThemeToken<Shape>("buttonShape")
-
-private val LightTheme = buildTheme {
-  name = "LightTheme"
+private val AppTheme = buildTheme {
+  name = "AppTheme"
 
   properties[colors] = mapOf(
-    accent to Color(0xFF3B82F6),
-    card to Color.White,
-    onCard to Color(0xFF1E293B),
-    outline to Color(0xFFE2E8F0),
+    background to Color(0xFFF8FAFC),
+    surface to Color.White,
     primary to Color(0xFF2563EB),
+    onSurface to Color(0xFF0F172A),
     onPrimary to Color.White,
-    secondary to Color(0xFFE2E8F0),
-    onSecondary to Color(0xFF64748B),
-    background to Color(0xFFF8F9FA),
   )
 
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 18.sp,
-      fontWeight = FontWeight.SemiBold,
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Normal,
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(16.dp),
-    albumCoverShape to RoundedCornerShape(12.dp),
-    buttonShape to CircleShape,
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 8.dp,
-  )
-}
-
-private val DarkTheme = buildTheme {
-  name = "DarkTheme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFF60A5FA),
-    card to Color(0xFF1E293B),
-    onCard to Color(0xFFF1F5F9),
-    outline to Color(0xFF374151),
-    primary to Color(0xFF3B82F6),
-    onPrimary to Color.White,
-    secondary to Color(0xFF374151),
-    onSecondary to Color(0xFF9CA3AF),
-    background to Color(0xFF0F172A),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 18.sp,
-      fontWeight = FontWeight.SemiBold,
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Normal,
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(16.dp),
-    albumCoverShape to RoundedCornerShape(12.dp),
-    buttonShape to CircleShape,
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 12.dp,
-  )
-}
-
-private val BrutalistTheme = buildTheme {
-  name = "BrutalistTheme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFF000000),
-    card to Color(0xFF00FF00),
-    onCard to Color(0xFF000000),
-    outline to Color(0xFF000000),
-    primary to Color(0xFF000000),
-    onPrimary to Color(0xFF00FF00),
-    secondary to Color(0xFF000000),
-    onSecondary to Color(0xFF000000),
-    background to Color(0xFFFFAA00),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
+  properties[textStyles] = mapOf(
+    title to TextStyle(
       fontSize = 22.sp,
-      fontWeight = FontWeight.Black,
-      fontFamily = FontFamily(Font(Res.font.BebasNeue)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 16.sp,
-      fontWeight = FontWeight.Bold,
-      fontFamily = FontFamily(Font(Res.font.BebasNeue)),
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RectangleShape,
-    albumCoverShape to RectangleShape,
-    buttonShape to RectangleShape,
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 0.dp,
-  )
-}
-
-private val Material3Theme = buildTheme {
-  name = "Material3Theme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFF6750A4),
-    card to Color(0xFFFFFBFE),
-    onCard to Color(0xFF1D1B20),
-    outline to Color.Unspecified,
-    primary to Color(0xFF6750A4),
-    onPrimary to Color.White,
-    secondary to Color(0xFFE8DEF8),
-    onSecondary to Color(0xFF49454F),
-    background to Color(0xFFFEF7FF),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 18.sp,
-      fontWeight = FontWeight.Medium,
-      fontFamily = FontFamily(Font(Res.font.Roboto)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Normal,
-      fontFamily = FontFamily(Font(Res.font.Roboto)),
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(12.dp),
-    albumCoverShape to RoundedCornerShape(8.dp),
-    buttonShape to RoundedCornerShape(20.dp),
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 6.dp,
-  )
-}
-
-private val NeoBrutalistTheme = buildTheme {
-  name = "NeoBrutalistTheme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFFEF4444),
-    card to Color(0xFFF3F4F6),
-    onCard to Color(0xFF1F2937),
-    outline to Color.Black,
-    primary to Color(0xFFEF4444),
-    onPrimary to Color.White,
-    secondary to Color(0xFFE5E7EB),
-    onSecondary to Color(0xFF6B7280),
-    background to Color(0xFFFAFAFA),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 20.sp,
-      fontWeight = FontWeight.Bold,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Medium,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RectangleShape,
-    albumCoverShape to CutCornerShape(12.dp),
-    buttonShape to CutCornerShape(8.dp),
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 0.dp,
-  )
-}
-
-private val AppleMusicTheme = buildTheme {
-  name = "AppleMusicTheme"
-
-  properties[colors] = mapOf(
-    accent to Color.Black,
-    card to Color(0xFFFF2D55),
-    onCard to Color(0xFFFFFFFF),
-    outline to Color(0xFFFF1744),
-    primary to Color(0xFFFFFFFF),
-    onPrimary to Color(0xFFFF2D55),
-    secondary to Color(0xFFFFFFFF).copy(alpha = 0.6f),
-    onSecondary to Color(0xFFFFFFFF).copy(alpha = 0.7f),
-    background to Color(0xFF000000),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 20.sp,
-      fontWeight = FontWeight.Bold,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 16.sp,
       fontWeight = FontWeight.SemiBold,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
     ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(20.dp),
-    albumCoverShape to RoundedCornerShape(12.dp),
-    buttonShape to CircleShape,
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 8.dp,
+    body to TextStyle(
+      fontSize = 15.sp,
+      lineHeight = 22.sp,
+    ),
   )
 }
-
-data class ThemeInfo(
-  val theme: @Composable (@Composable () -> Unit) -> Unit,
-  val color: Color,
-)
-
-private val OceanTheme = buildTheme {
-  name = "OceanTheme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFF0077BE),
-    card to Color(0xFFE6F3FF),
-    onCard to Color(0xFF003D66),
-    outline to Color(0xFF87CEEB),
-    primary to Color(0xFF0077BE),
-    onPrimary to Color.White,
-    secondary to Color(0xFFB3E0FF),
-    onSecondary to Color(0xFF005C99),
-    background to Color(0xFFF0F8FF),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 18.sp,
-      fontWeight = FontWeight.SemiBold,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Normal,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(20.dp),
-    albumCoverShape to RoundedCornerShape(16.dp),
-    buttonShape to CircleShape,
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 6.dp,
-  )
-}
-
-private val ForestTheme = buildTheme {
-  name = "ForestTheme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFF228B22),
-    card to Color(0xFFF0FFF0),
-    onCard to Color(0xFF2F4F2F),
-    outline to Color(0xFF90EE90),
-    primary to Color(0xFF228B22),
-    onPrimary to Color.White,
-    secondary to Color(0xFFE0FFE0),
-    onSecondary to Color(0xFF556B2F),
-    background to Color(0xFFF5FFFA),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 18.sp,
-      fontWeight = FontWeight.SemiBold,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Normal,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(12.dp),
-    albumCoverShape to RoundedCornerShape(8.dp),
-    buttonShape to RoundedCornerShape(8.dp),
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 4.dp,
-  )
-}
-
-private val SunsetTheme = buildTheme {
-  name = "SunsetTheme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFFFF6B35),
-    card to Color(0xFFFFF8E1),
-    onCard to Color(0xFF8B4513),
-    outline to Color(0xFFFFB347),
-    primary to Color(0xFFFF6B35),
-    onPrimary to Color.White,
-    secondary to Color(0xFFFFE0B3),
-    onSecondary to Color(0xFFD2691E),
-    background to Color(0xFFFFF4E6),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 18.sp,
-      fontWeight = FontWeight.SemiBold,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Normal,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(16.dp),
-    albumCoverShape to RoundedCornerShape(12.dp),
-    buttonShape to RoundedCornerShape(20.dp),
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 8.dp,
-  )
-}
-
-private val MonochromeTheme = buildTheme {
-  name = "MonochromeTheme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFF000000),
-    card to Color(0xFFFAFAFA),
-    onCard to Color(0xFF333333),
-    outline to Color(0xFFE0E0E0),
-    primary to Color(0xFF000000),
-    onPrimary to Color.White,
-    secondary to Color(0xFFF0F0F0),
-    onSecondary to Color(0xFF666666),
-    background to Color(0xFFFFFFFF),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 18.sp,
-      fontWeight = FontWeight.Bold,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Normal,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(2.dp),
-    albumCoverShape to RoundedCornerShape(2.dp),
-    buttonShape to RoundedCornerShape(2.dp),
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 1.dp,
-  )
-}
-
-private val GalaxyTheme = buildTheme {
-  name = "GalaxyTheme"
-
-  properties[colors] = mapOf(
-    accent to Color(0xFF06B6D4),
-    card to Color(0xFF1E293B),
-    onCard to Color(0xFFE2E8F0),
-    outline to Color(0xFF0891B2),
-    primary to Color(0xFF06B6D4),
-    onPrimary to Color.White,
-    secondary to Color(0xFF0F172A),
-    onSecondary to Color(0xFF94A3B8),
-    background to Color(0xFF020617),
-  )
-
-  properties[typography] = mapOf(
-    titleMedium to TextStyle(
-      fontSize = 18.sp,
-      fontWeight = FontWeight.SemiBold,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-    bodyMedium to TextStyle(
-      fontSize = 14.sp,
-      fontWeight = FontWeight.Normal,
-      fontFamily = FontFamily(Font(Res.font.Inter)),
-    ),
-  )
-
-  properties[shapes] = mapOf(
-    cardShape to RoundedCornerShape(24.dp),
-    albumCoverShape to RoundedCornerShape(16.dp),
-    buttonShape to CircleShape,
-  )
-
-  properties[elevation] = mapOf(
-    subtle to 12.dp,
-  )
-}
-
-private val availableThemes = listOf(
-  ThemeInfo(LightTheme, Color(0xFFF8F9FA)),
-  ThemeInfo(DarkTheme, Color(0xFF1E293B)),
-  ThemeInfo(Material3Theme, Color(0xFF6750A4)),
-  ThemeInfo(BrutalistTheme, Color(0xFF00FF00)),
-  ThemeInfo(NeoBrutalistTheme, Color(0xFFEF4444)),
-  ThemeInfo(AppleMusicTheme, Color(0xFFFF2D55)),
-  ThemeInfo(OceanTheme, Color(0xFF0077BE)),
-  ThemeInfo(ForestTheme, Color(0xFF228B22)),
-  ThemeInfo(SunsetTheme, Color(0xFFFF6B35)),
-  ThemeInfo(MonochromeTheme, Color(0xFF333333)),
-  ThemeInfo(GalaxyTheme, Color(0xFF06B6D4)),
-)
 
 @Composable
 fun ThemingDemo() {
-  var selectedTheme by remember { mutableStateOf(0) }
-  val currentTheme = availableThemes[selectedTheme].theme
-
-  currentTheme {
+  AppTheme {
     Box(
       modifier = Modifier
         .fillMaxSize()
-        .background(Theme[colors][background]).padding(vertical = 16.dp),
-      contentAlignment = Alignment.TopCenter,
+        .background(Theme[colors][background])
+        .padding(24.dp),
+      contentAlignment = Alignment.Center,
     ) {
-      Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Row(
-          horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-          verticalAlignment = Alignment.CenterVertically,
-          modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        ) {
-          availableThemes.forEachIndexed { index, themeInfo ->
-            SimpleThemeCard(index, selectedTheme, themeInfo.color) {
-              selectedTheme = index
-            }
-          }
-        }
-
-        Spacer(Modifier.height(12.dp))
-
-        Box(Modifier.padding(horizontal = 16.dp)) {
-          MusicPlayerCard(Modifier.width(400.dp))
-        }
-      }
-    }
-  }
-}
-
-@Composable
-fun MusicPlayerCard(modifier: Modifier = Modifier) {
-  Box(
-    modifier = modifier
-      .outline(1.dp, Theme[colors][outline], Theme[shapes][cardShape])
-      .background(Theme[colors][card], Theme[shapes][cardShape])
-      .padding(24.dp),
-  ) {
-    ProvideContentColor(Theme[colors][onCard]) {
-      Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-        Row(
-          verticalAlignment = Alignment.CenterVertically,
-          horizontalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-          Image(
-            painter = painterResource(Res.drawable.just_hoist_it_cover),
-            modifier = Modifier
-              .clip(Theme[shapes][albumCoverShape])
-              .background(Theme[colors][primary])
-              .size(80.dp),
-            contentDescription = "Album Cover",
-            contentScale = ContentScale.Crop,
+      Column(
+        modifier = Modifier
+          .background(
+            color = Theme[colors][surface],
+            shape = RoundedCornerShape(12.dp),
           )
-
-          Column(modifier = Modifier.weight(1f)) {
-            Text(
-              text = "Just hoist it!",
-              style = Theme[typography][titleMedium],
-            )
-            Spacer(Modifier.height(4.dp))
-            Text(
-              text = "The Deprecated",
-              style = Theme[typography][bodyMedium],
-              color = Theme[colors][onSecondary],
-            )
-          }
-        }
-
-        var sliderValue by remember { mutableFloatStateOf(0.3f) }
-
-        UnstyledSlider(
-          value = sliderValue,
-          onValueChange = { sliderValue = it },
-          modifier = Modifier.fillMaxWidth(),
-          track = { state ->
-            Box(
-              Modifier
-                .fillMaxWidth()
-                .height(4.dp)
-                .clip(RoundedCornerShape(2.dp)),
-            ) {
-              Box(
-                Modifier
-                  .fillMaxSize()
-                  .background(Theme[colors][secondary]),
-              )
-              Box(
-                Modifier
-                  .fillMaxWidth(state.fraction)
-                  .fillMaxSize()
-                  .background(Theme[colors][accent]),
-              )
-            }
-          },
-          thumb = {
-            Box(
-              modifier = Modifier
-                .size(16.dp)
-                .clip(Theme[shapes][buttonShape])
-                .background(Theme[colors][accent]),
-            )
-          },
+          .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+      ) {
+        BasicText(
+          text = "Create a theme",
+          style = Theme[textStyles][title].copy(
+            color = Theme[colors][onSurface],
+          ),
         )
 
-        Row(
-          modifier = Modifier.fillMaxWidth(),
-          horizontalArrangement = Arrangement.SpaceEvenly,
-          verticalAlignment = Alignment.CenterVertically,
+        BasicText(
+          text = "Define theme properties and tokens, assign values in buildTheme {}, " +
+            "then read them with Theme[property][token].",
+          style = Theme[textStyles][body].copy(
+            color = Theme[colors][onSurface],
+          ),
+        )
+
+        Box(
+          modifier = Modifier
+            .background(
+              color = Theme[colors][primary],
+              shape = RoundedCornerShape(8.dp),
+            )
+            .padding(horizontal = 16.dp, vertical = 10.dp),
         ) {
-          UnstyledButton(
-            onClick = { },
-            modifier = Modifier.clip(Theme[shapes][buttonShape]),
-            indication = LocalIndication.current,
-          ) {
-            Box(Modifier.padding(12.dp)) {
-              UnstyledIcon(
-                imageVector = Lucide.SkipBack,
-                contentDescription = "Previous",
-                modifier = Modifier.size(20.dp),
-              )
-            }
-          }
-
-          UnstyledButton(
-            onClick = { },
-            modifier = Modifier
-              .clip(Theme[shapes][buttonShape])
-              .background(Theme[colors][primary]),
-            indication = LocalIndication.current,
-          ) {
-            Box(Modifier.padding(16.dp)) {
-              UnstyledIcon(
-                imageVector = Lucide.Pause,
-                contentDescription = "Pause",
-                modifier = Modifier.size(24.dp),
-              )
-            }
-          }
-
-          UnstyledButton(
-            onClick = { },
-            modifier = Modifier.clip(Theme[shapes][buttonShape]),
-            indication = LocalIndication.current,
-          ) {
-            Box(Modifier.padding(12.dp)) {
-              UnstyledIcon(
-                imageVector = Lucide.SkipForward,
-                contentDescription = "Next",
-                modifier = Modifier.size(20.dp),
-              )
-            }
-          }
+          BasicText(
+            text = "Themed action",
+            style = Theme[textStyles][body].copy(
+              color = Theme[colors][onPrimary],
+              fontWeight = FontWeight.Medium,
+            ),
+          )
         }
       }
     }
   }
-}
-
-@Composable
-private fun SimpleThemeCard(
-  themeIndex: Int,
-  selectedTheme: Int,
-  themeColor: Color,
-  onClick: () -> Unit,
-) {
-  val isSelected = selectedTheme == themeIndex
-  val interactionSource = remember { MutableInteractionSource() }
-  val isHovered by interactionSource.collectIsHoveredAsState()
-  val isFocused by interactionSource.collectIsFocusedAsState()
-
-  LaunchedEffect(isHovered, isFocused) {
-    if (isHovered || isFocused) {
-      onClick()
-    }
-  }
-
-  val outlineColor by animateColorAsState(
-    if (isSelected) {
-      Theme[colors][accent]
-    } else {
-      Color.Black.copy(
-        0.1f,
-      )
-    },
-  )
-  val outlineThickness by animateDpAsState(if (isSelected) 2.dp else 1.dp)
-  val offset by animateDpAsState(if (isSelected) 2.dp else 0.dp)
-
-  UnstyledButton(
-    onClick = onClick,
-    modifier = Modifier
-      .size(32.dp)
-      .clip(CircleShape)
-      .background(themeColor)
-      .outline(outlineThickness, outlineColor, CircleShape, offset),
-    interactionSource = interactionSource,
-    indication = LocalIndication.current,
-  ) { }
 }

--- a/demo/src/commonMain/kotlin/ThemeExtendDemo.kt
+++ b/demo/src/commonMain/kotlin/ThemeExtendDemo.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled.demo
+
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import com.composeunstyled.theme.buildTheme
+
+@Composable
+fun ThemeExtendDemo() {
+  val ExtendedTheme = buildTheme {
+    extend { content ->
+      CompositionLocalProvider(LocalDensity provides Density(4.0f)) {
+        content()
+      }
+    }
+  }
+
+  ExtendedTheme {
+    BasicText("The density of this content comes from the Theme")
+  }
+}


### PR DESCRIPTION
## Summary

Adds `ThemeBuilder.extend { content -> ... }` so themes can wrap their rendered content with extra Compose context, such as `CompositionLocalProvider`s.

Also adds guards for accidental duplicate `extend {}` calls and duplicate `content()` calls inside an extension, plus a demo example for the API.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Commands run:

```bash
./gradlew :composeunstyled-theming:jvmTest
./gradlew :demo:compileKotlinJvm
./gradlew jvmTest spotlessCheck
```

## Related Issues

#433

## Screenshots/Videos

Not applicable.