### PR TITLE
Add release note for short bottom sheet drags

### DIFF
--- a/.changeset/tidy-bottom-sheets.md
+++ b/.changeset/tidy-bottom-sheets.md
@@ -1,0 +1,5 @@
+---
+"compose-unstyled": patch
+---
+
+Fix content-sized bottom sheets so short sheets follow upward drags immediately and stop at their measured content height.


### PR DESCRIPTION
## Summary

Adds the missing patch changeset for #487 so the short content-sized bottom sheet drag fix is included in the next release notes and version bump.

## Test Plan

- [ ] Tests added/updated
- [ ] Manual testing performed

Ran:

- `npm ci`
- `npm exec changeset status`

## Manual QA

- Platform/device: N/A
- Setup: N/A
- Steps:
  1. N/A
- Expected result: The changeset is detected as a patch bump for `compose-unstyled`.
- Known limitations: No runtime behavior changed in this PR.

## Related Issues

- Follow-up for #487

## Screenshots/Videos

N/A
