### PR TITLE
Fix portalled content losing composition locals

### DIFF
--- a/composeunstyled-portal/src/commonMain/kotlin/com/composeunstyled/Portal.kt
+++ b/composeunstyled-portal/src/commonMain/kotlin/com/composeunstyled/Portal.kt
@@ -23,9 +23,11 @@ package com.composeunstyled
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
@@ -34,8 +36,13 @@ import androidx.compose.ui.Modifier
 
 private val LocalPortalState = staticCompositionLocalOf<PortalState?> { null }
 
+private class PortalEntry(
+  val compositionLocalContext: CompositionLocalContext,
+  val content: @Composable () -> Unit,
+)
+
 private class PortalState {
-  val entries = mutableStateMapOf<Any, @Composable () -> Unit>()
+  val entries = mutableStateMapOf<Any, PortalEntry>()
 }
 
 @Composable
@@ -48,10 +55,12 @@ fun PortalHost(
   CompositionLocalProvider(LocalPortalState provides state) {
     Box(modifier) {
       content()
-      state.entries.forEach { (id, content) ->
+      state.entries.forEach { (id, entry) ->
         key(id) {
           Box(Modifier.matchParentSize()) {
-            content()
+            CompositionLocalProvider(entry.compositionLocalContext) {
+              entry.content()
+            }
           }
         }
       }
@@ -65,13 +74,17 @@ fun Portal(
 ) {
   val state = LocalPortalState.current
   val id = remember { Any() }
+  val compositionLocalContext = currentCompositionLocalContext
 
   if (state == null) {
     return
   }
 
   SideEffect {
-    state.entries[id] = content
+    state.entries[id] = PortalEntry(
+      compositionLocalContext = compositionLocalContext,
+      content = content,
+    )
   }
 
   DisposableEffect(state, id) {

--- a/composeunstyled-portal/src/commonTest/kotlin/Portal.test.kt
+++ b/composeunstyled-portal/src/commonTest/kotlin/Portal.test.kt
@@ -24,6 +24,8 @@ package com.composeunstyled
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertHeightIsEqualTo
@@ -50,6 +52,21 @@ class PortalTest {
   }
 
   @Test
+  fun portalContentKeepsCallerCompositionLocals() = runComposeUiTest {
+    setContent {
+      PortalHost {
+        CompositionLocalProvider(LocalPortalTestValue provides "caller") {
+          Portal {
+            BasicText(LocalPortalTestValue.current)
+          }
+        }
+      }
+    }
+
+    onNodeWithText("caller").assertExists()
+  }
+
+  @Test
   fun rendersNothingWithoutPortalHost() = runComposeUiTest {
     setContent {
       Portal {
@@ -73,3 +90,5 @@ class PortalTest {
       .assertHeightIsEqualTo(24.dp)
   }
 }
+
+private val LocalPortalTestValue = staticCompositionLocalOf { "host" }


### PR DESCRIPTION
## Summary

Preserve the caller composition local context when rendering content through `PortalHost`.

The bug showed up when a component was declared under a theme but rendered through a modal/portal host above that theme. `Portal` now captures `currentCompositionLocalContext` at the declaration site and `PortalHost` re-provides it when rendering the entry.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Commands run:

```bash
./gradlew :composeunstyled-portal:jvmTest :composeunstyled-portal:spotlessCheck
```

## Related Issues

None.

## Screenshots/Videos

Not applicable.