### PR TITLE
Fix Android builds with Compose Multiplatform 1.12

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,9 @@ org.jetbrains.compose.experimental.wasm.enabled=true
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+# Preserve the existing KMP Android variants until the Android-KMP plugin migration.
+android.builtInKotlin=false
+android.newDsl=false
 #Publishing
 # These can be overridden by local.properties or environment variables
 mavenCentralUsername=

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,9 @@ ripple = "1.1.0"
 window = "1.4.0"
 
 # Android
-android-compileSDK = "36"
+android-compileSDK = "37"
 android-minSDK = "23"
-agp = "8.13.2"
+agp = "9.1.1"
 
 # testing
 assertk = "0.28.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Sat Oct 25 17:30:00 ICT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- upgrade Android Gradle Plugin to 9.1.1, Gradle to 9.3.1, and compile SDK to 37 as required by Compose Android 1.12
- preserve the existing KMP Android variants through AGP's temporary compatibility mode

## Test Plan

- [ ] Tests added/updated — build-tool compatibility is covered by the existing build and instrumentation suites
- [x] Manual testing performed
- `ORG_GRADLE_JVMARGS='-Xmx6g -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8' ./gradlew --console=plain --no-daemon --max-workers=4 jvmTest spotlessCheck :demo:assembleDebug`
- `ORG_GRADLE_JVMARGS='-Xmx6g -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8' ./gradlew --console=plain --no-daemon --max-workers=4 :composeunstyled-modal:connectedDebugAndroidTest`
- [full Nightly Checks on this branch](https://github.com/composablehorizons/compose-unstyled/actions/runs/33063946947): all 35 Android module jobs passed; the independent `tabgroup-demo` screenshot mismatch remained the only failure

## Manual QA

- Platform/device: macOS; `Unstyled_Tests` Android 6.0 / API 23 emulator
- Setup: launch the repository-owned Android test AVD
- Steps:
  1. Run `:composeunstyled-modal:connectedDebugAndroidTest`.
  2. Build the Android demo application.
- Expected result: Compose 1.12 Android dependencies pass AAR metadata validation, all 11 modal instrumentation tests pass, and the demo APK builds.
- Known limitations: `android.builtInKotlin=false` and `android.newDsl=false` are temporary AGP 9 compatibility flags. A dedicated Android-KMP plugin migration is required before AGP 10. The independent `tabgroup-demo` screenshot mismatch seen in the manual nightly run is outside this PR.

## Related Issues

- Related to #497; this addresses the Compose 1.12 Android toolchain failure without closing the generic nightly-failure issue.
- Baseline run on `main`: https://github.com/composablehorizons/compose-unstyled/actions/runs/33061985646

## Screenshots/Videos

Not applicable.
