### PR TITLE
Bump Kotlin and Compose Multiplatform

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 unstyled = "2.6.0"
 
-kotlin = "2.3.20"
-compose = "1.11.0"
+kotlin = "2.4.0"
+compose = "1.11.1"
 compose-material3 = "1.11.0-alpha01"
 
 vanniktech = "0.35.0"


### PR DESCRIPTION
## Summary

Bumps Kotlin to 2.4.0 and Compose Multiplatform to 1.11.1.

## Test Plan

- `./gradlew jvmTest`

- [ ] Tests added/updated
- [ ] Manual testing performed

## Related Issues

Fixes https://github.com/composablehorizons/compose-unstyled/issues/125

## Screenshots/Videos

N/A
