### PR TITLE
Add release note for portal stacking fix

### DIFF
--- a/.changeset/fix-portal-stacking-order.md
+++ b/.changeset/fix-portal-stacking-order.md
@@ -1,0 +1,5 @@
+---
+"compose-unstyled": patch
+---
+
+Fixed newer portal content sometimes rendering behind older portal content after repeated mounts.


### PR DESCRIPTION
## Summary

Adds the missing patch changeset for the portal stacking fix merged in #462.

## Test Plan

- [ ] Tests added/updated
- [ ] Manual testing performed

Validation run:

- `npm exec -- changeset status --since=origin/main`

## Manual QA

- Platform/device: N/A
- Setup: N/A
- Steps:
  1. N/A
- Expected result: Changesets reports a patch bump for `compose-unstyled`.
- Known limitations: Release metadata only; no runtime behavior change.

## Related Issues

Follow-up to #462 / #443

## Screenshots/Videos

N/A