### PR TITLE
Run Android tests for release pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
                 <(printf '%s\n' "$test_modules" | sort -u) \
                 <(printf '%s\n' "$android_changed_modules" | sort -u)
             )"
+          else
+            android_modules="$test_modules"
           fi
 
           if [ -z "$android_modules" ]; then


### PR DESCRIPTION
## Summary

Fixes the release PR test matrix so it includes all Android modules. The previous gate correctly failed because `android-tests` was skipped when the discovery job left its output empty for `changeset-release/*` branches.

## Test Plan

- [x] Tests added/updated
- [ ] Manual testing performed

- `git diff --check`
- Verified the discovery job assigns all discovered test modules for release PRs.

## Manual QA

- Platform/device: GitHub Actions
- Setup: A Changesets release PR
- Steps:
  1. Merge this PR.
  2. Update the release PR.
  3. Confirm the Android matrix is created for all modules.
- Expected result: Android tests run before `release-gate` can pass.
- Known limitations: The aggregate check still needs to be configured as required in the main ruleset.

## Related Issues

None.

## Screenshots/Videos

Not applicable.