### PR TITLE
Fix demo APK signing verification in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
 
           actual_cert_sha256="$(
             printf '%s\n' "$signing_report" |
-              awk -F': ' '/Signer #1 certificate SHA-256 digest/ { print $2 }'
+              awk '/^(Signer #1|V2 Signer):? certificate SHA-256 digest:/ { sub(/^.*certificate SHA-256 digest: /, ""); print; exit }'
           )"
 
           if [ "$actual_cert_sha256" != "$expected_cert_sha256" ]; then


### PR DESCRIPTION
## Summary

Fixes release demo APK signing verification so it accepts the `V2 Signer: certificate SHA-256 digest` output emitted by the current Android build-tools `apksigner`, while still accepting the previous `Signer #1 certificate SHA-256 digest` format.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

Verified the parser against:
- The new `V2 Signer: certificate SHA-256 digest` output from the failed release job log.
- The previous `Signer #1 certificate SHA-256 digest` output format.
- YAML parsing with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`.

## Manual QA

- Platform/device: local shell
- Setup: downloaded failed release job log for https://github.com/composablehorizons/compose-unstyled/actions/runs/29146906218/job/86529920994
- Steps:
  1. Extract the `V2 Signer: certificate SHA-256 digest` line from the failed job log.
  2. Run the updated `awk` parser against that line.
  3. Run the updated parser against the previous `Signer #1 certificate SHA-256 digest` format.
- Expected result: both formats return `7d19a99ad9ae519b90681aaff27bc9692c2f060a179fd539c67ba507c3ab9bd3`.
- Known limitations: this does not make rerunning the existing `2.8.2` tag job use the fixed workflow; the release tag/input needs to point at a commit containing this PR.

## Related Issues

Release failure: https://github.com/composablehorizons/compose-unstyled/actions/runs/29146906218/job/86529920994

## Screenshots/Videos

Not applicable.
