### PR TITLE
Introduce `enabled` parameter to ModalBottomSheet

### DIFF
--- a/.changeset/modal-bottom-sheet-enabled.md
+++ b/.changeset/modal-bottom-sheet-enabled.md
@@ -1,0 +1,5 @@
+---
+"compose-unstyled": minor
+---
+
+Expose an `enabled` parameter on modal bottom sheets so callers can disable sheet dragging.

--- a/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/ModalBottomSheet.kt
@@ -239,6 +239,7 @@ class ModalBottomSheetState(
 @Composable
 fun UnstyledModalBottomSheet(
   state: ModalBottomSheetState,
+  enabled: Boolean = true,
   properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
   onDismiss: () -> Unit = DoNothing,
   overlay: (@Composable ModalBottomSheetOverlayScope.() -> Unit)? = null,
@@ -327,6 +328,7 @@ fun UnstyledModalBottomSheet(
         modifier = Modifier
           .fillMaxSize()
           .keepModalMountedWhileSheetExits(state),
+        enabled = enabled,
         offsetForIme = properties.offsetForIme,
       ) {
         val modalBottomSheetScope = remember(this) {

--- a/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
+++ b/composeunstyled-modal-bottom-sheet/src/commonTest/kotlin/ModalBottomSheet.test.kt
@@ -656,6 +656,41 @@ class ModalBottomSheetTest {
   }
 
   @Test
+  fun setting_enabled_to_false_blocks_sheet_dragging() = runComposeUiTest {
+    val peek = SheetDetent("peek") { containerHeight, _ ->
+      containerHeight * 0.6f
+    }
+    lateinit var state: ModalBottomSheetState
+
+    setContent {
+      state = rememberModalBottomSheetState(
+        initialDetent = peek,
+        detents = listOf(SheetDetent.Hidden, peek, SheetDetent.FullyExpanded),
+      )
+      UnstyledModalBottomSheet(
+        state = state,
+        enabled = false,
+        overlay = {
+          Scrim(Modifier.testTag("scrim"))
+        },
+      ) {
+        Sheet { Box(Modifier.testTag("sheet").size(400.dp)) }
+      }
+    }
+    onNodeWithTag("sheet").assertIsDisplayed()
+
+    val initialOffset = state.offset
+
+    onNodeWithTag("sheet").performTouchInput {
+      swipeDown()
+    }
+    waitForIdle()
+
+    assertThat(state.currentDetent).isEqualTo(peek)
+    assertThat(state.offset).isEqualTo(initialOffset)
+  }
+
+  @Test
   fun sheet_can_be_shown_again_when_caller_observes_that_it_settled_at_hidden() = runComposeUiTest {
     val peek = SheetDetent("peek") { containerHeight, _ ->
       containerHeight * 0.6f


### PR DESCRIPTION
## Summary

Expose `enabled` on `UnstyledModalBottomSheet` and forward it to the underlying `UnstyledBottomSheet`, so callers can disable sheet dragging for modal sheets.

The issue was true: modal sheets always used the underlying bottom sheet default `enabled = true`, even though regular bottom sheets already exposed this control.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed

Ran:

```
./gradlew :composeunstyled-modal-bottom-sheet:jvmTest --tests 'com.composeunstyled.ModalBottomSheetTest.setting_enabled_to_false_blocks_sheet_dragging'\n./gradlew jvmTest spotlessCheck\n```\n\n## Related Issues\n\nCloses #477\n\n## Screenshots/Videos\n\nNot applicable.