### PR TITLE
Send issue template contact links to GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Get Help
-    url: https://github.com/composablehorizons/compose-unstyled/discussions/new?category=help
-    about: If you can't get something to work the way you expect, open a question in our discussion forums.
+    url: https://github.com/composablehorizons/compose-unstyled/issues/new
+    about: If you can't get something to work the way you expect, open a GitHub issue.
   - name: Feature Request
-    url: https://github.com/composablehorizons/compose-unstyled/discussions/new?category=ideas
-    about: 'Suggest any ideas you have using our discussion forums.'
+    url: https://github.com/composablehorizons/compose-unstyled/issues/new
+    about: Suggest any ideas you have using GitHub issues.


### PR DESCRIPTION
## Summary

Updates the GitHub issue template chooser contact links so help requests and feature requests open GitHub Issues instead of GitHub Discussions.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

Validated `.github/ISSUE_TEMPLATE/config.yml` parses as YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/ISSUE_TEMPLATE/config.yml")'`.

## Related Issues

None.

## Screenshots/Videos

Not applicable.