### PR TITLE
Fix anchored content fallback near viewport edges

### DIFF
--- a/.changeset/fallback-anchored-floating-content.md
+++ b/.changeset/fallback-anchored-floating-content.md
@@ -1,0 +1,5 @@
+---
+"compose-unstyled": patch
+---
+
+Fixed anchored floating content near viewport edges to try the opposite side before clamping into the window.

--- a/composeunstyled-internal-anchored/src/commonMain/kotlin/com/composeunstyled/Anchored.kt
+++ b/composeunstyled-internal-anchored/src/commonMain/kotlin/com/composeunstyled/Anchored.kt
@@ -28,10 +28,12 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 
 data class FloatingPlacement(
   val position: IntOffset,
   val positionAdjustment: IntOffset,
+  val side: AnchorSide,
 )
 
 fun calculateFloatingPlacement(
@@ -45,6 +47,58 @@ fun calculateFloatingPlacement(
   sideOffset: Dp = 0.dp,
   alignmentOffset: Dp = 0.dp,
 ): FloatingPlacement {
+  val sideOffsetPx = with(density) { sideOffset.roundToPx() }
+  val alignmentOffsetPx = with(density) { alignmentOffset.roundToPx() }
+  val preferredPlacement = calculatePlacement(
+    anchorBounds = anchorBounds,
+    windowSize = windowSize,
+    layoutDirection = layoutDirection,
+    contentSize = contentSize,
+    side = side,
+    alignment = alignment,
+    sideOffsetPx = sideOffsetPx,
+    alignmentOffsetPx = alignmentOffsetPx,
+  )
+  val oppositePlacement = calculatePlacement(
+    anchorBounds = anchorBounds,
+    windowSize = windowSize,
+    layoutDirection = layoutDirection,
+    contentSize = contentSize,
+    side = side.opposite(),
+    alignment = alignment,
+    sideOffsetPx = sideOffsetPx,
+    alignmentOffsetPx = alignmentOffsetPx,
+  )
+  val selectedPlacement = if (oppositePlacement.overflow < preferredPlacement.overflow) {
+    oppositePlacement
+  } else {
+    preferredPlacement
+  }
+
+  return FloatingPlacement(
+    position = selectedPlacement.position,
+    positionAdjustment = selectedPlacement.position - selectedPlacement.idealPosition,
+    side = selectedPlacement.side,
+  )
+}
+
+private data class PlacementCandidate(
+  val side: AnchorSide,
+  val idealPosition: IntOffset,
+  val position: IntOffset,
+  val overflow: Int,
+)
+
+private fun calculatePlacement(
+  anchorBounds: IntRect,
+  windowSize: IntSize,
+  layoutDirection: LayoutDirection,
+  contentSize: IntSize,
+  side: AnchorSide,
+  alignment: AnchorAlignment,
+  sideOffsetPx: Int,
+  alignmentOffsetPx: Int,
+): PlacementCandidate {
   val x = when (side) {
     AnchorSide.Top, AnchorSide.Bottom -> when (alignment) {
       AnchorAlignment.Start -> if (layoutDirection == LayoutDirection.Ltr) {
@@ -85,8 +139,6 @@ fun calculateFloatingPlacement(
   }
 
   val isLtr = layoutDirection == LayoutDirection.Ltr
-  val sideOffsetPx = with(density) { sideOffset.roundToPx() }
-  val alignmentOffsetPx = with(density) { alignmentOffset.roundToPx() }
 
   val offsetX = when (side) {
     AnchorSide.Top, AnchorSide.Bottom -> alignmentOffsetPx * if (isLtr) 1 else -1
@@ -104,12 +156,15 @@ fun calculateFloatingPlacement(
     y = y + offsetY,
   )
   val position = IntOffset(
-    x = (x + offsetX).coerceInWindowAxis(windowSize.width, contentSize.width),
-    y = (y + offsetY).coerceInWindowAxis(windowSize.height, contentSize.height),
+    x = idealPosition.x.coerceInWindowAxis(windowSize.width, contentSize.width),
+    y = idealPosition.y.coerceInWindowAxis(windowSize.height, contentSize.height),
   )
-  return FloatingPlacement(
+  val positionAdjustment = position - idealPosition
+  return PlacementCandidate(
+    side = side,
+    idealPosition = idealPosition,
     position = position,
-    positionAdjustment = position - idealPosition,
+    overflow = abs(positionAdjustment.x) + abs(positionAdjustment.y),
   )
 }
 
@@ -120,4 +175,11 @@ private fun Int.coerceInWindowAxis(windowSize: Int, contentSize: Int): Int {
   } else {
     coerceIn(0, max)
   }
+}
+
+private fun AnchorSide.opposite(): AnchorSide = when (this) {
+  AnchorSide.Top -> AnchorSide.Bottom
+  AnchorSide.Bottom -> AnchorSide.Top
+  AnchorSide.Start -> AnchorSide.End
+  AnchorSide.End -> AnchorSide.Start
 }

--- a/composeunstyled-internal-anchored/src/commonTest/kotlin/com/composeunstyled/AnchoredPositionTest.kt
+++ b/composeunstyled-internal-anchored/src/commonTest/kotlin/com/composeunstyled/AnchoredPositionTest.kt
@@ -98,6 +98,27 @@ class AnchoredPositionTest {
   }
 
   @Test
+  fun usesOppositeHorizontalSideWhenPreferredSideDoesNotFit() {
+    val position = calculatePosition(
+      anchorBounds = IntRect(left = 8, top = 50, right = 88, bottom = 90),
+      side = AnchorSide.Start,
+      alignment = AnchorAlignment.Center,
+    )
+
+    assertThat(position).isEqualTo(IntOffset(x = 88, y = 50))
+  }
+
+  @Test
+  fun usesOppositeVerticalSideWhenPreferredSideDoesNotFit() {
+    val position = calculatePosition(
+      anchorBounds = IntRect(left = 100, top = 8, right = 180, bottom = 48),
+      side = AnchorSide.Top,
+    )
+
+    assertThat(position).isEqualTo(IntOffset(x = 100, y = 48))
+  }
+
+  @Test
   fun clampsOffsetPositionInsideWindow() {
     val position = calculatePosition(
       side = AnchorSide.Top,
@@ -128,6 +149,21 @@ class AnchoredPositionTest {
   }
 
   @Test
+  fun reportsSelectedFallbackSide() {
+    val placement = calculateFloatingPlacement(
+      density = Density(1f),
+      anchorBounds = IntRect(left = 8, top = 50, right = 88, bottom = 90),
+      windowSize = windowSize,
+      layoutDirection = LayoutDirection.Ltr,
+      contentSize = contentSize,
+      side = AnchorSide.Start,
+      alignment = AnchorAlignment.Center,
+    )
+
+    assertThat(placement.side).isEqualTo(AnchorSide.End)
+  }
+
+  @Test
   fun clampsOversizedContentToWindowOrigin() {
     val position = calculatePosition(
       windowSize = IntSize(width = 80, height = 40),
@@ -138,6 +174,7 @@ class AnchoredPositionTest {
   }
 
   private fun calculatePosition(
+    anchorBounds: IntRect = this.anchorBounds,
     side: AnchorSide = AnchorSide.Bottom,
     alignment: AnchorAlignment = AnchorAlignment.Start,
     sideOffset: Dp = 0.dp,

--- a/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
+++ b/composeunstyled-tooltip/src/commonMain/kotlin/com/composeunstyled/Tooltip.kt
@@ -240,7 +240,10 @@ fun UnstyledTooltip(
     sideOffset = sideOffset,
     alignmentOffset = alignmentOffset,
     onPlaced = {
-      state.placement = state.placement.copy(positionAdjustment = it.positionAdjustment)
+      state.placement = state.placement.copy(
+        side = it.side,
+        positionAdjustment = it.positionAdjustment,
+      )
     },
     floatingContent = {
       CompositionLocalProvider(LocalTooltipState provides state) {


### PR DESCRIPTION
## Summary

Fixed anchored floating content so it evaluates the preferred side and its opposite, picks the placement with the least viewport overflow, and only clamps after selecting that side. Tooltip placement metadata now reports the actual selected side after fallback.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Commands run:

- `./gradlew :composeunstyled-internal-anchored:jvmTest --tests '*AnchoredPositionTest*' :composeunstyled-dropdown-menu:jvmTest :composeunstyled-tooltip:jvmTest`
- `./gradlew jvmTest`
- `./gradlew spotlessCheck`
- `git diff --check`

## Manual QA

- Platform/device: Not run
- Setup: N/A
- Steps:
  1. Place anchored floating content near a viewport edge with the preferred side pointing out of bounds.
  2. Open the floating content.
  3. Inspect that it appears on the opposite side when that side overflows less.
- Expected result: Floating content avoids overlapping the anchor when the opposite side fits better, and clamps only after selecting the best side.
- Known limitations: This adds preferred-opposite fallback behavior, not a configurable fallback side list.

## Related Issues

Closes #427

## Screenshots/Videos

N/A
