### PR TITLE
Report release timeouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,20 @@ jobs:
 
   report-failure:
     needs: [ spotless-check, desktop-tests, screenshot-tests, discover-android-modules, android-tests, demo-apk, publish, github-release ]
-    if: ${{ always() && (needs.spotless-check.result == 'failure' || needs.desktop-tests.result == 'failure' || needs.screenshot-tests.result == 'failure' || needs.discover-android-modules.result == 'failure' || needs.android-tests.result == 'failure' || needs.demo-apk.result == 'failure' || needs.publish.result == 'failure' || needs.github-release.result == 'failure') }}
+    if: >-
+      ${{
+        always() &&
+        (
+          contains(fromJson('["failure","cancelled"]'), needs.spotless-check.result) ||
+          contains(fromJson('["failure","cancelled"]'), needs.desktop-tests.result) ||
+          contains(fromJson('["failure","cancelled"]'), needs.screenshot-tests.result) ||
+          contains(fromJson('["failure","cancelled"]'), needs.discover-android-modules.result) ||
+          contains(fromJson('["failure","cancelled"]'), needs.android-tests.result) ||
+          contains(fromJson('["failure","cancelled"]'), needs.demo-apk.result) ||
+          contains(fromJson('["failure","cancelled"]'), needs.publish.result) ||
+          contains(fromJson('["failure","cancelled"]'), needs.github-release.result)
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Open GitHub issue
@@ -319,6 +332,37 @@ jobs:
               'publish': '${{ needs.publish.result }}',
               'github-release': '${{ needs.github-release.result }}',
             };
+            const failedJobs = Object.entries(results).filter(([, result]) => result === 'failure');
+
+            const { data: workflowRun } = await github.rest.actions.getWorkflowRun({
+              owner,
+              repo,
+              run_id: context.runId,
+            });
+            if (workflowRun.canceling_actor) {
+              core.info(`Release run was cancelled by ${workflowRun.canceling_actor.login}; skipping failure issue.`);
+              return;
+            }
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner,
+              repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const timeoutThresholdMs = 59 * 60 * 1000;
+            const timedOutJobs = jobs.filter(job => {
+              if (job.conclusion !== 'cancelled' || !job.started_at || !job.completed_at) return false;
+
+              const startedAt = new Date(job.started_at).getTime();
+              const completedAt = new Date(job.completed_at).getTime();
+              return completedAt - startedAt >= timeoutThresholdMs;
+            });
+
+            if (failedJobs.length === 0 && timedOutJobs.length === 0) {
+              core.info('No failed jobs or timeout-cancelled jobs found; skipping failure issue.');
+              return;
+            }
 
             const body = [
               `Release failed for \`${releaseRef}\`.`,
@@ -327,6 +371,11 @@ jobs:
               '',
               'Job results:',
               ...Object.entries(results).map(([job, result]) => `- \`${job}\`: ${result}`),
+              ...(timedOutJobs.length > 0 ? [
+                '',
+                'Timed out jobs:',
+                ...timedOutJobs.map(job => `- \`${job.name}\``),
+              ] : []),
               '',
               'Please inspect the failed job logs and rerun the release once the issue is fixed.',
             ].join('\n');


### PR DESCRIPTION
## Summary

Update the release failure reporter so timeout-cancelled release jobs still open a `release-failure` issue, while manually cancelled release runs are ignored.

The missed 2.9.0 release had Android matrix jobs cancelled at the workflow timeout, which made `publish` and `github-release` skip without creating the expected failure issue.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

Validated locally:

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- Replayed the timeout detection logic against release run `29721677957`; it identified `outline-android-tests` and `tab-group-android-tests`.

## Manual QA

- Platform/device: GitHub Actions release workflow
- Setup: A release workflow run with a job cancelled by timeout and no `canceling_actor`
- Steps:
  1. Trigger or inspect a release workflow run where a required job times out.
  2. Let the `report-failure` job evaluate the workflow run jobs.
  3. Confirm manual cancellations still have `canceling_actor` and return early.
- Expected result: timeout-cancelled jobs open or update a `release-failure` issue; manually cancelled runs do not.
- Known limitations: Timeout detection uses cancelled jobs with at least 59 minutes of runtime, matching the release workflow's 60-minute Android timeout.

## Related Issues

Related to #483.

## Screenshots/Videos

Not applicable.
