### PR TITLE
Fix tooltip placement in overridden window contexts

### DIFF
--- a/composeunstyled-internal-anchored/src/commonMain/kotlin/com/composeunstyled/AnchoredLayout.kt
+++ b/composeunstyled-internal-anchored/src/commonMain/kotlin/com/composeunstyled/AnchoredLayout.kt
@@ -139,12 +139,18 @@ fun AnchoredContent(
   onPlaced: (FloatingPlacement) -> Unit,
   content: @Composable () -> Unit,
 ) {
-  var containerPositionInWindow by remember { mutableStateOf<IntOffset?>(null) }
+  var containerBoundsInWindow by remember { mutableStateOf<IntRect?>(null) }
 
   Layout(
     content = content,
     modifier = modifier.onGloballyPositioned {
-      containerPositionInWindow = it.positionInWindow().round()
+      val position = it.positionInWindow().round()
+      containerBoundsInWindow = IntRect(
+        left = position.x,
+        top = position.y,
+        right = position.x + it.size.width,
+        bottom = position.y + it.size.height,
+      )
     },
   ) { measurables, constraints ->
     val contentPlaceable = measurables.firstOrNull()?.measure(Constraints())
@@ -153,16 +159,23 @@ fun AnchoredContent(
       return@Layout layout(0, 0) {}
     }
 
-    val containerPosition = containerPositionInWindow
+    val currentContainerBounds = containerBoundsInWindow
 
-    if (containerPosition == null) {
+    if (currentContainerBounds == null) {
       return@Layout layout(constraints.maxWidth, constraints.maxHeight) {}
     }
+    val placementWindowSize = IntSize(currentContainerBounds.width, currentContainerBounds.height)
+    val placementAnchorBounds = anchorBounds.translate(
+      IntOffset(
+        x = -currentContainerBounds.left,
+        y = -currentContainerBounds.top,
+      ),
+    )
 
     val placement = calculateFloatingPlacement(
       density = density,
-      anchorBounds = anchorBounds,
-      windowSize = windowSize,
+      anchorBounds = placementAnchorBounds,
+      windowSize = placementWindowSize,
       layoutDirection = layoutDirection,
       contentSize = IntSize(contentPlaceable.width, contentPlaceable.height),
       side = side,
@@ -175,8 +188,8 @@ fun AnchoredContent(
     layout(constraints.maxWidth, constraints.maxHeight) {
       onPlaced(placement)
       contentPlaceable.place(
-        x = contentPosition.x - containerPosition.x,
-        y = contentPosition.y - containerPosition.y,
+        x = contentPosition.x,
+        y = contentPosition.y,
       )
     }
   }

--- a/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
+++ b/composeunstyled-tooltip/src/commonTest/kotlin/FloatingContent.test.kt
@@ -22,18 +22,33 @@
 package com.composeunstyled
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.platform.WindowInfo
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThanOrEqualTo
 import assertk.assertions.isNotEqualTo
+import kotlin.math.roundToInt
 import kotlin.test.Test
 
 class FloatingContentTest {
@@ -190,5 +205,76 @@ class FloatingContentTest {
     // to maximize the visible portion at the top-left
     assertThat(floatingX).isGreaterThanOrEqualTo(0f)
     assertThat(floatingY).isGreaterThanOrEqualTo(0f)
+  }
+
+  @Test
+  fun positionsFloatingContentInsideOffsetHostWhenWindowInfoIsOverridden() = runComposeUiTest {
+    setContent {
+      Box(Modifier.requiredSize(700.dp)) {
+        FakeWindowInfoSurface(
+          width = 300.dp,
+          height = 300.dp,
+          modifier = Modifier
+            .offset(x = 200.dp, y = 100.dp)
+            .testTag("fake_host"),
+        ) {
+          TooltipHost(Modifier.requiredSize(300.dp, 300.dp)) {
+            FloatingContent(
+              modifier = Modifier.offset(x = 260.dp, y = 160.dp),
+              side = AnchorSide.Top,
+              alignment = AnchorAlignment.Center,
+              sideOffset = 8.dp,
+              floatingContent = {
+                Box(Modifier.size(width = 80.dp, height = 20.dp)) {
+                  BasicText("Floating")
+                }
+              },
+              anchor = {
+                Box(Modifier.size(40.dp)) {
+                  BasicText("Anchor")
+                }
+              },
+            )
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+
+    val hostX = onNodeWithTag("fake_host").fetchSemanticsNode().positionInWindow.x
+    val floatingX = onNodeWithText("Floating").fetchSemanticsNode().positionInWindow.x
+
+    assertThat((floatingX - hostX).roundToInt()).isEqualTo(220)
+  }
+
+  @Composable
+  private fun FakeWindowInfoSurface(
+    width: Dp,
+    height: Dp,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+  ) {
+    val density = LocalDensity.current
+    val parentWindowInfo = LocalWindowInfo.current
+    val containerSize = with(density) {
+      IntSize(width.roundToPx(), height.roundToPx())
+    }
+    val fakeWindowInfo = remember(parentWindowInfo, containerSize, width, height) {
+      object : WindowInfo {
+        override val containerSize: IntSize = containerSize
+        override val containerDpSize: DpSize = DpSize(width, height)
+        override val isWindowFocused: Boolean
+          get() = parentWindowInfo.isWindowFocused
+        override val keyboardModifiers: androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+          get() = parentWindowInfo.keyboardModifiers
+      }
+    }
+
+    Box(modifier.requiredSize(width, height)) {
+      CompositionLocalProvider(LocalWindowInfo provides fakeWindowInfo) {
+        content()
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes tooltip floating placement when `LocalWindowInfo` is overridden inside an offset host. Floating panels now resolve anchor coordinates and collision bounds in the floating container's coordinate space instead of mixing anchor window coordinates with the overridden window size.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed
- `./gradlew :composeunstyled-tooltip:jvmTest --tests 'com.composeunstyled.FloatingContentTest.positionsFloatingContentInsideOffsetHostWhenWindowInfoIsOverridden' --quiet`
- `./gradlew :composeunstyled-tooltip:jvmTest :composeunstyled-internal-anchored:jvmTest --quiet`
- `./gradlew jvmTest spotlessCheck --quiet`

## Manual QA

- Platform/device: Desktop JVM demo on macOS
- Setup: Temporarily replaced `TooltipDemo` with the fake-window repro from #451
- Steps:
  1. Run the demo on `main` and open Tooltip.
  2. Hover the black anchor inside the offset fake window surface.
  3. Switch to this branch with the same temporary demo repro and hover the anchor again.
- Expected result: On `main`, the tooltip is shifted/clamped incorrectly. On this branch, the tooltip is positioned relative to the anchor inside the fake window surface.
- Known limitations: The temporary demo repro is not part of this PR.

## Related Issues

Closes #451

## Screenshots/Videos

Not applicable.
