### PR TITLE
Generate release notes from Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": false,
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,55 @@ env:
   RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.RELEASE_REF }}
+          fetch-depth: 0
+
+      - name: Validate release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release ref must be a plain semantic version, got: $RELEASE_REF"
+            exit 1
+          fi
+
+          if ! git show-ref --verify --quiet "refs/tags/$RELEASE_REF"; then
+            echo "Release ref is not a tag: $RELEASE_REF"
+            exit 1
+          fi
+
+          package_version="$(jq -r '.version' package.json)"
+          lock_version="$(jq -r '.version' package-lock.json)"
+          lock_root_version="$(jq -r '.packages[""].version' package-lock.json)"
+          gradle_version="$(awk -F'"' '/^unstyled = / { print $2; exit }' gradle/libs.versions.toml)"
+
+          declare -A versions=(
+            [package.json]="$package_version"
+            [package-lock.json]="$lock_version"
+            [package-lock-root]="$lock_root_version"
+            [gradle-version-catalog]="$gradle_version"
+          )
+
+          for source in "${!versions[@]}"; do
+            if [ "${versions[$source]}" != "$RELEASE_REF" ]; then
+              echo "$source has version ${versions[$source]}, expected $RELEASE_REF."
+              exit 1
+            fi
+          done
+
+          if ! grep -Fqx "## $RELEASE_REF" CHANGELOG.md; then
+            echo "CHANGELOG.md has no release section for $RELEASE_REF."
+            exit 1
+          fi
+
   spotless-check:
+    needs: validate-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -38,6 +86,7 @@ jobs:
         run: ./gradlew --console=plain spotlessCheck
 
   desktop-tests:
+    needs: validate-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -56,6 +105,7 @@ jobs:
         run: ./gradlew --console=plain jvmTest :demo:jvmTest
 
   screenshot-tests:
+    needs: validate-release
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
@@ -74,6 +124,7 @@ jobs:
         run: ./gradlew --console=plain :visual-regressions:jvmScreenshotTest
 
   discover-android-modules:
+    needs: validate-release
     runs-on: ubuntu-latest
     outputs:
       modules: ${{ steps.discover.outputs.modules }}
@@ -124,6 +175,7 @@ jobs:
       test-command: ./gradlew --console=plain :composeunstyled-${{ matrix.module }}:connectedDebugAndroidTest
 
   demo-apk:
+    needs: validate-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -265,11 +317,12 @@ jobs:
           fail_on_unmatched_files: true
 
   report-failure:
-    needs: [ spotless-check, desktop-tests, screenshot-tests, discover-android-modules, android-tests, demo-apk, publish, github-release ]
+    needs: [ validate-release, spotless-check, desktop-tests, screenshot-tests, discover-android-modules, android-tests, demo-apk, publish, github-release ]
     if: >-
       ${{
         always() &&
         (
+          contains(fromJson('["failure","cancelled"]'), needs.validate-release.result) ||
           contains(fromJson('["failure","cancelled"]'), needs.spotless-check.result) ||
           contains(fromJson('["failure","cancelled"]'), needs.desktop-tests.result) ||
           contains(fromJson('["failure","cancelled"]'), needs.screenshot-tests.result) ||
@@ -293,6 +346,7 @@ jobs:
             const labels = ['release-failure'];
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             const results = {
+              'validate-release': '${{ needs.validate-release.result }}',
               'spotless-check': '${{ needs.spotless-check.result }}',
               'desktop-tests': '${{ needs.desktop-tests.result }}',
               'screenshot-tests': '${{ needs.screenshot-tests.result }}',

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ permissions:
   contents: write
   issues: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,12 +233,33 @@ jobs:
           name: compose-unstyled-demo-apk
           path: release-artifacts
 
+      - name: Extract release notes
+        id: release-notes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_notes_path="$RUNNER_TEMP/release-notes.md"
+          awk -v heading="## $RELEASE_REF" '
+            $0 == heading { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+            END { if (!found) exit 1 }
+          ' CHANGELOG.md > "$release_notes_path"
+
+          if grep -q '[^[:space:]]' "$release_notes_path"; then
+            echo "path=$release_notes_path" >> "$GITHUB_OUTPUT"
+          else
+            echo "CHANGELOG.md notes for $RELEASE_REF are empty."
+            exit 1
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_REF }}
           name: ${{ env.RELEASE_REF }}
-          generate_release_notes: true
+          body_path: ${{ steps.release-notes.outputs.path }}
           draft: true
           files: release-artifacts/*.apk
           fail_on_unmatched_files: true

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -11,6 +11,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: version-packages
+  cancel-in-progress: true
+
 jobs:
   version:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -61,13 +61,13 @@ jobs:
           cat > "$body_file" <<'EOF'
           This release PR was opened by the Version Packages workflow.
 
-          It consumes pending changesets, bumps `package.json`, and syncs `gradle/libs.versions.toml`.
+          It consumes pending changesets, updates `CHANGELOG.md`, and synchronizes the release version files.
           EOF
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$version_branch"
-          git add .changeset gradle/libs.versions.toml package.json package-lock.json
+          git add .changeset CHANGELOG.md gradle/libs.versions.toml package.json package-lock.json
 
           if git diff --cached --quiet; then
             echo "No version PR changes to commit."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,8 +24,8 @@ That PR runs:
 npm run changeset:version
 ```
 
-This consumes the pending `.changeset/*.md` files, bumps `package.json`, and syncs
-`gradle/libs.versions.toml`.
+This consumes the pending `.changeset/*.md` files, writes their descriptions to `CHANGELOG.md`,
+bumps `package.json`, and synchronizes `package-lock.json` and `gradle/libs.versions.toml`.
 
 ## Publishing
 
@@ -33,5 +33,6 @@ After the version PR is merged, the `Version Packages` workflow sees that no pen
 remain. It creates the current version tag, pushes it, and dispatches `.github/workflows/release.yml`
 with that tag.
 
-The `Release` workflow runs the release checks, publishes artifacts to Maven Central, and creates a
-draft GitHub Release with GitHub-generated release notes.
+The `Release` workflow verifies that the tag and release metadata agree, runs the release checks,
+publishes artifacts to Maven Central, and creates a draft GitHub Release from the matching
+`CHANGELOG.md` section.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compose-unstyled",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compose-unstyled",
-      "version": "2.8.1",
+      "version": "2.9.0",
       "devDependencies": {
         "@changesets/cli": "^2.29.7"
       }

--- a/scripts/sync-release-version.mjs
+++ b/scripts/sync-release-version.mjs
@@ -19,3 +19,15 @@ if (updatedVersionCatalog === versionCatalog) {
 }
 
 fs.writeFileSync(versionCatalogPath, updatedVersionCatalog);
+
+const packageLockPath = 'package-lock.json';
+const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
+
+if (typeof packageLock.packages?.[''] !== 'object') {
+  throw new Error(`Could not find the root package in ${packageLockPath}`);
+}
+
+packageLock.version = version;
+packageLock.packages[''].version = version;
+
+fs.writeFileSync(packageLockPath, `${JSON.stringify(packageLock, null, 2)}\n`);


### PR DESCRIPTION
## Summary

Generate release changelog entries from Changesets descriptions instead of GitHub PR titles.

Keep package, lockfile, and Gradle release versions synchronized; reject mismatched release tags; and serialize release automation. The generated release PR now contains the exact notes that will be published.

## Test Plan

- [ ] Tests added/updated
- [x] Manual testing performed

- `npm exec changeset status`
- `./gradlew --console=plain spotlessCheck :demo:jvmTest`
- Parsed the workflow YAML and release JSON/config files.
- Ran `npm run changeset:version` in an isolated copy and verified the generated 2.9.1 changelog contains all four pending Changesets.
- Verified release-note extraction and tag/version validation accept 2.9.1 and reject mismatched 2.9.2.

## Manual QA

- Platform/device: macOS / local Node and Gradle
- Setup: Four pending Changesets from current `main`
- Steps:
  1. Run `npm ci`.
  2. Run `npm run changeset:version` in an isolated copy.
  3. Inspect `CHANGELOG.md` and the synchronized version files.
- Expected result: Changesets generate the 2.9.1 release notes, all four version fields match, and the exact changelog section is used as the GitHub Release body.
- Known limitations: Maven Central publishing and GitHub Release creation require the real tagged release workflow.

## Related Issues

Follow-up to #490 and #469.

## Screenshots/Videos

Not applicable.
