### PR TITLE
Fix bottom sheet content being squished when collapsed

### DIFF
--- a/.changeset/calm-bottom-sheets.md
+++ b/.changeset/calm-bottom-sheets.md
@@ -1,0 +1,5 @@
+---
+"compose-unstyled": patch
+---
+
+Fix bottom sheet content being squished when collapsed.

--- a/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
+++ b/composeunstyled-bottom-sheet/src/commonMain/kotlin/com/composeunstyled/BottomSheet.kt
@@ -78,6 +78,7 @@ import androidx.compose.ui.semantics.collapse
 import androidx.compose.ui.semantics.dismiss
 import androidx.compose.ui.semantics.expand
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -774,10 +775,14 @@ private fun DraggableAnchors<SheetDetent>.closestDetent(
 private class BottomSheetContext(
   internal val state: BottomSheetState? = null,
   enabled: Boolean = true,
+  measureContentBeyondContainerBounds: Boolean = false,
   internal val coroutineScope: CoroutineScope? = null,
   internal val dragInteractionSource: MutableInteractionSource? = null,
 ) {
   internal var enabled by mutableStateOf(enabled)
+  internal var measureContentBeyondContainerBounds by mutableStateOf(
+    measureContentBeyondContainerBounds,
+  )
 }
 
 private val LocalBottomSheetContext: ProvidableCompositionLocal<BottomSheetContext> =
@@ -793,6 +798,7 @@ fun UnstyledBottomSheet(
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
   offsetForIme: Boolean = false,
+  measureContentBeyondContainerBounds: Boolean = false,
   content: @Composable BottomSheetScope.() -> Unit,
 ) {
   val coroutineScope = rememberCoroutineScope()
@@ -801,11 +807,15 @@ fun UnstyledBottomSheet(
     BottomSheetContext(
       state = state,
       enabled = enabled,
+      measureContentBeyondContainerBounds = measureContentBeyondContainerBounds,
       coroutineScope = coroutineScope,
       dragInteractionSource = dragInteractionSource,
     )
   }
-  SideEffect { context.enabled = enabled }
+  SideEffect {
+    context.enabled = enabled
+    context.measureContentBeyondContainerBounds = measureContentBeyondContainerBounds
+  }
 
   LaunchedEffect(dragInteractionSource) {
     dragInteractionSource.interactions.collect { interaction ->
@@ -940,9 +950,17 @@ fun BottomSheetScope.Sheet(
       minHeight = contentMinHeight,
       maxHeight = contentMaxHeight,
     )
+    val preferredContentConstraints = if (
+      context.measureContentBeyondContainerBounds &&
+      state?.hasContentDependentDetents() == true
+    ) {
+      contentConstraints.copy(maxHeight = Constraints.Infinity)
+    } else {
+      contentConstraints
+    }
 
     val placeables = measurables.map { measurable ->
-      measurable.measure(contentConstraints)
+      measurable.measure(preferredContentConstraints)
     }
 
     val width = max(

--- a/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
+++ b/composeunstyled-bottom-sheet/src/commonTest/kotlin/BottomSheet.test.kt
@@ -876,6 +876,75 @@ class BottomSheetCommonTest {
   }
 
   @Test
+  fun content_sized_sheet_uses_container_bounds_for_content_measurement_by_default() = runComposeUiTest {
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(220.dp)) {
+        state = rememberBottomSheetState(
+          initialDetent = SheetDetent.FullyExpanded,
+          detents = listOf(SheetDetent.FullyExpanded),
+        )
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.fillMaxSize(),
+        ) {
+          Sheet {
+            Column {
+              repeat(6) {
+                Box(
+                  Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+
+    assertThat(state.contentHeightPx).isEqualTo(with(density) { 220.dp.toPx() })
+  }
+
+  @Test
+  fun content_sized_sheet_can_measure_content_beyond_container_bounds_when_enabled() = runComposeUiTest {
+    lateinit var state: BottomSheetState
+
+    setContent {
+      Box(Modifier.requiredSize(220.dp)) {
+        state = rememberBottomSheetState(
+          initialDetent = SheetDetent.FullyExpanded,
+          detents = listOf(SheetDetent.FullyExpanded),
+        )
+        UnstyledBottomSheet(
+          state = state,
+          modifier = Modifier.fillMaxSize(),
+          measureContentBeyondContainerBounds = true,
+        ) {
+          Sheet {
+            Column {
+              repeat(6) {
+                Box(
+                  Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+
+    assertThat(state.contentHeightPx).isEqualTo(with(density) { 288.dp.toPx() })
+  }
+
+  @Test
   fun fully_expanded_sheet_with_taller_percentage_detent_matches_changing_content_height() = runComposeUiTest {
     val peekDetent = SheetDetent("peek") { containerHeight, _ ->
       containerHeight * 0.6f


### PR DESCRIPTION
## Summary

- Adds coverage for bounded and opt-in bottom sheet content measurement.
- Adds `measureContentBeyondContainerBounds` so content-sized sheets can measure natural content height beyond the container when needed.
- Adds a patch changeset for the collapsed bottom sheet content fix.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

```bash
./gradlew jvmTest spotlessCheck --console=plain
npx @changesets/cli status --since=main
```

## Manual QA

- Platform/device: Not manually tested
- Setup: N/A
- Steps:
  1. N/A
- Expected result: N/A
- Known limitations: No manual UI QA in this PR; the demo changes were intentionally excluded.

## Related Issues

None

## Screenshots/Videos

Not included
