### PR TITLE
Fix dialog panels skipping enter transitions

### DIFF
--- a/.changeset/fix-dialog-enter-transition.md
+++ b/.changeset/fix-dialog-enter-transition.md
@@ -1,0 +1,5 @@
+---
+"compose-unstyled": patch
+---
+
+Fix dialog panels skipping their enter transition when shown.

--- a/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
+++ b/composeunstyled-dialog/src/commonMain/kotlin/com/composeunstyled/Dialog.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
@@ -76,8 +77,10 @@ fun DialogOverlayScope.Scrim(
   exit: ExitTransition = ExitTransition.None,
 ) {
   val state = LocalModalState.current
+  val visible = rememberModalFragmentVisibility(state)
+
   AnimatedVisibility(
-    visible = state.transitionState.targetState,
+    visible = visible,
     enter = enter,
     exit = exit,
   ) {
@@ -152,10 +155,11 @@ fun DialogScope.DialogPanel(
   content: @Composable () -> Unit,
 ) {
   val modalState = LocalModalState.current
+  val visible = rememberModalFragmentVisibility(modalState)
   val panelFocusRequester = remember { FocusRequester() }
 
   AnimatedVisibility(
-    visible = modalState.transitionState.targetState,
+    visible = visible,
     enter = enter,
     exit = exit,
   ) {
@@ -180,5 +184,18 @@ fun DialogScope.DialogPanel(
     ) {
       content()
     }
+  }
+}
+
+@Composable
+private fun rememberModalFragmentVisibility(modalState: ModalState): Boolean {
+  val hasComposed = remember { mutableStateOf(false) }
+  SideEffect {
+    hasComposed.value = true
+  }
+  return if (hasComposed.value) {
+    modalState.transitionState.targetState
+  } else {
+    modalState.transitionState.currentState
   }
 }

--- a/composeunstyled-dialog/src/jvmTest/kotlin/DialogJvmTest.kt
+++ b/composeunstyled-dialog/src/jvmTest/kotlin/DialogJvmTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Composable Horizons
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.composeunstyled
+
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import kotlin.test.Test
+
+class DialogJvmTest {
+
+  @Test
+  fun dialogPanelRunsEnterTransitionWhenShown() = runComposeUiTest {
+    var visible by mutableStateOf(false)
+
+    setContent {
+      UnstyledDialog(
+        visible = visible,
+        onDismissRequest = { visible = false },
+      ) {
+        Box(
+          modifier = Modifier.fillMaxSize(),
+          contentAlignment = Alignment.Center,
+        ) {
+          DialogPanel(
+            modifier = Modifier
+              .size(100.dp)
+              .testTag("dialog_content"),
+            enter = slideInVertically(
+              animationSpec = tween(durationMillis = 10_000),
+              initialOffsetY = { it },
+            ),
+          ) {
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    mainClock.autoAdvance = false
+    try {
+      visible = true
+      mainClock.advanceTimeByFrame()
+      waitUntilExactlyOneExists(hasTestTag("dialog_content"))
+
+      val enteringTop = onNodeWithTag("dialog_content").fetchSemanticsNode().boundsInRoot.top
+
+      mainClock.advanceTimeBy(10_000)
+      val restingTop = onNodeWithTag("dialog_content").fetchSemanticsNode().boundsInRoot.top
+
+      assertThat(enteringTop).isGreaterThan(restingTop)
+    } finally {
+      mainClock.autoAdvance = true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes dialog panels so their provided enter transition runs when a hidden dialog becomes visible.

The regression came from composing dialog fragments for the first time after the modal target state was already visible. The panel then entered `AnimatedVisibility` at its final visible state. Dialog fragments now use the modal current state only for their first composition, then follow the modal target state directly.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Ran:

```sh
./gradlew :composeunstyled-dialog:jvmTest --tests 'com.composeunstyled.DialogTest.dialogPanelRunsEnterTransitionWhenShown' --tests 'com.composeunstyled.DialogTest.scrimWithoutTransitionsDoesNotSkipPanelExitTransition' --console=plain
./gradlew jvmTest --console=plain
./gradlew spotlessCheck --console=plain
```

## Manual QA

- Platform/device: Not manually tested
- Setup: N/A
- Steps:
  1. N/A
  2. N/A
  3. N/A
- Expected result: Dialog panels run their enter transition when shown.
- Known limitations: The regression is covered by a deterministic JVM Compose UI test, not visual/video regression coverage.

## Related Issues

Closes #476

## Screenshots/Videos

N/A
