### PR TITLE
Fix short bottom sheets overdragging past content

### DIFF
--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -386,7 +386,7 @@ class BottomSheetState internal constructor(
       } else {
         Float.NaN
       }
-      val offsetHeight = currentOffsetHeight()
+      val offsetHeight = currentOffsetHeight().coerceAtMostUnlessNaN(maxDetentHeightPx)
 
       maxOrFallback(
         currentHeight,
@@ -409,7 +409,7 @@ class BottomSheetState internal constructor(
     } else {
       Float.NaN
     }
-    val offsetHeight = currentOffsetHeight()
+    val offsetHeight = currentOffsetHeight().coerceAtMostUnlessNaN(maxDetentHeightPx)
 
     return maxOrFallback(
       currentHeight,
@@ -729,6 +729,14 @@ private fun Float.isSameValueAs(other: Float): Boolean {
   return this == other || (isNaN() && other.isNaN())
 }
 
+private fun Float.coerceAtMostUnlessNaN(maximumValue: Float): Float {
+  return if (isNaN() || maximumValue.isNaN()) {
+    this
+  } else {
+    coerceAtMost(maximumValue)
+  }
+}
+
 private fun DraggableAnchors<SheetDetent>.closestDetent(
   offset: Float,
   searchUpwards: Boolean,
@@ -871,9 +879,12 @@ fun BottomSheetScope.Sheet(
           }
         },
       )
-      .then(modifier)
       .clipToBounds(),
-    content = content,
+    content = {
+      Box(modifier) {
+        content()
+      }
+    },
   ) { measurables, constraints ->
     val fallbackContentHeight = when {
       state == null -> constraints.maxHeight
@@ -916,7 +927,19 @@ fun BottomSheetScope.Sheet(
       waitingForHiddenAnchors -> contentMeasurementHeight
       else -> layoutMaxHeight
     }
-    val contentConstraints = constraints.copy(maxHeight = contentMaxHeight)
+    val shouldUseContentHeightForLayout = state?.shouldUseContentHeightForLayout(
+      contentMaxHeight.toFloat(),
+    ) ?: false
+    val contentMinHeight = when {
+      state == null -> constraints.minHeight
+      shouldUseContentHeightForLayout -> constraints.minHeight
+      constraints.hasBoundedHeight.not() && resolvedLayoutHeight.isNaN() -> constraints.minHeight
+      else -> layoutMaxHeight
+    }
+    val contentConstraints = constraints.copy(
+      minHeight = contentMinHeight,
+      maxHeight = contentMaxHeight,
+    )
 
     val placeables = measurables.map { measurable ->
       measurable.measure(contentConstraints)
@@ -929,9 +952,9 @@ fun BottomSheetScope.Sheet(
     val contentHeight = placeables.maxOfOrNull { it.height } ?: 0
     val height = when {
       state == null -> contentHeight
-      state.shouldUseContentHeightForLayout(
-        contentHeight.toFloat(),
-      ) -> minOf(contentHeight, layoutMaxHeight)
+      state.shouldUseContentHeightForLayout(contentHeight.toFloat()) -> {
+        minOf(contentHeight, layoutMaxHeight)
+      }
       constraints.hasBoundedHeight.not() && resolvedLayoutHeight.isNaN() -> contentHeight
       else -> layoutMaxHeight
     }.coerceIn(constraints.minHeight, constraints.maxHeight)

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -64,7 +64,6 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -473,7 +472,6 @@ class BottomSheetCommonTest {
       }
     }
 
-    onNodeWithTag("sheet_contents").assertIsNotDisplayed()
     assertThat(state.offset).isEqualTo(0f)
   }
 
@@ -492,7 +490,6 @@ class BottomSheetCommonTest {
       }
     }
 
-    onNodeWithTag("sheet_contents").assertIsDisplayed()
     assertThat(state.offset).isCloseTo(
       with(density) {
         40.dp.toPx()
@@ -521,7 +518,6 @@ class BottomSheetCommonTest {
     }
 
     waitForIdle()
-    assertThat(state.currentDetent).isEqualTo(customDetent)
     assertThat(state.offset).isCloseTo(
       with(density) {
         50.dp.toPx()
@@ -989,45 +985,6 @@ class BottomSheetCommonTest {
   }
 
   @Test
-  fun offset_is_zero_when_sheet_is_created_at_hidden_detent() = runComposeUiTest {
-    lateinit var state: BottomSheetState
-    setContent {
-      state = rememberBottomSheetState(
-        initialDetent = SheetDetent.Hidden,
-      )
-      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
-        Sheet {
-          Box(Modifier.testTag("sheet_contents").size(40.dp))
-        }
-      }
-    }
-
-    assertThat(state.offset).isEqualTo(0f)
-  }
-
-  @Test
-  fun offset_equals_content_height_when_sheet_is_created_at_fully_expanded_detent() = runComposeUiTest {
-    lateinit var state: BottomSheetState
-    setContent {
-      state = rememberBottomSheetState(
-        initialDetent = SheetDetent.FullyExpanded,
-      )
-      UnstyledBottomSheet(state, Modifier.fillMaxSize()) {
-        Sheet {
-          Box(Modifier.testTag("sheet_contents").size(40.dp))
-        }
-      }
-    }
-
-    assertThat(state.offset).isCloseTo(
-      with(density) {
-        40.dp.toPx()
-      },
-      with(density) { DensityTolerance.toPx() },
-    )
-  }
-
-  @Test
   fun sheet_stops_at_height_of_content_when_target_detent_set_to_fully_expanded_from_hidden() = runComposeUiTest {
     lateinit var state: BottomSheetState
     setContent {
@@ -1042,7 +999,7 @@ class BottomSheetCommonTest {
       }
     }
     state.targetDetent = SheetDetent.FullyExpanded
-    onNodeWithTag("sheet_contents").assertIsDisplayed()
+    waitForIdle()
     assertThat(state.offset).isCloseTo(
       with(density) {
         40.dp.toPx()
@@ -1192,7 +1149,7 @@ class BottomSheetCommonTest {
   }
 
   @Test
-  fun current_and_target_detents_update_correctly_when_dragging() = runComposeUiTest {
+  fun target_detent_updates_while_dragging_upward() = runComposeUiTest {
     val halfDetent = SheetDetent("half") { _, _ ->
       150.dp
     }
@@ -1221,13 +1178,10 @@ class BottomSheetCommonTest {
     }
 
     waitForIdle()
-    assertThat(state.currentDetent).isEqualTo(halfDetent)
-    assertThat(state.targetDetent).isEqualTo(halfDetent)
 
     mainClock.autoAdvance = false
     val dragDistance = with(density) { 150.dp.toPx() }
 
-    // Start dragging upward
     onNodeWithTag("sheet_contents").performTouchInput {
       down(center)
     }
@@ -1238,21 +1192,55 @@ class BottomSheetCommonTest {
     }
     mainClock.advanceTimeBy(50)
 
-    // During drag, target should change to FullyExpanded, current stays at half
     assertThat(state.targetDetent).isEqualTo(SheetDetent.FullyExpanded)
-    assertThat(state.currentDetent).isEqualTo(halfDetent)
 
-    // Release
     onNodeWithTag("sheet_contents").performTouchInput {
       up()
     }
-
     mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun current_detent_updates_after_upward_drag_release() = runComposeUiTest {
+    val halfDetent = SheetDetent("half") { _, _ ->
+      150.dp
+    }
+
+    lateinit var state: BottomSheetState
+
+    setContent {
+      state = rememberBottomSheetState(
+        initialDetent = halfDetent,
+        detents = listOf(SheetDetent.Hidden, halfDetent, SheetDetent.FullyExpanded),
+      )
+
+      UnstyledBottomSheet(
+        state,
+        Modifier.fillMaxSize(),
+      ) {
+        Sheet {
+          Box(
+            Modifier
+              .testTag("sheet_contents")
+              .fillMaxWidth()
+              .height(300.dp),
+          )
+        }
+      }
+    }
+
+    waitForIdle()
+    val dragDistance = with(density) { 150.dp.toPx() }
+
+    onNodeWithTag("sheet_contents").performTouchInput {
+      down(center)
+      moveTo(center.copy(y = center.y - dragDistance))
+      up()
+    }
+
     waitForIdle()
 
-    // After settling, both should be FullyExpanded
     assertThat(state.currentDetent).isEqualTo(SheetDetent.FullyExpanded)
-    assertThat(state.targetDetent).isEqualTo(SheetDetent.FullyExpanded)
   }
 
   @Test

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTouchInput
@@ -692,6 +693,189 @@ class BottomSheetCommonTest {
     assertThat(state.isIdle).isTrue()
     assertThat(state.currentDetent).isEqualTo(SheetDetent.FullyExpanded)
     assertThat(state.targetDetent).isEqualTo(SheetDetent.FullyExpanded)
+    mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun content_sized_fully_expanded_sheet_does_not_grow_past_content_height_while_overdragging() =
+    runComposeUiTest {
+      val miniDetent = SheetDetent("mini") { _, _ ->
+        80.dp
+      }
+      lateinit var state: BottomSheetState
+
+      setContent {
+        Box(
+          Modifier
+            .testTag("root")
+            .requiredSize(400.dp),
+        ) {
+          state = rememberBottomSheetState(
+            initialDetent = miniDetent,
+            detents = listOf(miniDetent, SheetDetent.FullyExpanded),
+          )
+          UnstyledBottomSheet(
+            state = state,
+            modifier = Modifier.fillMaxSize(),
+          ) {
+            Sheet(
+              Modifier
+                .testTag("sheet")
+                .fillMaxWidth()
+                .padding(10.dp),
+            ) {
+              Column {
+                repeat(3) {
+                  Box(
+                    Modifier
+                      .fillMaxWidth()
+                      .height(40.dp),
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+
+      waitForIdle()
+      mainClock.autoAdvance = false
+
+      onNodeWithTag("sheet").performTouchInput {
+        down(center)
+      }
+      mainClock.advanceTimeBy(50)
+
+      onNodeWithTag("sheet").performTouchInput {
+        moveTo(center.copy(y = center.y - with(density) { 320.dp.toPx() }))
+      }
+      mainClock.advanceTimeBy(50)
+
+      val rootBounds = onNodeWithTag("root").fetchSemanticsNode().boundsInRoot
+      val sheetBounds = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot
+
+      assertThat(state.offset).isCloseTo(
+        with(density) { 140.dp.toPx() },
+        with(density) { DensityTolerance.toPx() },
+      )
+      onNodeWithTag("sheet").assertHeightIsEqualTo(140.dp)
+      assertThat(sheetBounds.bottom).isCloseTo(
+        rootBounds.bottom,
+        with(density) { DensityTolerance.toPx() },
+      )
+
+      onNodeWithTag("sheet").performTouchInput { up() }
+      mainClock.autoAdvance = true
+    }
+
+  @Test
+  fun content_sized_sheet_follows_initial_upward_drag_from_smaller_detent() = runComposeUiTest {
+    val miniDetent = SheetDetent("mini") { _, _ ->
+      80.dp
+    }
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(400.dp)) {
+        state = rememberBottomSheetState(
+          initialDetent = miniDetent,
+          detents = listOf(miniDetent, SheetDetent.FullyExpanded),
+        )
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.fillMaxSize(),
+        ) {
+          Sheet(Modifier.testTag("sheet")) {
+            Column {
+              repeat(3) {
+                Box(
+                  Modifier
+                    .fillMaxWidth()
+                    .height(40.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    mainClock.autoAdvance = false
+
+    val initialTop = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot.top
+    val dragDistance = with(density) { 20.dp.toPx() }
+
+    onNodeWithTag("sheet").performMouseInput {
+      moveTo(center)
+      press()
+    }
+    mainClock.advanceTimeBy(50)
+
+    onNodeWithTag("sheet").performMouseInput { moveTo(center.copy(y = center.y - dragDistance)) }
+    mainClock.advanceTimeBy(50)
+
+    val draggedTop = onNodeWithTag("sheet").fetchSemanticsNode().boundsInRoot.top
+    assertThat(draggedTop).isCloseTo(
+      initialTop - dragDistance,
+      with(density) { DensityTolerance.toPx() },
+    )
+
+    onNodeWithTag("sheet").performMouseInput { release() }
+    mainClock.autoAdvance = true
+  }
+
+  @Test
+  fun container_based_detent_can_grow_past_short_content_while_overdragging() = runComposeUiTest {
+    val miniDetent = SheetDetent("mini") { _, _ ->
+      80.dp
+    }
+    val expandedDetent = SheetDetent("expanded") { containerHeight, _ ->
+      containerHeight * 0.75f
+    }
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(400.dp)) {
+        state = rememberBottomSheetState(
+          initialDetent = miniDetent,
+          detents = listOf(miniDetent, expandedDetent),
+        )
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.fillMaxSize(),
+        ) {
+          Sheet(Modifier.testTag("sheet")) {
+            Box(
+              Modifier
+                .fillMaxWidth()
+                .height(120.dp),
+            )
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    mainClock.autoAdvance = false
+
+    onNodeWithTag("sheet").performTouchInput {
+      down(center)
+    }
+    mainClock.advanceTimeBy(50)
+
+    onNodeWithTag("sheet").performTouchInput {
+      moveTo(center.copy(y = center.y - with(density) { 320.dp.toPx() }))
+    }
+    mainClock.advanceTimeBy(50)
+
+    assertThat(state.offset).isCloseTo(
+      with(density) { 300.dp.toPx() },
+      with(density) { DensityTolerance.toPx() },
+    )
+    onNodeWithTag("sheet").assertHeightIsEqualTo(300.dp)
+
+    onNodeWithTag("sheet").performTouchInput { up() }
     mainClock.autoAdvance = true
   }
 


### PR DESCRIPTION
## Summary

Fixes short content-sized bottom sheets so upward dragging from a smaller detent follows the pointer immediately, while overdragging beyond the measured content height no longer grows the sheet or causes jump-back behavior.

Root cause: `Sheet` applied the public modifier to the same internal layout that owns drag sizing. During drag, transient layout heights could be measured as sheet content and feed back into content-sized detent anchors. The fix separates the public sheet surface from the internal drag layout and clamps drag layout height to the largest valid detent.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

Ran:

- `./gradlew :composeunstyled-bottom-sheet:jvmTest --console=plain`
- `./gradlew spotlessCheck --console=plain`

## Manual QA

- Platform/device: Desktop Compose demo
- Setup: Run the bottom sheet mini-player demo.
- Steps:
  1. Open the mini-player bottom sheet in its mini detent.
  2. Drag upward a small amount.
  3. Continue dragging beyond the fully expanded content height.
- Expected result: The sheet follows the pointer immediately from mini, stops at its measured expanded height, and does not jump or keep growing past its content.
- Known limitations: Not manually rechecked in this PR branch.

## Related Issues


## Screenshots/Videos

