### PR TITLE
Run nightly checks at 21:00 UTC

### DIFF
--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -2,7 +2,7 @@ name: Nightly Checks
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 21 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Moves the nightly checks schedule from 02:00 UTC to 21:00 UTC.

## Test Plan

- [ ] Tests added/updated
- [ ] Manual testing performed

No tests run; this only changes the GitHub Actions cron schedule.

## Manual QA

- Platform/device: GitHub Actions
- Setup: Nightly Checks workflow
- Steps:
  1. Inspect `.github/workflows/nightly-checks.yml`.
  2. Confirm the scheduled cron is `0 21 * * *`.
- Expected result: Nightly checks are scheduled for 21:00 UTC.
- Known limitations: The next scheduled run must occur on GitHub Actions to verify actual dispatch timing.

## Related Issues

N/A

## Screenshots/Videos

N/A
