### PR TITLE
Require all tests for release pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           )"
 
           android_modules=""
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.head_ref }}" != "changeset-release/main" ]; then
             merge_base="$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
             changed_files="$(git diff --name-only "$merge_base" "${{ github.event.pull_request.head.sha }}")"
             android_changed_modules="$(
@@ -81,7 +81,7 @@ jobs:
           )"
 
           changed_modules=""
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.head_ref }}" != "changeset-release/main" ]; then
             merge_base="$(git merge-base "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
             changed_files="$(git diff --name-only "$merge_base" "${{ github.event.pull_request.head.sha }}")"
 
@@ -166,6 +166,24 @@ jobs:
           printf '  %s\n' "${tasks[@]}"
           ./gradlew --console=plain "${tasks[@]}"
 
+  release-screenshot-tests:
+    runs-on: macos-latest
+    if: startsWith(github.head_ref, 'changeset-release/')
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          token: ${{ github.token }}
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Screenshot Tests
+        run: ./gradlew --console=plain :visual-regressions:jvmScreenshotTest
+
   android-tests:
     name: ${{ matrix.module }}-android-tests
     needs: [ discover-android-modules, fast-checks ]
@@ -177,3 +195,25 @@ jobs:
     with:
       module: ${{ matrix.module }}
       test-command: ./gradlew --console=plain ${{ matrix.module }}:connectedDebugAndroidTest
+
+  release-gate:
+    name: release-gate
+    if: always() && startsWith(github.head_ref, 'changeset-release/')
+    needs: [ fast-checks, release-screenshot-tests, android-tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify release checks
+        env:
+          FAST_CHECKS_RESULT: ${{ needs.fast-checks.result }}
+          SCREENSHOT_TESTS_RESULT: ${{ needs.release-screenshot-tests.result }}
+          ANDROID_TESTS_RESULT: ${{ needs.android-tests.result }}
+        run: |
+          set -euo pipefail
+
+          printf 'fast-checks: %s\n' "$FAST_CHECKS_RESULT"
+          printf 'release-screenshot-tests: %s\n' "$SCREENSHOT_TESTS_RESULT"
+          printf 'android-tests: %s\n' "$ANDROID_TESTS_RESULT"
+
+          test "$FAST_CHECKS_RESULT" = success
+          test "$SCREENSHOT_TESTS_RESULT" = success
+          test "$ANDROID_TESTS_RESULT" = success


### PR DESCRIPTION
## Summary

Run the full test suite for Changesets release pull requests. Release PRs now run all JVM/Desktop tests, all Android module tests, and the macOS screenshot suite. A single `release-gate` check fails unless every group passes.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

- `git diff --check`
- Verified all release workflow tasks exist with `./gradlew --console=plain tasks --all`

## Manual QA

- Platform/device: GitHub Actions
- Setup: Open a PR from `changeset-release/*`
- Steps:
  1. Create or update a Changesets release PR.
  2. Wait for `fast-checks`, `release-screenshot-tests`, and the Android test matrix.
  3. Confirm `release-gate` reports their results.
- Expected result: The release PR cannot pass its required gate unless all test groups pass.
- Known limitations: The GitHub ruleset must require the `release-gate` status check for merge blocking.

## Related Issues

None.

## Screenshots/Videos

Not applicable.