### PR TITLE
Add ColorScheme to theming

### DIFF
--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/ColorScheme.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/ColorScheme.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import kotlin.jvm.JvmInline
+
+/**
+ * Used by elements to choose colors that maintain a consistent look and feel across the application.
+ */
+@JvmInline
+value class ColorScheme internal constructor(@Suppress("unused") private val value: Int) {
+  companion object {
+    val Light = ColorScheme(0)
+    val Dark = ColorScheme(1)
+  }
+}
+
+/**
+ * The current [ColorScheme] to use in this composition.
+ */
+val LocalColorScheme = staticCompositionLocalOf<ColorScheme> {
+  error(
+    "Tried to access LocalColorScheme without it being set up." +
+      " This value is provided by default in themes built using buildTheme {}." +
+      " If you are trying to get the system's ColorScheme, use currentSystemColorScheme() instead",
+  )
+}
+
+/**
+ * Returns the currently set [ColorScheme] provided by the system.
+ */
+@Composable
+fun currentSystemColorScheme(): ColorScheme {
+  return if (isSystemInDarkTheme()) ColorScheme.Dark else ColorScheme.Light
+}

--- a/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
+++ b/composeunstyled-theming/src/commonMain/kotlin/com/composeunstyled/theme/Theme.kt
@@ -112,6 +112,7 @@ fun buildTheme(themeAction: @Composable ThemeBuilder.() -> Unit = {}): ThemeComp
 
     CompositionLocalProvider(
       LocalTheme provides theme,
+      LocalColorScheme provides currentSystemColorScheme(),
       LocalIndication provides defaultIndication,
       LocalTextStyle provides builder.defaultTextStyle,
       LocalContentColor provides builder.defaultContentColor,

--- a/composeunstyled-theming/src/commonTest/kotlin/Theme.test.kt
+++ b/composeunstyled-theming/src/commonTest/kotlin/Theme.test.kt
@@ -40,11 +40,14 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
+import com.composeunstyled.theme.ColorScheme
+import com.composeunstyled.theme.LocalColorScheme
 import com.composeunstyled.theme.NoIndication
 import com.composeunstyled.theme.Theme
 import com.composeunstyled.theme.ThemeProperty
 import com.composeunstyled.theme.ThemeToken
 import com.composeunstyled.theme.buildTheme
+import com.composeunstyled.theme.currentSystemColorScheme
 import kotlin.test.Test
 
 class ThemeCommonTest {
@@ -156,6 +159,53 @@ class ThemeCommonTest {
     waitForIdle()
     assertThat(currentSelectionColors.handleColor).isEqualTo(Color.Unspecified)
     assertThat(currentSelectionColors.backgroundColor).isEqualTo(Color.Unspecified)
+  }
+
+  @Test
+  fun themeProvidesSystemColorSchemeByDefault() = runComposeUiTest {
+    var expectedColorScheme = ColorScheme.Light
+    var currentColorScheme = ColorScheme.Dark
+    val testTheme = buildTheme()
+
+    setContent {
+      expectedColorScheme = currentSystemColorScheme()
+
+      testTheme {
+        currentColorScheme = LocalColorScheme.current
+      }
+    }
+
+    waitForIdle()
+    assertThat(currentColorScheme).isEqualTo(expectedColorScheme)
+  }
+
+  @Test
+  fun extendedThemeCanOverrideColorScheme() = runComposeUiTest {
+    var expectedColorScheme = ColorScheme.Light
+    var currentColorScheme = ColorScheme.Light
+    val testTheme = buildTheme {
+      val colorScheme = if (currentSystemColorScheme() == ColorScheme.Dark) {
+        ColorScheme.Light
+      } else {
+        ColorScheme.Dark
+      }
+      expectedColorScheme = colorScheme
+
+      extend { content ->
+        CompositionLocalProvider(LocalColorScheme provides colorScheme) {
+          content()
+        }
+      }
+    }
+
+    setContent {
+      testTheme {
+        currentColorScheme = LocalColorScheme.current
+      }
+    }
+
+    waitForIdle()
+    assertThat(currentColorScheme).isEqualTo(expectedColorScheme)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds a shared color scheme environment API to `composeunstyled-theming` so design systems and tools can agree on light/dark mode without each owning their own type.

The new API includes:

- `ColorScheme.Light`
- `ColorScheme.Dark`
- `LocalColorScheme`
- `currentSystemColorScheme()`

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

Ran:

```bash
./gradlew jvmTest spotlessCheck
```

## Related Issues

None.

## Screenshots/Videos

Not applicable.
