### PR TITLE
[codex] Fix dialog panel exit transitions with non-animated scrims

### DIFF
--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -77,7 +77,7 @@ fun DialogOverlayScope.Scrim(
 ) {
   val state = LocalModalState.current
   AnimatedVisibility(
-    visibleState = state.transitionState,
+    visible = state.transitionState.targetState,
     enter = enter,
     exit = exit,
   ) {
@@ -155,7 +155,7 @@ fun DialogScope.DialogPanel(
   val panelFocusRequester = remember { FocusRequester() }
 
   AnimatedVisibility(
-    visibleState = modalState.transitionState,
+    visible = modalState.transitionState.targetState,
     enter = enter,
     exit = exit,
   ) {

--- a/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
+++ b/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
@@ -214,7 +214,6 @@ class DialogTest {
 
   @Test
   fun scrimWithoutTransitionsDoesNotSkipPanelExitTransition() = runComposeUiTest {
-    mainClock.autoAdvance = false
     var visible by mutableStateOf(true)
 
     setContent {
@@ -233,8 +232,10 @@ class DialogTest {
       }
     }
 
+    waitForIdle()
     onNodeWithTag("dialog_content").assertExists()
 
+    mainClock.autoAdvance = false
     visible = false
     mainClock.advanceTimeBy(100)
 

--- a/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
+++ b/composeunstyled-dialog/src/commonTest/kotlin/Dialog.test.kt
@@ -22,6 +22,8 @@
 package com.composeunstyled
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -208,6 +210,39 @@ class DialogTest {
 
     onNodeWithTag("dialog_content").assertDoesNotExist()
     onNode(isDialog()).assertDoesNotExist()
+  }
+
+  @Test
+  fun scrimWithoutTransitionsDoesNotSkipPanelExitTransition() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    var visible by mutableStateOf(true)
+
+    setContent {
+      UnstyledDialog(
+        visible = visible,
+        onDismissRequest = { visible = false },
+        overlay = {
+          Scrim()
+        },
+      ) {
+        DialogPanel(
+          modifier = Modifier.testTag("dialog_content"),
+          exit = fadeOut(animationSpec = tween(durationMillis = 1_000)),
+        ) {
+        }
+      }
+    }
+
+    onNodeWithTag("dialog_content").assertExists()
+
+    visible = false
+    mainClock.advanceTimeBy(100)
+
+    onNodeWithTag("dialog_content").assertExists()
+
+    mainClock.advanceTimeBy(1_000)
+    onNodeWithTag("dialog_content").assertDoesNotExist()
+    mainClock.autoAdvance = true
   }
 
   @Test

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -82,7 +82,7 @@ fun ModalBottomSheetOverlayScope.Scrim(
 ) {
   val state = LocalModalState.current
   AnimatedVisibility(
-    visibleState = state.transitionState,
+    visible = state.transitionState.targetState,
     enter = enter,
     exit = exit,
   ) {

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Scrim.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Scrim.kt
@@ -40,7 +40,7 @@ fun ModalScope.Scrim(
 ) {
   val state = LocalModalState.current
   AnimatedVisibility(
-    visibleState = state.transitionState,
+    visible = state.transitionState.targetState,
     enter = enter,
     exit = exit,
   ) {


### PR DESCRIPTION
## Summary

Fix dialog and shared modal scrim exit handling so a non-animated scrim does not cut off a longer dialog panel exit transition.

The root cause was sharing one `MutableTransitionState` across multiple `AnimatedVisibility` blocks. A scrim with `ExitTransition.None` could mark the shared transition hidden before the panel finished its own exit animation. This change switches the affected animated fragments to follow `transitionState.targetState` while keeping their own visibility lifecycle, and adds a regression test for issue #438.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Ran:
- `./gradlew jvmTest spotlessCheck`
- `./gradlew :composeunstyled-dialog:jvmTest --tests DialogTest.scrimWithoutTransitionsDoesNotSkipPanelExitTransition`
- `./gradlew :composeunstyled-modal:jvmTest --tests ScrimTest`
- `./gradlew :composeunstyled-modal-bottom-sheet:jvmTest --tests '*scrim*'`
- `./gradlew :composeunstyled-dialog:jvmTest`

## Related Issues

- Closes #438

## Screenshots/Videos

N/A