### PR TITLE
Fix newer portals rendering behind older portals

### DIFF
--- a/composeunstyled-portal/src/commonMain/kotlin/com/composeunstyled/Portal.kt
+++ b/composeunstyled-portal/src/commonMain/kotlin/com/composeunstyled/Portal.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
@@ -35,8 +35,26 @@ import androidx.compose.ui.Modifier
 private val LocalPortalState = staticCompositionLocalOf<PortalState?> { null }
 
 private class PortalState {
-  val entries = mutableStateMapOf<Any, @Composable () -> Unit>()
+  val entries = mutableStateListOf<PortalEntry>()
+
+  fun addOrUpdate(id: Any, content: @Composable () -> Unit) {
+    val index = entries.indexOfFirst { it.id == id }
+    if (index == -1) {
+      entries.add(PortalEntry(id = id, content = content))
+    } else {
+      entries[index] = entries[index].copy(content = content)
+    }
+  }
+
+  fun remove(id: Any) {
+    entries.removeAll { it.id == id }
+  }
 }
+
+private data class PortalEntry(
+  val id: Any,
+  val content: @Composable () -> Unit,
+)
 
 @Composable
 fun PortalHost(
@@ -48,10 +66,10 @@ fun PortalHost(
   CompositionLocalProvider(LocalPortalState provides state) {
     Box(modifier) {
       content()
-      state.entries.forEach { (id, content) ->
-        key(id) {
+      state.entries.forEach { entry ->
+        key(entry.id) {
           Box(Modifier.matchParentSize()) {
-            content()
+            entry.content()
           }
         }
       }
@@ -71,12 +89,12 @@ fun Portal(
   }
 
   SideEffect {
-    state.entries[id] = content
+    state.addOrUpdate(id = id, content = content)
   }
 
   DisposableEffect(state, id) {
     onDispose {
-      state.entries.remove(id)
+      state.remove(id)
     }
   }
 }

--- a/composeunstyled-portal/src/commonTest/kotlin/Portal.test.kt
+++ b/composeunstyled-portal/src/commonTest/kotlin/Portal.test.kt
@@ -21,17 +21,27 @@
  */
 package com.composeunstyled
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
 class PortalTest {
@@ -58,6 +68,47 @@ class PortalTest {
     }
 
     onNodeWithText("Portal content").assertDoesNotExist()
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun newestPortalContentIsRenderedAboveOlderPortalContentAfterRepeatedMounts() = runComposeUiTest {
+    var showTopPortal by mutableStateOf(false)
+    var bottomClicks = 0
+    var topClicks = 0
+
+    setContent {
+      PortalHost(Modifier.size(100.dp)) {
+        Portal {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .clickable { bottomClicks += 1 },
+          )
+        }
+
+        if (showTopPortal) {
+          Portal {
+            Box(
+              Modifier
+                .fillMaxSize()
+                .clickable { topClicks += 1 },
+            )
+          }
+        }
+      }
+    }
+
+    repeat(50) {
+      showTopPortal = true
+      waitForIdle()
+      onRoot().performTouchInput { click(center) }
+      showTopPortal = false
+      waitForIdle()
+    }
+
+    assertThat(topClicks).isEqualTo(50)
+    assertThat(bottomClicks).isEqualTo(0)
   }
 
   @Test


### PR DESCRIPTION
### Motivation

- Repeatedly mounting portal content (e.g. dropdown menus inside a dialog host) could cause newer portals to render behind older portals due to using an unordered state map for portal entries. 
- Ensure deterministic stacking so newly mounted portal content always appears above earlier content to prevent intermittent layering bugs.

### Description

- Replace `mutableStateMapOf` with an ordered `mutableStateListOf<PortalEntry>` and add `addOrUpdate`/`remove` helpers to preserve insertion order while allowing content updates in place in `composeunstyled-portal/src/commonMain/kotlin/com/composeunstyled/Portal.kt`.
- Iterate the ordered `entries` list in `PortalHost` and use stable keys so newer entries are laid out after older entries (rendered above them). 
- Add a regression UI test `newestPortalContentIsRenderedAboveOlderPortalContentAfterRepeatedMounts` in `composeunstyled-portal/src/commonTest/kotlin/Portal.test.kt` that repeatedly mounts a top portal over a bottom portal and verifies clicks go to the newest portal.

### Testing

- Ran `./gradlew spotlessCheck` which completed successfully. 
- Added a focused `:composeunstyled-portal:jvmTest` test (`com.composeunstyled.PortalTest.newestPortalContentIsRenderedAboveOlderPortalContentAfterRepeatedMounts`) but execution was blocked by dependency resolution errors (HTTP 403 fetching Kotlin/Compose artifacts), so the JVM test could not be executed here. 
- Attempting a full `./gradlew jvmTest spotlessCheck` was also blocked due to unresolved native/Skiko version resolution for Compose `1.11.1`, so CI/JVM verification remains pending until dependencies are resolvable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43725bb56c832b93c9240174721ab4)