### PR TITLE
Upgrade Compose Multiplatform to 1.12.0

### DIFF
--- a/.changeset/fix-desktop-accessibility.md
+++ b/.changeset/fix-desktop-accessibility.md
@@ -1,0 +1,5 @@
+---
+"compose-unstyled": patch
+---
+
+Upgrade Compose Multiplatform to 1.12.0 to prevent desktop accessibility crashes when opening modal content.

--- a/composeunstyled-dialog/src/jvmTest/kotlin/DialogJvmTest.kt
+++ b/composeunstyled-dialog/src/jvmTest/kotlin/DialogJvmTest.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
@@ -73,8 +73,10 @@ class DialogJvmTest {
     waitForIdle()
     mainClock.autoAdvance = false
     try {
-      visible = true
-      mainClock.advanceTimeByFrame()
+      runOnIdle { visible = true }
+      mainClock.advanceTimeUntil {
+        onAllNodes(hasTestTag("dialog_content")).fetchSemanticsNodes().isNotEmpty()
+      }
       waitUntilExactlyOneExists(hasTestTag("dialog_content"))
 
       val enteringTop = onNodeWithTag("dialog_content").fetchSemanticsNode().boundsInRoot.top

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 unstyled = "2.9.0"
 
 kotlin = "2.4.0"
-compose = "1.11.1"
+compose = "1.12.0"
 compose-material3 = "1.11.0-alpha01"
 composeUriPainter = "1.1.0"
 


### PR DESCRIPTION
## Summary

- upgrade Compose Multiplatform from 1.11.1 to 1.12.0
- adapt the desktop dialog transition test to Compose 1.12 queued scheduling
- add a patch changeset for the dependency upgrade

This upgrade is needed for the specific desktop crash seen when starting the drawer form. Compose 1.12.0 includes the upstream fix that guards against a null accessible child in `ComposeSceneAccessibility.defaultAccessibilityFocusTarget`; in Compose 1.11.1 that path throws a `NullPointerException` while accessibility focus is being resolved.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed
- `./gradlew --console=plain jvmTest :demo:jvmTest spotlessCheck`

## Manual QA

- Platform/device: macOS desktop
- Setup: launch the demo with `dev unstyled`
- Steps:
  1. Open the drawer form demo.
  2. Start the drawer form.
- Expected result: The drawer opens without the desktop accessibility `NullPointerException`.
- Known limitations: Compose reports that Coil 3.5.0 declares an older Skiko version, which dependency resolution overrides to the Skiko version used by Compose 1.12.0. No newer `compose-uri-painter` release is available; JVM compilation and tests pass with the resolved version.

## Related Issues

None.

## Screenshots/Videos

Not applicable.