### PR TITLE
Retry Android AVD creation

### DIFF
--- a/.github/workflows/android-emulator-tests.yml
+++ b/.github/workflows/android-emulator-tests.yml
@@ -1,0 +1,126 @@
+name: Android Emulator Tests
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        description: Git ref to check out before running tests. Uses the workflow ref when omitted.
+        required: false
+        type: string
+        default: ''
+      module:
+        description: Module label used for the job name.
+        required: true
+        type: string
+      test-command:
+        description: Gradle command to run inside the Android emulator.
+        required: true
+        type: string
+      api-level:
+        description: Android API level for the emulator.
+        required: false
+        type: string
+        default: '23'
+      arch:
+        description: Android system image architecture.
+        required: false
+        type: string
+        default: x86_64
+      disk-size:
+        description: Emulator disk size.
+        required: false
+        type: string
+        default: 2048M
+
+jobs:
+  android-test:
+    name: ${{ inputs.module }}-android-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Enable Hardware Acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/checkout@v5
+        if: inputs.checkout-ref == ''
+
+      - uses: actions/checkout@v5
+        if: inputs.checkout-ref != ''
+        with:
+          ref: ${{ inputs.checkout-ref }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          token: ${{ github.token }}
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Restore AVD
+        uses: actions/cache@v5
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ inputs.api-level }}-${{ inputs.arch }}-${{ inputs.disk-size }}
+
+      - name: Create AVD
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        timeout-minutes: 8
+        continue-on-error: true
+        id: create-avd-first-attempt
+        with:
+          api-level: ${{ inputs.api-level }}
+          arch: ${{ inputs.arch }}
+          disk-size: ${{ inputs.disk-size }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Create AVD retry 1
+        if: steps.avd-cache.outputs.cache-hit != 'true' && steps.create-avd-first-attempt.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        timeout-minutes: 8
+        continue-on-error: true
+        id: create-avd-second-attempt
+        with:
+          api-level: ${{ inputs.api-level }}
+          arch: ${{ inputs.arch }}
+          disk-size: ${{ inputs.disk-size }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Create AVD retry 2
+        if: steps.avd-cache.outputs.cache-hit != 'true' && steps.create-avd-second-attempt.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        timeout-minutes: 8
+        id: create-avd-third-attempt
+        with:
+          api-level: ${{ inputs.api-level }}
+          arch: ${{ inputs.arch }}
+          disk-size: ${{ inputs.disk-size }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Android Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ inputs.api-level }}
+          arch: ${{ inputs.arch }}
+          disk-size: ${{ inputs.disk-size }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ${{ inputs.test-command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,61 +170,10 @@ jobs:
     name: ${{ matrix.module }}-android-tests
     needs: [ discover-android-modules, fast-checks ]
     if: needs.discover-android-modules.outputs.android_modules != '[]'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      API_LEVEL: 23
-      ARCH: x86_64
-      DISK_SIZE: 2048M
     strategy:
       matrix:
         module: ${{ fromJson(needs.discover-android-modules.outputs.android_modules) }}
-    steps:
-      - name: Enable Hardware Acceleration
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-          token: ${{ github.token }}
-
-      - uses: actions/checkout@v5
-
-      - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Restore AVD
-        uses: actions/cache@v5
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}-${{ env.ARCH }}-${{ env.DISK_SIZE }}
-
-      - name: Create AVD
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          arch: ${{ env.ARCH }}
-          disk-size: ${{ env.DISK_SIZE }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: Android Tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          arch: ${{ env.ARCH }}
-          disk-size: ${{ env.DISK_SIZE }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew --console=plain ${{ matrix.module }}:connectedDebugAndroidTest
+    uses: ./.github/workflows/android-emulator-tests.yml
+    with:
+      module: ${{ matrix.module }}
+      test-command: ./gradlew --console=plain ${{ matrix.module }}:connectedDebugAndroidTest

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -92,61 +92,14 @@ jobs:
   android-tests:
     name: ${{ matrix.module }}-android-tests
     needs: discover-android-modules
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         module: ${{ fromJson(needs.discover-android-modules.outputs.modules) }}
-    steps:
-      - name: Enable Hardware Acceleration
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-          token: ${{ github.token }}
-
-      - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Restore AVD
-        uses: actions/cache@v5
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}-${{ env.ARCH }}-${{ env.DISK_SIZE }}
-
-      - name: Create AVD
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          arch: ${{ env.ARCH }}
-          disk-size: ${{ env.DISK_SIZE }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: Android Tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          arch: ${{ env.ARCH }}
-          disk-size: ${{ env.DISK_SIZE }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew --console=plain ${{ matrix.module }}:connectedDebugAndroidTest
+    uses: ./.github/workflows/android-emulator-tests.yml
+    with:
+      module: ${{ matrix.module }}
+      test-command: ./gradlew --console=plain ${{ matrix.module }}:connectedDebugAndroidTest
 
   report-failure:
     needs: [ jvm-and-assemble, screenshot-tests, discover-android-modules, android-tests ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,65 +114,14 @@ jobs:
   android-tests:
     name: ${{ matrix.module }}-android-tests
     needs: discover-android-modules
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      API_LEVEL: 23
-      ARCH: x86_64
-      DISK_SIZE: 2048M
     strategy:
       matrix:
         module: ${{ fromJson(needs.discover-android-modules.outputs.modules) }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ env.RELEASE_REF }}
-      - uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-          token: ${{ github.token }}
-
-      - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Create AVD
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          arch: ${{ env.ARCH }}
-          disk-size: ${{ env.DISK_SIZE }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: Enable Hardware Acceleration
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: AVD cache
-        uses: actions/cache@v5
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}-${{ env.ARCH }}-${{ env.DISK_SIZE }}
-
-      - name: Android Tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          arch: ${{ env.ARCH }}
-          disk-size: ${{ env.DISK_SIZE }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: ./gradlew --console=plain :composeunstyled-${{ matrix.module }}:connectedDebugAndroidTest
+    uses: ./.github/workflows/android-emulator-tests.yml
+    with:
+      checkout-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      module: ${{ matrix.module }}
+      test-command: ./gradlew --console=plain :composeunstyled-${{ matrix.module }}:connectedDebugAndroidTest
 
   demo-apk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Move Android emulator setup into a reusable workflow used by PR, nightly, and release Android test jobs.

The shared workflow restores the AVD cache before creating an emulator and retries uncached AVD creation up to two times after the first attempt, with each creation attempt capped at 8 minutes. This avoids waiting for the full 60-minute job timeout when emulator creation hangs.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

Validated locally:

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "#{f} ok" }'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `git diff --check origin/main...HEAD`

## Manual QA

- Platform/device: GitHub Actions Android emulator jobs
- Setup: PR checks, nightly checks, or release workflow with Android matrix jobs
- Steps:
  1. Run any workflow that executes Android emulator tests.
  2. Confirm the matrix job calls `android-emulator-tests.yml`.
  3. On AVD cache miss, confirm AVD creation has up to three 8-minute attempts.
  4. Confirm Android tests still run through `reactivecircus/android-emulator-runner` after setup.
- Expected result: emulator setup is shared, cache is restored before creation, and hung AVD creation fails fast enough to retry.
- Known limitations: The actual connected Android tests are still allowed to run under the existing 60-minute job timeout.

## Related Issues

Related to #483.

## Screenshots/Videos

Not applicable.
