### PR TITLE
Release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-06-25
+
+### Added
+
+- Added `UnstyledAvatar` as a new primitive for rendering avatars with painter-backed content and
+  fallback underlay content. Avatar is now included in the `composeunstyled` module by default.
+- Added `UnstyledDropdownMenuItem` as an unscoped dropdown menu item API for building menu content
+  without relying on `DropdownMenuPanelScope.MenuItem`. This make it easier to build menu items without having to wrap the scope.
+
+### Deprecated
+
+- Deprecated `DropdownMenuPanelScope.MenuItem`. Use `UnstyledDropdownMenuItem` instead. It will be
+  removed in 3.0.
+
 ## [2.7.0] - 2026-06-15
 
 ### Added

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-unstyled = "2.7.0"
+unstyled = "2.8.0"
 
 kotlin = "2.4.0"
 compose = "1.11.1"


### PR DESCRIPTION
## Summary

Prepares the 2.8.0 release by moving the current unreleased notes into the 2.8.0 section and bumping the published version to 2.8.0.

## Test Plan

- Ran `git diff --check`
- Confirmed tag `2.8.0` does not already exist locally
- [ ] Tests added/updated
- [ ] Manual testing performed

## Related Issues

None.

## Screenshots/Videos

Not applicable.
