### PR TITLE
Fix newer portals rendering behind older portals

### DIFF
--- a/composeunstyled-portal/src/commonMain/kotlin/com/composeunstyled/Portal.kt
+++ b/composeunstyled-portal/src/commonMain/kotlin/com/composeunstyled/Portal.kt
@@ -29,20 +29,47 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 
 private val LocalPortalState = staticCompositionLocalOf<PortalState?> { null }
 
-private class PortalEntry(
+private data class PortalEntry(
+  val id: Any,
   val compositionLocalContext: CompositionLocalContext,
   val content: @Composable () -> Unit,
 )
 
 private class PortalState {
-  val entries = mutableStateMapOf<Any, PortalEntry>()
+  val entries = mutableStateListOf<PortalEntry>()
+
+  fun addOrUpdate(
+    id: Any,
+    compositionLocalContext: CompositionLocalContext,
+    content: @Composable () -> Unit,
+  ) {
+    val index = entries.indexOfFirst { it.id == id }
+    if (index == -1) {
+      entries.add(
+        PortalEntry(
+          id = id,
+          compositionLocalContext = compositionLocalContext,
+          content = content,
+        ),
+      )
+    } else {
+      entries[index] = entries[index].copy(
+        compositionLocalContext = compositionLocalContext,
+        content = content,
+      )
+    }
+  }
+
+  fun remove(id: Any) {
+    entries.removeAll { it.id == id }
+  }
 }
 
 @Composable
@@ -55,8 +82,8 @@ fun PortalHost(
   CompositionLocalProvider(LocalPortalState provides state) {
     Box(modifier) {
       content()
-      state.entries.forEach { (id, entry) ->
-        key(id) {
+      state.entries.forEach { entry ->
+        key(entry.id) {
           Box(Modifier.matchParentSize()) {
             CompositionLocalProvider(entry.compositionLocalContext) {
               entry.content()
@@ -81,7 +108,8 @@ fun Portal(
   }
 
   SideEffect {
-    state.entries[id] = PortalEntry(
+    state.addOrUpdate(
+      id = id,
       compositionLocalContext = compositionLocalContext,
       content = content,
     )
@@ -89,7 +117,7 @@ fun Portal(
 
   DisposableEffect(state, id) {
     onDispose {
-      state.entries.remove(id)
+      state.remove(id)
     }
   }
 }

--- a/composeunstyled-portal/src/commonTest/kotlin/Portal.test.kt
+++ b/composeunstyled-portal/src/commonTest/kotlin/Portal.test.kt
@@ -21,19 +21,28 @@
  */
 package com.composeunstyled
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
 class PortalTest {
@@ -75,6 +84,46 @@ class PortalTest {
     }
 
     onNodeWithText("Portal content").assertDoesNotExist()
+  }
+
+  @Test
+  fun newerPortalContentIsRenderedAboveOlderPortalContentAfterRepeatedMounts() = runComposeUiTest {
+    var showTopPortal by mutableStateOf(false)
+    var bottomClicks = 0
+    var topClicks = 0
+
+    setContent {
+      PortalHost(Modifier.size(100.dp).testTag("host")) {
+        Portal {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .clickable { bottomClicks += 1 },
+          )
+        }
+
+        if (showTopPortal) {
+          Portal {
+            Box(
+              Modifier
+                .fillMaxSize()
+                .clickable { topClicks += 1 },
+            )
+          }
+        }
+      }
+    }
+
+    repeat(50) {
+      showTopPortal = true
+      waitForIdle()
+      onNodeWithTag("host").performTouchInput { click(center) }
+      showTopPortal = false
+      waitForIdle()
+    }
+
+    assertThat(topClicks).isEqualTo(50)
+    assertThat(bottomClicks).isEqualTo(0)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes portal stacking so newly mounted portal content renders above older portal content instead of relying on snapshot map iteration order. This prevents dropdown menus mounted inside dialog portals from intermittently appearing behind the dialog panel.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Commands run:

- `./gradlew :composeunstyled-portal:jvmTest --tests com.composeunstyled.PortalTest.newerPortalContentIsRenderedAboveOlderPortalContentAfterRepeatedMounts`
- `./gradlew jvmTest spotlessCheck`

## Manual QA

- Platform/device: Not manually tested
- Setup: N/A
- Steps:
  1. N/A
- Expected result: Newer portal content is rendered above older portal content.
- Known limitations: Covered by automated Compose UI regression test rather than manual app testing.

## Related Issues

Closes #443

## Screenshots/Videos

N/A