### PR TITLE
Fix version workflow token for Changesets

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Create version PR
         if: steps.changesets.outputs.hasChangesets == 'true'
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Expose the built-in Actions token as `GITHUB_TOKEN` in the version PR step so `@changesets/changelog-github` can generate changelog entries. Keep `GH_TOKEN` for the later `gh` CLI calls in the same step.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

Validated the workflow file parses as YAML and the diff has no whitespace errors. Kotlin tests were not run because this only changes a GitHub Actions workflow environment variable.

## Manual QA

- Platform/device: GitHub Actions
- Setup: Run the Version Packages workflow when pending `.changeset/*.md` files exist.
- Steps:
  1. Trigger the Version Packages workflow on `main` or with `workflow_dispatch`.
  2. Let the `Create version PR` step run.
  3. Confirm `npm run changeset:version` can generate changelog entries.
- Expected result: Changesets sees `GITHUB_TOKEN`, completes version generation, and the step proceeds to create or update the release PR.
- Known limitations: The full workflow behavior can only be proven by a GitHub Actions run with pending changesets.

## Related Issues

Fixes the failed Version Packages run: https://github.com/composablehorizons/compose-unstyled/actions/runs/29146229555/job/86528130907

## Screenshots/Videos

Not applicable.