### PR TITLE
Add unscoped dropdown menu items

### DIFF
--- a/composeunstyled-dropdown-menu/src/androidInstrumentedTest/kotlin/DropdownMenu.androidTest.kt
+++ b/composeunstyled-dropdown-menu/src/androidInstrumentedTest/kotlin/DropdownMenu.androidTest.kt
@@ -45,7 +45,7 @@ class DropdownMenuAndroidTest {
         onExpandedChange = { expanded = it },
         panel = {
           DropdownMenuPanel {
-            MenuItem(onClick = {}, modifier = Modifier.testTag("item")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("item")) {
               BasicText("Item")
             }
           }

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -92,6 +92,8 @@ internal val LocalDropdownMenuState = staticCompositionLocalOf<DropdownMenuState
     transitionState = MutableTransitionState(false),
   )
 }
+internal val LocalDropdownMenuPanelScope =
+  staticCompositionLocalOf<DropdownMenuPanelScope?> { null }
 
 internal class DropdownMenuItemFocusTarget(
   val focusRequester: FocusRequester,
@@ -318,15 +320,17 @@ fun DropdownMenuScope.DropdownMenuPanel(
         }
       },
   ) {
-    DropdownMenuPanelLayout(
-      scope = scope,
-      modifier = modifier
-        .modalFragment()
-        .onPlaced { placed = true }
-        .focusRequester(menuFocusRequester)
-        .focusable(),
-    ) {
-      scope.content()
+    CompositionLocalProvider(LocalDropdownMenuPanelScope provides scope) {
+      DropdownMenuPanelLayout(
+        scope = scope,
+        modifier = modifier
+          .modalFragment()
+          .onPlaced { placed = true }
+          .focusRequester(menuFocusRequester)
+          .focusable(),
+      ) {
+        scope.content()
+      }
     }
   }
 }
@@ -341,17 +345,39 @@ fun DropdownMenuPanelScope.MenuItem(
   indication: Indication? = null,
   content: @Composable () -> Unit,
 ) {
+  UnstyledDropdownMenuItem(
+    onClick = onClick,
+    modifier = modifier,
+    enabled = enabled,
+    closeOnClick = closeOnClick,
+    interactionSource = interactionSource,
+    indication = indication,
+    content = content,
+  )
+}
+
+@Composable
+fun UnstyledDropdownMenuItem(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  closeOnClick: Boolean = true,
+  interactionSource: MutableInteractionSource? = null,
+  indication: Indication? = null,
+  content: @Composable () -> Unit,
+) {
   val state = LocalDropdownMenuState.current
+  val scope = LocalDropdownMenuPanelScope.current
   val modalState = LocalModalState.current
   val focusRequester = remember { FocusRequester() }
   val focusTarget = remember(focusRequester) {
     DropdownMenuItemFocusTarget(focusRequester = focusRequester)
   }
   var placed by remember { mutableStateOf(false) }
-  val isFirstItem = firstItemFocusTarget == focusTarget
+  val isFirstItem = scope?.firstItemFocusTarget == focusTarget
   val shouldRequestInitialFocus = when (state.initialFocusDirection) {
     FocusDirection.Next -> isFirstItem
-    FocusDirection.Previous -> itemFocusTargets.lastOrNull() == focusTarget
+    FocusDirection.Previous -> scope?.itemFocusTargets?.lastOrNull() == focusTarget
     else -> false
   }
 
@@ -370,7 +396,9 @@ fun DropdownMenuPanelScope.MenuItem(
 
   Box(
     modifier = modifier then buildModifier {
-      add(DropdownMenuItemParentDataModifier(focusTarget))
+      if (scope != null) {
+        add(DropdownMenuItemParentDataModifier(focusTarget))
+      }
       add(Modifier.onPlaced { placed = true })
       add(Modifier.focusRequester(focusRequester))
       add(Modifier.onFocusChanged { focusTarget.focused = it.hasFocus })

--- a/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
+++ b/composeunstyled-dropdown-menu/src/commonMain/kotlin/com/composeunstyled/DropdownMenu.kt
@@ -336,6 +336,12 @@ fun DropdownMenuScope.DropdownMenuPanel(
 }
 
 @Composable
+@Deprecated(
+  message = "This will go away in 3.0. Use UnstyledDropdownMenuItem instead.",
+  replaceWith = ReplaceWith(
+    expression = "UnstyledDropdownMenuItem(onClick, modifier, enabled, closeOnClick, interactionSource, indication, content)",
+  ),
+)
 fun DropdownMenuPanelScope.MenuItem(
   onClick: () -> Unit,
   modifier: Modifier = Modifier,

--- a/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
+++ b/composeunstyled-dropdown-menu/src/commonTest/kotlin/com/composeunstyled/DropdownMenuPanelTest.kt
@@ -137,7 +137,7 @@ class DropdownMenuPanelTest {
           ),
         ) {
           DropdownMenuPanel {
-            MenuItem(
+            UnstyledDropdownMenuItem(
               onClick = { clicked = true },
               modifier = Modifier.testTag("item"),
             ) {
@@ -168,7 +168,7 @@ class DropdownMenuPanelTest {
           ),
         ) {
           DropdownMenuPanel {
-            MenuItem(
+            UnstyledDropdownMenuItem(
               onClick = { clicked = true },
               closeOnClick = false,
               modifier = Modifier.testTag("item"),
@@ -197,7 +197,7 @@ class DropdownMenuPanelTest {
         onExpandedChange = { expanded = it },
         panel = {
           DropdownMenuPanel {
-            MenuItem(
+            UnstyledDropdownMenuItem(
               onClick = { clicked = true },
               modifier = Modifier.testTag("item"),
             ) {
@@ -227,13 +227,13 @@ class DropdownMenuPanelTest {
         onExpandedChange = { expanded = it },
         panel = {
           DropdownMenuPanel {
-            MenuItem(
+            UnstyledDropdownMenuItem(
               onClick = {},
               modifier = Modifier.testTag("first"),
             ) {
               BasicText("First")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
               BasicText("Last")
             }
           }
@@ -263,10 +263,10 @@ class DropdownMenuPanelTest {
         onExpandedChange = { expanded = it },
         panel = {
           DropdownMenuPanel {
-            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
               BasicText("First")
             }
-            MenuItem(
+            UnstyledDropdownMenuItem(
               onClick = {},
               modifier = Modifier.testTag("last"),
             ) {
@@ -304,7 +304,7 @@ class DropdownMenuPanelTest {
           DropdownMenuPanel(
             enter = fadeIn(animationSpec = tween(durationMillis = 1_000)),
           ) {
-            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
               BasicText("First")
             }
           }
@@ -338,10 +338,15 @@ class DropdownMenuPanelTest {
         onExpandedChange = { expanded = it },
         panel = {
           DropdownMenuPanel(modifier = Modifier.testTag("panel")) {
-            MenuItem(onClick = { firstItemClicked = true }, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(
+              onClick = {
+                firstItemClicked = true
+              },
+              modifier = Modifier.testTag("first"),
+            ) {
               BasicText("First")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
               BasicText("Last")
             }
           }
@@ -384,10 +389,10 @@ class DropdownMenuPanelTest {
         onExpandedChange = { expanded = it },
         panel = {
           DropdownMenuPanel(modifier = Modifier.testTag("panel")) {
-            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
               BasicText("First")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
               BasicText("Last")
             }
           }
@@ -426,10 +431,10 @@ class DropdownMenuPanelTest {
         onExpandedChange = { expanded = it },
         panel = {
           DropdownMenuPanel(modifier = Modifier.testTag("panel")) {
-            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
               BasicText("First")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
               BasicText("Last")
             }
           }
@@ -469,10 +474,15 @@ class DropdownMenuPanelTest {
         onExpandedChange = { expanded = it },
         panel = {
           DropdownMenuPanel(modifier = Modifier.testTag("panel")) {
-            MenuItem(onClick = { firstItemClicked = true }, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(
+              onClick = {
+                firstItemClicked = true
+              },
+              modifier = Modifier.testTag("first"),
+            ) {
               BasicText("First")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
               BasicText("Last")
             }
           }
@@ -518,10 +528,10 @@ class DropdownMenuPanelTest {
           onExpandedChange = { expanded = it },
           panel = {
             DropdownMenuPanel {
-              MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
                 BasicText("First")
               }
-              MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
                 BasicText("Last")
               }
             }
@@ -561,10 +571,10 @@ class DropdownMenuPanelTest {
           onExpandedChange = { expanded = it },
           panel = {
             DropdownMenuPanel {
-              MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+              UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
                 BasicText("First")
               }
-              MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+              UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
                 BasicText("Last")
               }
             }
@@ -613,7 +623,7 @@ class DropdownMenuPanelTest {
           ),
         ) {
           DropdownMenuPanel {
-            MenuItem(
+            UnstyledDropdownMenuItem(
               onClick = {},
               modifier = Modifier
                 .testTag("first")
@@ -626,7 +636,7 @@ class DropdownMenuPanelTest {
               text = "Separator",
               modifier = Modifier.size(itemHeight),
             )
-            MenuItem(
+            UnstyledDropdownMenuItem(
               onClick = {},
               modifier = Modifier
                 .testTag("second")
@@ -657,13 +667,13 @@ class DropdownMenuPanelTest {
           ),
         ) {
           DropdownMenuPanel {
-            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
               BasicText("First")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
               BasicText("Middle")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
               BasicText("Last")
             }
           }
@@ -695,13 +705,13 @@ class DropdownMenuPanelTest {
           ),
         ) {
           DropdownMenuPanel {
-            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
               BasicText("First")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("middle")) {
               BasicText("Middle")
             }
-            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
               BasicText("Last")
             }
           }
@@ -734,11 +744,11 @@ class DropdownMenuPanelTest {
         ) {
           DropdownMenuPanel {
             BasicText("Before")
-            MenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("first")) {
               BasicText("First")
             }
             BasicText("Separator")
-            MenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
+            UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag("last")) {
               BasicText("Last")
             }
             BasicText("After")
@@ -836,8 +846,8 @@ private fun UseKeyboardInputMode() {
 }
 
 @Composable
-private fun DropdownMenuPanelScope.ReorderableMenuItem(tag: String, text: String) {
-  MenuItem(onClick = {}, modifier = Modifier.testTag(tag)) {
+private fun ReorderableMenuItem(tag: String, text: String) {
+  UnstyledDropdownMenuItem(onClick = {}, modifier = Modifier.testTag(tag)) {
     BasicText(text)
   }
 }

--- a/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
+++ b/demo/src/commonMain/kotlin/DropdownMenuDemo.kt
@@ -61,9 +61,9 @@ import com.composables.icons.lucide.Scissors
 import com.composables.icons.lucide.Trash2
 import com.composeunstyled.DropdownMenuPanel
 import com.composeunstyled.LocalContentColor
-import com.composeunstyled.MenuItem
 import com.composeunstyled.UnstyledButton
 import com.composeunstyled.UnstyledDropdownMenu
+import com.composeunstyled.UnstyledDropdownMenuItem
 import com.composeunstyled.UnstyledHorizontalSeparator
 import com.composeunstyled.UnstyledIcon
 
@@ -112,7 +112,7 @@ fun DropdownMenuDemo() {
           if (index == 1 || index == options.lastIndex) {
             UnstyledHorizontalSeparator(color = Color(0xFFBDBDBD))
           }
-          MenuItem(
+          UnstyledDropdownMenuItem(
             onClick = {},
             enabled = option.enabled,
             indication = LocalIndication.current,

--- a/docs/pages/dropdown-menu.md
+++ b/docs/pages/dropdown-menu.md
@@ -26,7 +26,7 @@ UnstyledDropdownMenu(
   onExpandedChange = onExpandedChange,
   panel = {
     DropdownMenuPanel {
-      MenuItem(onClick = onClick) {
+      UnstyledDropdownMenuItem(onClick = onClick) {
       }
     }
   },
@@ -41,14 +41,14 @@ UnstyledDropdownMenu(
   - The `anchor` slot renders the content the menu is positioned against.
   - The `panel` slot renders the floating menu content.
 - `DropdownMenuPanel` renders the menu surface and arranges direct children vertically.
-- `MenuItem` renders a focusable item inside `DropdownMenuPanel`. Use direct `MenuItem` children for managed keyboard navigation. Custom nested layouts can be rendered inside the panel, but nested items are not part of the panel-managed menu order.
+- `UnstyledDropdownMenuItem` renders a focusable item inside `DropdownMenuPanel`. Use direct `UnstyledDropdownMenuItem` children for managed keyboard navigation. Custom nested layouts can be rendered inside the panel, but nested items are not part of the panel-managed menu order.
 
 ## Accessibility
 
 Dropdown menu handles keyboard interactions out of the box. Pressing Arrow Down opens the menu and
 focuses the first item. Pressing Arrow Down and Arrow Up moves focus to the next and previous item.
 Home moves focus to the first item. End moves focus to the last item. Escape closes the menu. Use
-`MenuItem` for focusable menu actions.
+`UnstyledDropdownMenuItem` for focusable menu actions.
 
 ## Code Examples
 
@@ -64,7 +64,7 @@ UnstyledDropdownMenu(
   onExpandedChange = { expanded = it },
   panel = {
     DropdownMenuPanel {
-      MenuItem(onClick = { expanded = false }) {
+      UnstyledDropdownMenuItem(onClick = { expanded = false }) {
         BasicText("Close")
       }
     }
@@ -91,7 +91,7 @@ UnstyledDropdownMenu(
   sideOffset = 8.dp,
   panel = {
     DropdownMenuPanel {
-      MenuItem(onClick = { select() }) {
+      UnstyledDropdownMenuItem(onClick = { select() }) {
         BasicText("Item")
       }
     }
@@ -104,7 +104,7 @@ UnstyledDropdownMenu(
 
 ### Closing the menu after clicking an item
 
-`MenuItem` closes the menu after click by default by calling the dropdown's `onExpandedChange`
+`UnstyledDropdownMenuItem` closes the menu after click by default by calling the dropdown's `onExpandedChange`
 callback with `false`:
 
 ```kotlin
@@ -113,7 +113,7 @@ UnstyledDropdownMenu(
   onExpandedChange = { expanded = it },
   panel = {
     DropdownMenuPanel {
-      MenuItem(onClick = { select() }) {
+      UnstyledDropdownMenuItem(onClick = { select() }) {
         BasicText("Item")
       }
     }
@@ -134,7 +134,7 @@ UnstyledDropdownMenu(
   onExpandedChange = { expanded = it },
   panel = {
     DropdownMenuPanel {
-      MenuItem(
+      UnstyledDropdownMenuItem(
         closeOnClick = false,
         onClick = { enabled = enabled.not() },
       ) {
@@ -161,7 +161,7 @@ UnstyledDropdownMenu(
       enter = fadeIn(),
       exit = fadeOut(),
     ) {
-      MenuItem(onClick = { select() }) {
+      UnstyledDropdownMenuItem(onClick = { select() }) {
         BasicText("Item")
       }
     }

--- a/docs/pages/migration-to-2.md
+++ b/docs/pages/migration-to-2.md
@@ -207,8 +207,8 @@ UnstyledDisclosure(
 
 ### Dropdown Menu
 
-Menu anchor and panel content are now slots on `UnstyledDropdownMenu`. Use scoped `DropdownMenuPanel`
-and `MenuItem`.
+Menu anchor and panel content are now slots on `UnstyledDropdownMenu`. Use `DropdownMenuPanel`
+and `UnstyledDropdownMenuItem`.
 
 Dropdown Menu also has new anchor placement parameters: `side`, `alignment`, `sideOffset`, and
 `alignmentOffset`. Use them instead of the old `DropdownPanelAnchor` values:
@@ -225,7 +225,7 @@ UnstyledDropdownMenu(
   alignmentOffset = 0.dp,
   panel = {
     DropdownMenuPanel {
-      MenuItem(onClick = { expanded = false }) {
+      UnstyledDropdownMenuItem(onClick = { expanded = false }) {
         Text("Item")
       }
     }


### PR DESCRIPTION
## Summary

- add `UnstyledDropdownMenuItem` as the unscoped dropdown menu item API
- deprecate `DropdownMenuPanelScope.MenuItem` and point callers to the unscoped API for 3.0
- migrate internal tests, demo, and docs to use `UnstyledDropdownMenuItem`

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed

Ran:
- `./gradlew jvmTest spotlessCheck`

## Related Issues

- #437

## Screenshots/Videos

Not applicable.
