### PR TITLE
Fix modal content missing from Compose previews

### DIFF
--- a/.changeset/fix-modal-preview-content.md
+++ b/.changeset/fix-modal-preview-content.md
@@ -1,0 +1,5 @@
+---
+"compose-unstyled": patch
+---
+
+Fix modal content not rendering in Compose previews and preview screenshot tests.

--- a/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
+++ b/composeunstyled-modal/src/androidMain/kotlin/com/composeunstyled/Modal.android.kt
@@ -91,15 +91,7 @@ internal actual fun PlatformModal(
               LocalModalWindow provides localWindow,
               LocalLayoutDirection provides layoutDirection,
             ) {
-              DisposableEffect(state) {
-                state.attachedToWindow = true
-                onDispose {
-                  state.attachedToWindow = false
-                }
-              }
-              if (state.attachedToWindow) {
-                ModalScopeInstance.content()
-              }
+              ModalScopeContent(state = state, content = content)
             }
           }
         }

--- a/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
+++ b/composeunstyled-modal/src/commonMain/kotlin/com/composeunstyled/Modal.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
 import kotlinx.coroutines.flow.first
@@ -149,16 +150,24 @@ internal fun ModalContent(
       .semantics { dialog() },
   ) {
     CompositionLocalProvider(LocalModalState provides state) {
-      DisposableEffect(state) {
-        state.attachedToWindow = true
-        onDispose {
-          state.attachedToWindow = false
-        }
-      }
-      if (state.attachedToWindow) {
-        ModalScopeInstance.content()
-      }
+      ModalScopeContent(state = state, content = content)
     }
+  }
+}
+
+@Composable
+internal fun ModalScopeContent(
+  state: ModalState,
+  content: @Composable ModalScope.() -> Unit,
+) {
+  DisposableEffect(state) {
+    state.attachedToWindow = true
+    onDispose {
+      state.attachedToWindow = false
+    }
+  }
+  if (state.attachedToWindow || LocalInspectionMode.current) {
+    ModalScopeInstance.content()
   }
 }
 

--- a/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
+++ b/composeunstyled-modal/src/commonTest/kotlin/Modal.test.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertTextEquals
@@ -89,6 +90,29 @@ class ModalTest {
     }
 
     onNodeWithTag("modal_host").assertExists()
+    onNodeWithTag("modal_content").assertExists()
+  }
+
+  @Test
+  fun inspection_mode_renders_content_without_window_attachment() = runComposeUiTest {
+    lateinit var state: ModalState
+
+    setContent {
+      state = rememberModalState(initiallyVisible = true)
+      CompositionLocalProvider(LocalInspectionMode provides true) {
+        ModalHost {
+          Modal(state = state) {
+            Box(Modifier.testTag("modal_content"))
+          }
+        }
+      }
+    }
+
+    waitForIdle()
+    runOnIdle {
+      state.attachedToWindow = false
+    }
+
     onNodeWithTag("modal_content").assertExists()
   }
 

--- a/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
+++ b/composeunstyled-modal/src/nonAndroidMain/kotlin/com/composeunstyled/Modal.nonAndroid.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -55,15 +54,7 @@ internal actual fun PlatformModal(
     content = {
       CompositionLocalProvider(LocalModalState provides state) {
         Box(Modifier.fillMaxSize().onKeyEvent(onKeyEvent)) {
-          DisposableEffect(state) {
-            state.attachedToWindow = true
-            onDispose {
-              state.attachedToWindow = false
-            }
-          }
-          if (state.attachedToWindow) {
-            ModalScopeInstance.content()
-          }
+          ModalScopeContent(state = state, content = content)
         }
       }
     },


### PR DESCRIPTION
## Summary

- Render modal content immediately in Compose inspection mode while preserving attachment-aware runtime transitions.
- Share the attachment and inspection behavior across platform dialogs and hosted modals.
- Add common test coverage and a patch changeset.

## Test Plan

- [x] Tests added/updated
- [x] Manual testing performed

- `./gradlew :composeunstyled-modal:jvmTest`
- `./gradlew :composeunstyled-modal:compileDebugKotlinAndroid`
- `./gradlew jvmTest spotlessCheck`

## Manual QA

- Platform/device: AGP Compose Preview Screenshot Testing renderer 0.0.1-alpha16
- Setup: Isolated Android preview using Compose Unstyled 2.0.0, 2.1.0, and 2.9.0
- Steps:
  1. Render an initially expanded modal bottom sheet containing a colored text panel.
  2. Compare renderer output before and after the attachment gate was introduced.
- Expected result: Inspection-mode modal content renders without waiting for an effect-driven attachment recomposition.
- Known limitations: The repository test simulates inspection mode through the existing Compose UI test harness instead of adding the AGP screenshot-testing dependency.

## Related Issues

Closes #499

## Screenshots/Videos

Not applicable; regression coverage asserts that modal semantics content remains present in inspection mode.